### PR TITLE
Fix CSP to allow data: URIs in connect-src

### DIFF
--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -842,7 +842,7 @@ var cspHeader = strings.Join([]string{
 	"style-src 'self' 'unsafe-inline' https:",
 	"img-src 'self' data: blob: https:",
 	"font-src 'self' https:",
-	"connect-src 'self' https:",
+	"connect-src 'self' https: data:",
 	"frame-src https:",
 	"media-src 'self' https:",
 	"worker-src 'self' blob:",


### PR DESCRIPTION
A WebAssembly module loaded via a data: URI was being blocked by the Content Security Policy connect-src directive. Adding data: to the allowed sources unblocks this.