### PR TITLE
Fix index page nav buttons, ad layout overhaul, sidebar state persist…

### DIFF
--- a/internal/pages/index.go
+++ b/internal/pages/index.go
@@ -136,58 +136,82 @@ func IndexHandler(cacheService *cache.Service, registry *server.Registry, appSto
 			trendingSchematics = trendingSchematics[:indexPageSize]
 		}
 
-		// Determine hasNext flags from cache (default false if not cached)
+		// Determine hasNext flags from cache.
 		latestHasNext := false
 		trendingHasNext := false
 		highestHasNext := false
+		latestHasNextCached := false
+		trendingHasNextCached := false
+		highestHasNextCached := false
 		if v, ok := cacheService.Get(cache.LatestHasNextKey); ok {
 			if b, ok := v.(bool); ok {
 				latestHasNext = b
+				latestHasNextCached = true
 			}
 		}
 		if v, ok := cacheService.Get(trendingHasNextKey); ok {
 			if b, ok := v.(bool); ok {
 				trendingHasNext = b
+				trendingHasNextCached = true
 			}
 		}
 		if v, ok := cacheService.Get(cache.HighestRatedHasNextKey); ok {
 			if b, ok := v.(bool); ok {
 				highestHasNext = b
+				highestHasNextCached = true
 			}
 		}
 
-		// Fallback: if cache is cold (first request before warm completes), query directly
-		if !latestCached {
+		// Fallback: if any cache is cold (first request before warm
+		// completes, or race between schematics and hasNext cache sets),
+		// query the DB directly for the missing sections.
+		if !latestCached || !latestHasNextCached {
 			latestStoreResults, lhn := fetchLatestPageFromStore(appStore, 1)
 			latestSchematics = MapStoreSchematics(appStore, latestStoreResults, cacheService)
 			latestHasNext = lhn
+		}
+		if !trendingHasNextCached {
 			trendingSchematics, trendingHasNext = getTrendingSchematicsPageForWindow(appStore, cacheService, 1, windowDays)
+		}
+		if !highestHasNextCached {
 			highestRated, highestHasNext = getHighestRatedSchematicsPageFromStore(appStore, cacheService, 1)
 		}
 
 		// Build category sections
 		categories := allCategoriesFromStoreOnly(appStore, cacheService)
 		categorySections := make([]CategorySection, 0, len(categories))
+		caser := cases.Title(language.English)
 		for _, cat := range categories {
 			cacheKey := cache.CategorySectionKeyForWindow(cat.Key, windowDays)
 			cacheHasNextKey := cache.CategorySectionHasNextKeyForWindow(cat.Key, windowDays)
 			items, cached := cacheService.GetSchematics(cacheKey)
 			catHasNext := false
+			catHasNextCached := false
 			if cached {
 				if v, ok := cacheService.Get(cacheHasNextKey); ok {
 					if b, ok := v.(bool); ok {
 						catHasNext = b
+						catHasNextCached = true
 					}
 				}
-			} else {
+			}
+			if !cached || !catHasNextCached {
 				items, catHasNext = getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, windowDays)
 			}
+			cat.Name = caser.String(cat.Name)
 			categorySections = append(categorySections, CategorySection{
 				Category: cat,
 				Items:    items,
 				HasNext:  catHasNext,
 			})
 		}
+		// Sort category sections: full sections (>= indexPageSize items) first,
+		// smaller sections last, preserving relative order within each group.
+		sort.SliceStable(categorySections, func(i, j int) bool {
+			iFull := len(categorySections[i].Items) >= indexPageSize
+			jFull := len(categorySections[j].Items) >= indexPageSize
+			return iFull && !jFull
+		})
 
 		d := IndexData{
 			Schematics:       latestSchematics,
@@ -565,9 +589,11 @@ func WarmIndexCacheFromStore(appStore *store.Store, cacheService *cache.Service,
 	}
 
 	// 1. Latest schematics (page 1)
+	// Set hasNext before schematics so that a concurrent request that sees
+	// cached schematics will also find the hasNext flag.
 	latestResults, latestHasNext := fetchLatestPageFromStore(appStore, 1)
-	cacheService.SetSchematics(cache.LatestSchematicsKey, MapStoreSchematics(appStore, latestResults, cacheService))
 	cacheService.Set(cache.LatestHasNextKey, latestHasNext)
+	cacheService.SetSchematics(cache.LatestSchematicsKey, MapStoreSchematics(appStore, latestResults, cacheService))
 
 	// 2. Trending schematics — warm all requested windows
 	for _, wd := range windowDays {
@@ -581,13 +607,13 @@ func WarmIndexCacheFromStore(appStore *store.Store, cacheService *cache.Service,
 	// Backward compat: also populate default (non-windowed) keys with 30-day data
 	cacheService.Delete(cache.TrendingSchematicsKey)
 	defaultTrending := getAllTrendingSchematicsForWindow(appStore, cacheService, 30)
-	cacheService.SetSchematics(cache.TrendingSchematicsKey, defaultTrending)
 	cacheService.Set(cache.TrendingHasNextKey, len(defaultTrending) > indexPageSize)
+	cacheService.SetSchematics(cache.TrendingSchematicsKey, defaultTrending)
 
 	// 3. Highest rated schematics (page 1)
 	highestRated, highestHasNext := getHighestRatedSchematicsPageFromStore(appStore, cacheService, 1)
-	cacheService.SetSchematics(cache.HighestRatedSchematicsKey, highestRated)
 	cacheService.Set(cache.HighestRatedHasNextKey, highestHasNext)
+	cacheService.SetSchematics(cache.HighestRatedSchematicsKey, highestRated)
 
 	// 4. Categories
 	allCategoriesFromStoreOnly(appStore, cacheService)
@@ -597,13 +623,13 @@ func WarmIndexCacheFromStore(appStore *store.Store, cacheService *cache.Service,
 	for _, cat := range categories {
 		for _, wd := range windowDays {
 			items, catHasNext := getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, wd)
-			cacheService.SetSchematics(cache.CategorySectionKeyForWindow(cat.Key, wd), items)
 			cacheService.Set(cache.CategorySectionHasNextKeyForWindow(cat.Key, wd), catHasNext)
+			cacheService.SetSchematics(cache.CategorySectionKeyForWindow(cat.Key, wd), items)
 		}
 		// Backward compat: default keys with 30-day data
 		items, catHasNext := getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, 30)
-		cacheService.SetSchematics(fmt.Sprintf("CategorySection:%s", cat.Key), items)
 		cacheService.Set(fmt.Sprintf("CategorySectionHasNext:%s", cat.Key), catHasNext)
+		cacheService.SetSchematics(fmt.Sprintf("CategorySection:%s", cat.Key), items)
 	}
 
 	logger.Debug("Index page cache warmed (store)")

--- a/template/collections.html
+++ b/template/collections.html
@@ -87,6 +87,7 @@
             <div id="collections-sticky-adrail-lg" class="mb-3"></div>
           </div>
           <div class="ad-rail d-none d-xl-block">
+            <div id="collections-video-nc-top-right" class="mb-3"></div>
             <div id="collections-sticky-adrail" class="mb-3"></div>
           </div>
         </div>
@@ -99,6 +100,18 @@
 
 <!-- Ad Scripts -->
 <script>
+window['nitroAds'].createAd('collections-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,collections",
+  "targeting": { "pageType": "collections" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('collections-sticky-adrail-lg', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/collections_show.html
+++ b/template/collections_show.html
@@ -124,6 +124,7 @@
             <div id="collshow-sticky-adrail-lg" class="mb-3"></div>
           </div>
           <div class="ad-rail d-none d-xl-block">
+            <div id="collshow-video-nc-top-right" class="mb-3"></div>
             <div id="collshow-sticky-adrail" class="mb-3"></div>
           </div>
         </div><!-- /d-flex -->
@@ -147,6 +148,18 @@ function copyShareLink() {
 
 <!-- Ad Scripts -->
 <script>
+window['nitroAds'].createAd('collshow-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,collection",
+  "targeting": { "pageType": "collection" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('collshow-sticky-adrail-lg', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/download_interstitial.html
+++ b/template/download_interstitial.html
@@ -8,6 +8,7 @@
         <div class="d-flex gap-3 justify-content-center">
           <!-- Left Ad Rail (desktop only) -->
           <div class="ad-rail d-none d-xl-block">
+            <div id="dlinterstitial-video-nc-top-left" class="mb-3"></div>
             <div id="dlinterstitial-sticky-adrail-left" class="mb-3"></div>
           </div>
           <div style="max-width:540px; width:100%; padding:2rem 0;">
@@ -33,6 +34,7 @@
           </div>
           <!-- Right Ad Rail (desktop only) -->
           <div class="ad-rail d-none d-xl-block">
+            <div id="dlinterstitial-video-nc-top-right" class="mb-3"></div>
             <div id="dlinterstitial-sticky-adrail-right" class="mb-3"></div>
           </div>
         </div>
@@ -112,6 +114,20 @@
 </script>
 <script>
 if (window['nitroAds']) {
+  ['dlinterstitial-video-nc-top-left', 'dlinterstitial-video-nc-top-right'].forEach(function(id) {
+    window['nitroAds'].createAd(id, {
+      "format": "video-nc",
+      "keywords": "minecraft,create-mod,download",
+      "targeting": { "pageType": "download-interstitial" },
+      "report": {
+        "enabled": true,
+        "icon": true,
+        "wording": "Report Ad",
+        "position": "top-right"
+      },
+      "mediaQuery": "(min-width: 1200px)"
+    });
+  });
   ['dlinterstitial-sticky-adrail-left', 'dlinterstitial-sticky-adrail-right'].forEach(function(id) {
     window['nitroAds'].createAd(id, {
       "refreshLimit": 10,

--- a/template/explore.html
+++ b/template/explore.html
@@ -59,6 +59,7 @@
 
                 <!-- Ad Rail (desktop only) -->
                 <div class="ad-rail d-none d-xl-block">
+                    <div id="explore-video-nc-top-right" class="mb-3"></div>
                     <div id="explore-sticky-adrail" class="mb-3"></div>
                 </div>
             </div>
@@ -68,6 +69,18 @@
 </div>
 {{template "foot.html" .}}
 <script>
+window['nitroAds'].createAd('explore-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,schematics,explore,discover",
+  "targeting": { "pageType": "explore" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('explore-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/external_interstitial.html
+++ b/template/external_interstitial.html
@@ -8,6 +8,7 @@
         <div class="d-flex gap-3 justify-content-center">
           <!-- Left Ad Rail (desktop only) -->
           <div class="ad-rail d-none d-xl-block">
+            <div id="extinterstitial-video-nc-top-left" class="mb-3"></div>
             <div id="extinterstitial-sticky-adrail-left" class="mb-3"></div>
           </div>
           <div style="max-width:540px; width:100%; padding:2rem 0;">
@@ -26,6 +27,7 @@
           </div>
           <!-- Right Ad Rail (desktop only) -->
           <div class="ad-rail d-none d-xl-block">
+            <div id="extinterstitial-video-nc-top-right" class="mb-3"></div>
             <div id="extinterstitial-sticky-adrail-right" class="mb-3"></div>
           </div>
         </div>
@@ -81,6 +83,20 @@
 </script>
 <script>
 if (window['nitroAds']) {
+  ['extinterstitial-video-nc-top-left', 'extinterstitial-video-nc-top-right'].forEach(function(id) {
+    window['nitroAds'].createAd(id, {
+      "format": "video-nc",
+      "keywords": "minecraft,create-mod,external",
+      "targeting": { "pageType": "external-interstitial" },
+      "report": {
+        "enabled": true,
+        "icon": true,
+        "wording": "Report Ad",
+        "position": "top-right"
+      },
+      "mediaQuery": "(min-width: 1200px)"
+    });
+  });
   ['extinterstitial-sticky-adrail-left', 'extinterstitial-sticky-adrail-right'].forEach(function(id) {
     window['nitroAds'].createAd(id, {
       "refreshLimit": 10,

--- a/template/guides.html
+++ b/template/guides.html
@@ -57,6 +57,7 @@
         <!-- Ad Rail (desktop only) -->
         {{if not .IsContributor}}
         <div class="ad-rail d-none d-xl-block">
+            <div id="guides-video-nc-top-right" class="mb-3"></div>
             <div id="guides-sticky-adrail" class="mb-3"></div>
         </div>
         {{end}}
@@ -73,6 +74,18 @@
 {{template "foot.html" .}}
 {{if not .IsContributor}}
 <script>
+window['nitroAds'].createAd('guides-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,guide,tutorial",
+  "targeting": { "pageType": "guides" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('guides-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/guides_show.html
+++ b/template/guides_show.html
@@ -87,6 +87,7 @@
         <!-- Ad Rail (desktop only) -->
         {{if not .IsContributor}}
         <div class="ad-rail d-none d-xl-block">
+            <div id="guideshow-video-nc-top-right" class="mb-3"></div>
             <div id="guideshow-sticky-adrail" class="mb-3"></div>
         </div>
         {{end}}
@@ -104,6 +105,18 @@
 {{template "foot.html" .}}
 {{if not .IsContributor}}
 <script>
+window['nitroAds'].createAd('guideshow-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,guide,tutorial",
+  "targeting": { "pageType": "guide" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('guideshow-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/include/foot.html
+++ b/template/include/foot.html
@@ -175,7 +175,8 @@ window['nitroAds'].createAd('outstream-player', {
   },
   "keywords": "minecraft,create-mod,schematics,builds",
   "targeting": { "pageType": "global" },
-  "geoDeny": ["IQ","LY","BY","CD","MR","AF","YE","DZ","SY"]
+  "geoDeny": ["IQ","LY","BY","CD","MR","AF","YE","DZ","SY"],
+  "mediaQuery": "(max-width: 1199px)"
 });
 </script>
 <!-- Blocker detection prompt (guarded against HTMX re-init) -->
@@ -185,29 +186,5 @@ if(!window._npAbpInit){window._npAbpInit=true;
 }
 </script>
 {{ end }}
-<!-- Mobile/tablet anchor ad (all pages) — guarded to prevent re-creation on HTMX navigation -->
-<div id="anchor-bottom"></div>
-<script>
-if (!window._nitroAnchorInit) {
-  window._nitroAnchorInit = true;
-  window['nitroAds'].createAd('anchor-bottom', {
-    "format": "anchor-v2",
-    "anchor": "bottom",
-    "anchorBgColor": "rgb(0 0 0 / 80%)",
-    "anchorClose": true,
-    "anchorPersistClose": false,
-    "anchorStickyOffset": 0,
-    "report": {
-      "enabled": true,
-      "icon": true,
-      "wording": "Report Ad",
-      "position": "top-right"
-    },
-    "keywords": "minecraft,create-mod,schematics,builds",
-    "targeting": { "pageType": "global" },
-    "mediaQuery": "(min-width: 768px) and (max-width: 1024px), (min-width: 320px) and (max-width: 767px)"
-  });
-}
-</script>
 </body>
 </html>

--- a/template/include/head.html
+++ b/template/include/head.html
@@ -173,8 +173,17 @@ window.setTheme=function(theme){
     try {
       // Restore sidebar state from localStorage before first paint.
       // Default is expanded (pinned) on desktop; only collapse if explicitly set to '0'.
-      if (window.innerWidth >= 992 && localStorage.getItem('sidebar-expanded') !== '0') {
-        document.body.classList.add('sidebar-pinned');
+      if (window.innerWidth >= 992) {
+        var sidebarCollapsed = localStorage.getItem('sidebar-expanded') === '0';
+        if (!sidebarCollapsed) {
+          document.body.classList.add('sidebar-pinned');
+        } else {
+          // Sidebar HTML defaults to expanded; remove the class when user previously collapsed.
+          var sb = document.getElementById('sidebar-menu');
+          if (sb) sb.classList.remove('sidebar-expanded');
+          var lbl = document.getElementById('sidebar-toggle-label');
+          if (lbl) lbl.textContent = 'Expand';
+        }
       }
 
       // Enable sidebar transition only after initial layout is stable.

--- a/template/index.html
+++ b/template/index.html
@@ -24,9 +24,6 @@
                             {{ end }}
                         </div>
 
-                        <!-- Mobile ad between sections -->
-                        <div id="index-mobile-mid" class="d-xl-none mb-3 mt-4 text-center"></div>
-
                         <!-- Latest -->
                         <h2 class="mb-3 mt-4"><a href="/search?sort=2" class="text-reset text-decoration-none">{{ T .Language "Latest" }} &rarr;</a></h2>
                         <div id="tab-panel-latest" class="tab-panel">
@@ -82,10 +79,6 @@
                         {{ end }}
                     </div>
 
-                    <!-- Ad Rail (desktop only) -->
-                    <div class="ad-rail d-none d-xl-block">
-                        <div id="index-sticky-adrail" class="mb-3"></div>
-                    </div>
                 </div>
             </div>
         </main>
@@ -93,44 +86,6 @@
     </div>
 </div>
 {{template "foot.html" .}}
-<script>
-window['nitroAds'].createAd('index-sticky-adrail', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 110,
-  "stickyStackResizable": false,
-  "keywords": "minecraft,create-mod,schematics,builds",
-  "targeting": { "pageType": "home" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('index-mobile-mid', {
-  "refreshTime": 60,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 200,
-  "keywords": "minecraft,create-mod,schematics,builds",
-  "targeting": { "pageType": "home" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 320px) and (max-width: 1199px)"
-});
-</script>
 <script>
 (function() {
   document.querySelectorAll('[data-trending-section] a[href*="/schematics/"]').forEach(function(link, i) {

--- a/template/mod_detail.html
+++ b/template/mod_detail.html
@@ -67,6 +67,7 @@
         </div>
         <!-- Ad Rail (desktop only) -->
         <div class="ad-rail d-none d-xl-block">
+            <div id="moddetail-video-nc-top-right" class="mb-3"></div>
             <div id="moddetail-sticky-adrail" class="mb-3"></div>
         </div>
         </div>
@@ -77,6 +78,18 @@
 </div>
 {{template "foot.html" .}}
 <script>
+window['nitroAds'].createAd('moddetail-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,mod,addon",
+  "targeting": { "pageType": "mod" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('moddetail-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/modify.html
+++ b/template/modify.html
@@ -174,6 +174,7 @@
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
                     <div class="ad-rail d-none d-xl-block">
+                        <div id="modify-video-nc-top-right" class="mb-3"></div>
                         <div id="modify-sticky-adrail" class="mb-3"></div>
                     </div>
                 </div><!-- /d-flex -->
@@ -631,6 +632,19 @@
 
 <!-- Ad Scripts -->
 <script>
+// Video NC ad (desktop only)
+window['nitroAds'].createAd('modify-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,modify,blocks",
+  "targeting": { "pageType": "modify" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 // Narrow ad rail (lg only: 992-1199px)
 window['nitroAds'].createAd('modify-sticky-adrail-lg', {
   "refreshLimit": 10,

--- a/template/profile.html
+++ b/template/profile.html
@@ -92,6 +92,7 @@
 
                     <!-- Ad Rail (desktop only) -->
                     <div class="ad-rail d-none d-xl-block">
+                        <div id="profile-video-nc-top-right" class="mb-3"></div>
                         <div id="profile-sticky-adrail" class="mb-3"></div>
                     </div>
                 </div>
@@ -102,6 +103,18 @@
 </div>
 {{template "foot.html" .}}
 <script>
+window['nitroAds'].createAd('profile-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,profile,builder",
+  "targeting": { "pageType": "profile" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('profile-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -752,6 +752,7 @@
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
                     <div class="ad-rail d-none d-xl-block">
+                        <div id="schematic-video-nc-top-right" class="mb-3"></div>
                         <div id="schematic-sticky-adrail" class="mb-3"></div>
                     </div>
                 </div><!-- /d-flex -->
@@ -1201,6 +1202,19 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     "modVersion": "{{ .Schematic.CreatemodVersion }}"
   };
 
+  // Video NC ad (desktop only)
+  window['nitroAds'].createAd('schematic-video-nc-top-right', {
+    "format": "video-nc",
+    "keywords": kwString,
+    "targeting": targeting,
+    "report": {
+      "enabled": true,
+      "icon": true,
+      "wording": "Report Ad",
+      "position": "top-right"
+    },
+    "mediaQuery": "(min-width: 1200px)"
+  });
   // Narrow ad rail (lg only: 992-1199px)
   window['nitroAds'].createAd('schematic-sticky-adrail-lg', {
     "refreshLimit": 10,

--- a/template/schematics.html
+++ b/template/schematics.html
@@ -31,6 +31,7 @@
                 </div>
                 <!-- Ad Rail (desktop only) -->
                 <div class="ad-rail d-none d-xl-block">
+                    <div id="schematics-video-nc-top-right" class="mb-3"></div>
                     <div id="schematics-sticky-adrail" class="mb-3"></div>
                 </div>
                 </div>
@@ -41,6 +42,18 @@
 </div>
 {{template "foot.html" .}}
 <script>
+window['nitroAds'].createAd('schematics-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,schematics,browse",
+  "targeting": { "pageType": "schematics" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('schematics-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/search.html
+++ b/template/search.html
@@ -74,6 +74,7 @@
 
                     <!-- Right: Ad rail (desktop only) -->
                     <div class="search-ad-rail d-none d-lg-block">
+                        <div id="search-video-nc-top-right" class="mb-3"></div>
                         <div id="search-sticky-adrail-top" class="mb-3"></div>
                     </div>
                 </div>
@@ -139,6 +140,19 @@
                     "position": "top-right"
                 },
                 "mediaQuery": "(min-width: 320px) and (max-width: 991px)"
+            });
+            // Video NC ad (desktop only)
+            window['nitroAds'].createAd('search-video-nc-top-right', {
+                "format": "video-nc",
+                "keywords": searchKw,
+                "targeting": searchTarget,
+                "report": {
+                    "enabled": true,
+                    "icon": true,
+                    "wording": "Report Ad",
+                    "position": "top-right"
+                },
+                "mediaQuery": "(min-width: 992px)"
             });
             // Left sidebar sticky ads
             window['nitroAds'].createAd('search-sticky-under', {

--- a/template/upload_modify.html
+++ b/template/upload_modify.html
@@ -118,6 +118,7 @@
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
                     <div class="ad-rail d-none d-xl-block">
+                        <div id="upload-modify-video-nc-top-right" class="mb-3"></div>
                         <div id="upload-modify-sticky-adrail" class="mb-3"></div>
                     </div>
                 </div><!-- /d-flex -->
@@ -474,6 +475,19 @@
 
 <!-- Ad Scripts -->
 <script>
+// Video NC ad (desktop only)
+window['nitroAds'].createAd('upload-modify-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,modify,blocks,upload",
+  "targeting": { "pageType": "modify" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 // Narrow ad rail (lg only: 992-1199px)
 window['nitroAds'].createAd('upload-modify-sticky-adrail-lg', {
   "refreshLimit": 10,

--- a/template/upload_preview.html
+++ b/template/upload_preview.html
@@ -230,6 +230,7 @@
 
                     <!-- Ad Rail (desktop only) -->
                     <div class="ad-rail d-none d-xl-block">
+                        <div id="upload-preview-video-nc-top-right" class="mb-3"></div>
                         <div id="upload-preview-sticky-adrail" class="mb-3"></div>
                     </div>
                 </div>
@@ -592,6 +593,18 @@ function deleteAdditionalFile(token, fileId, btn) {
 {{ end }}
 {{template "foot.html" .}}
 <script>
+window['nitroAds'].createAd('upload-preview-video-nc-top-right', {
+  "format": "video-nc",
+  "keywords": "minecraft,create-mod,upload,preview",
+  "targeting": { "pageType": "upload-preview" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
 window['nitroAds'].createAd('upload-preview-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/videos.html
+++ b/template/videos.html
@@ -51,6 +51,7 @@
 
         <!-- Ad Rail (desktop only) -->
         <div class="ad-rail d-none d-xl-block">
+            <div id="videos-video-nc-top-right" class="mb-3"></div>
             <div id="videos-sticky-adrail" class="mb-3"></div>
         </div>
         </div><!-- /d-flex -->
@@ -63,6 +64,18 @@
 </div>
 <script>
 if (window['nitroAds']) {
+  window['nitroAds'].createAd('videos-video-nc-top-right', {
+    "format": "video-nc",
+    "keywords": "minecraft,create-mod,videos",
+    "targeting": { "pageType": "videos" },
+    "report": {
+      "enabled": true,
+      "icon": true,
+      "wording": "Report Ad",
+      "position": "top-right"
+    },
+    "mediaQuery": "(min-width: 1200px)"
+  });
   window['nitroAds'].createAd('videos-sticky-adrail', {
     "refreshLimit": 10,
     "refreshTime": 45,


### PR DESCRIPTION
…ence

- Fix pagination button race condition where hasNext flags could be uncached while schematics were cached, hiding Previous/Next buttons on initial page load
- Capitalize category section names and sort sparse categories to bottom
- Restrict outstream video player to non-desktop (max-width: 1199px)
- Remove anchor-bottom mobile banner ad from all pages
- Add video-nc ad format above ad rails on all pages (desktop only)
- Remove all ads from the index/home page
- Fix sidebar collapse state not persisting across full page refreshes