### PR TITLE
Reduce trending timescale from 365d to 75d

### DIFF
--- a/internal/pages/index.go
+++ b/internal/pages/index.go
@@ -302,8 +302,9 @@ var trendingEpoch = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // trendingTimescale controls how quickly newer content displaces older content.
 // Every timescale period, an item needs 10x more engagement to hold its ranking.
-// 365 days in seconds — gives older high-quality content longer shelf life.
-const trendingTimescale = 365 * 24 * 3600.0
+// 75 days in seconds — tuned to rotate ~2-3 new items into the top-8 trending list
+// each week given current upload volume (~30-50/week) and engagement levels.
+const trendingTimescale = 75 * 24 * 3600.0
 
 // trendingScore computes a Reddit-style hot score.
 //

--- a/internal/pages/trending_test.go
+++ b/internal/pages/trending_test.go
@@ -88,19 +88,19 @@ func Test_TrendingScore_Finite(t *testing.T) {
 	}
 }
 
-func Test_TrendingScore_365DayTimescale(t *testing.T) {
-	// An item from 365 days ago needs ~10x engagement to match a new item
+func Test_TrendingScore_75DayTimescale(t *testing.T) {
+	// An item from 75 days ago needs ~10x engagement to match a new item
 	now := time.Date(2025, 10, 13, 0, 0, 0, 0, time.UTC)
-	yearAgo := now.Add(-365 * 24 * time.Hour)
+	timescaleAgo := now.Add(-75 * 24 * time.Hour)
 
 	// New item with 10 engagement units: log10(10) = 1
 	sNew := trendingScore(now, 10, 0, 0, 0, 0, 0)
 	// Old item: needs ~100 engagement to get log10(100) = 2, compensating for 1 timescale period
-	sOld := trendingScore(yearAgo, 100, 0, 0, 0, 0, 0)
+	sOld := trendingScore(timescaleAgo, 100, 0, 0, 0, 0, 0)
 
 	// They should be approximately equal (within 0.15)
 	diff := math.Abs(sNew - sOld)
 	if diff > 0.15 {
-		t.Fatalf("365-day-old item with 10x engagement should roughly match new item: new=%f old=%f diff=%f", sNew, sOld, diff)
+		t.Fatalf("75-day-old item with 10x engagement should roughly match new item: new=%f old=%f diff=%f", sNew, sOld, diff)
 	}
 }


### PR DESCRIPTION
The 365-day timescale meant top trending items were stuck for weeks because new uploads couldn't accumulate enough engagement to overcome the age advantage. On production, the top 20 trending had 0 items under 30 days old despite healthy weekly uploads (26-56/week).

At 75 days, simulations against production data show ~2-3 items under 14 days old rotating into the top 8 per week, matching the desired cadence while preserving proven hits at the top.

Updates Test_TrendingScore_365DayTimescale to reflect the new value.