### PR TITLE
Improve homepage performance and reduce HPA thrashing (round 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-CreateMod.com is a Go web application that serves as a community platform for Minecraft Create mod schematics. It uses server-side rendered Go templates with HTMX for progressive enhancement, PostgreSQL (via pgx + sqlc) for data, chi for HTTP routing, Bleve for full-text search, and Minio/S3 for file storage.
+CreateMod.com is a Go web application that serves as a community platform for Minecraft Create mod schematics. It uses server-side rendered Go templates with HTMX for progressive enhancement, PostgreSQL (via pgx + sqlc) for data, chi for HTTP routing, Meilisearch for full-text search, and Minio/S3 for file storage.
 
 ## Development Commands
 
@@ -46,9 +46,9 @@ Connects to PostgreSQL, runs database migrations (`database.RunMigrations`), run
 
 ### Server Initialization (`server/start.go`)
 
-`Server` struct holds all services: `search.Service` (Bleve), `cache.Service` (go-cache), `discord.Service`, `moderation.Service` (OpenAI), `translation.Service` (OpenAI), `session.Store` (PostgreSQL sessions), `storage.Service` (S3/Minio). Services are created in `New()` and passed to handlers via the router's `RegisterParams`.
+`Server` struct holds all services: `search.Service` (in-memory metadata index), `cache.Service` (go-cache), `discord.Service`, `moderation.Service` (OpenAI), `translation.Service` (OpenAI), `session.Store` (PostgreSQL sessions), `storage.Service` (S3/Minio). Services are created in `New()` and passed to handlers via the router's `RegisterParams`.
 
-On boot: builds per-pod search index from the store, warms caches in background goroutines, starts River job worker for periodic tasks (search rebuild, sitemap generation, trending scores, temp upload cleanup).
+On boot: builds per-pod in-memory index from the store, syncs to Meilisearch, warms caches in background goroutines, starts River job worker for periodic tasks (search rebuild, sitemap generation, trending scores, temp upload cleanup).
 
 ### Custom Server Framework (`internal/server/`)
 
@@ -107,7 +107,7 @@ River queue with PostgreSQL backing. Handles periodic tasks: search index rebuil
 
 ### Services
 
-- **Search** (`internal/search/`): Bleve full-text indexing. Per-pod in-memory index built on startup; periodically rebuilt via River job.
+- **Search** (`internal/search/`): Meilisearch handles all full-text search queries. A per-pod in-memory index (`search.Service`) provides autocomplete suggestions, search page filter slider bounds (`MaxStats`), trending score storage, and acts as the data bridge for syncing to Meilisearch. The in-memory index is built on startup from the DB (with an optional S3 cache for faster warm-up) and rebuilt every 10 minutes via River job. It is **not** a search engine — removing it would require migrating autocomplete, slider bounds, trending scores, and the Meilisearch sync pipeline to other backends.
 - **Cache** (`internal/cache/`): go-cache (per-pod in-memory, 60min default TTL). Used for categories, trending calculations, rendered content.
 - **Storage** (`internal/storage/`): Minio/S3 SDK for file storage. Use `StorageService.DownloadRaw(ctx, path)` to read files. Optional — if S3 not configured, file features are unavailable.
 - **i18n** (`internal/i18n/`): Translation via `T(lang, key)` template function. Language detected from URL prefix or `Accept-Language` header. Supports: en, pt-BR, pt-PT, es, de, pl, ru, zh-Hans, fr.
@@ -154,9 +154,9 @@ Image is set in `k8s/createmod/prod/deployment.yaml`. HPA config in `k8s/createm
 
 ### Multi-pod implications
 
-Caching (`go-cache`) and search (Bleve) are per-pod in-memory. With 2–6 replicas:
+Caching (`go-cache`) and the in-memory search metadata index are per-pod. With 2–6 replicas:
 - Cache mutations (e.g., new schematic) only invalidate on the pod handling the request; other pods serve stale data for up to 60 minutes.
-- Each pod rebuilds its own Bleve index on startup and carries a full copy in memory.
+- Each pod rebuilds its own in-memory index on startup and carries a full copy in memory. This index feeds autocomplete, slider bounds, and trending scores — actual search queries go to the shared Meilisearch instance.
 - River job deduplication (`UniqueOpts`) ensures periodic jobs (search rebuild, trending) run on only one pod, but cache warming runs on all pods independently.
 - Redis is used for rate limiting but not yet for caching or search.
 

--- a/internal/pages/index.go
+++ b/internal/pages/index.go
@@ -205,9 +205,16 @@ func IndexHandler(cacheService *cache.Service, registry *server.Registry, appSto
 
 		// Build category sections
 		categories := allCategoriesFromStoreOnly(appStore, cacheService)
-		categorySections := make([]CategorySection, 0, len(categories))
+		categorySections := make([]CategorySection, len(categories))
 		caser := cases.Title(language.English)
-		for _, cat := range categories {
+
+		// Identify which categories need a DB fetch (cold cache).
+		type coldCat struct {
+			idx int
+			cat models.SchematicCategory
+		}
+		var cold []coldCat
+		for i, cat := range categories {
 			cacheKey := cache.CategorySectionKeyForWindow(cat.Key, windowDays)
 			cacheHasNextKey := cache.CategorySectionHasNextKeyForWindow(cat.Key, windowDays)
 			items, cached := cacheService.GetSchematics(cacheKey)
@@ -221,15 +228,34 @@ func IndexHandler(cacheService *cache.Service, registry *server.Registry, appSto
 					}
 				}
 			}
-			if !cached || !catHasNextCached {
-				items, catHasNext = getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, windowDays)
-			}
 			cat.Name = caser.String(cat.Name)
-			categorySections = append(categorySections, CategorySection{
-				Category: cat,
-				Items:    items,
-				HasNext:  catHasNext,
-			})
+			if !cached || !catHasNextCached {
+				cold = append(cold, coldCat{idx: i, cat: cat})
+			} else {
+				categorySections[i] = CategorySection{
+					Category: cat,
+					Items:    items,
+					HasNext:  catHasNext,
+				}
+			}
+		}
+
+		// Fetch cold categories concurrently.
+		if len(cold) > 0 {
+			var catWg sync.WaitGroup
+			for _, cc := range cold {
+				catWg.Add(1)
+				go func(idx int, cat models.SchematicCategory) {
+					defer catWg.Done()
+					items, catHasNext := getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, windowDays)
+					categorySections[idx] = CategorySection{
+						Category: cat,
+						Items:    items,
+						HasNext:  catHasNext,
+					}
+				}(cc.idx, cc.cat)
+			}
+			catWg.Wait()
 		}
 		// Sort category sections: full sections (>= indexPageSize items) first,
 		// smaller sections last, preserving relative order within each group.
@@ -661,19 +687,29 @@ func WarmIndexCacheFromStore(appStore *store.Store, cacheService *cache.Service,
 	// 4. Categories
 	allCategoriesFromStoreOnly(appStore, cacheService)
 
-	// 5. Category sections — warm for all requested windows
+	// 5. Category sections — warm for all requested windows concurrently.
+	// Limit concurrency to avoid overwhelming the DB connection pool.
 	categories := allCategoriesFromStoreOnly(appStore, cacheService)
+	sem := make(chan struct{}, 4)
+	var warmWg sync.WaitGroup
 	for _, cat := range categories {
-		for _, wd := range windowDays {
-			items, catHasNext := getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, wd)
-			cacheService.Set(cache.CategorySectionHasNextKeyForWindow(cat.Key, wd), catHasNext)
-			cacheService.SetSchematics(cache.CategorySectionKeyForWindow(cat.Key, wd), items)
-		}
-		// Backward compat: default keys with 30-day data
-		items, catHasNext := getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, 30)
-		cacheService.Set(fmt.Sprintf("CategorySectionHasNext:%s", cat.Key), catHasNext)
-		cacheService.SetSchematics(fmt.Sprintf("CategorySection:%s", cat.Key), items)
+		warmWg.Add(1)
+		go func(cat models.SchematicCategory) {
+			defer warmWg.Done()
+			sem <- struct{}{}        // acquire
+			defer func() { <-sem }() // release
+			for _, wd := range windowDays {
+				items, catHasNext := getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, wd)
+				cacheService.Set(cache.CategorySectionHasNextKeyForWindow(cat.Key, wd), catHasNext)
+				cacheService.SetSchematics(cache.CategorySectionKeyForWindow(cat.Key, wd), items)
+			}
+			// Backward compat: default keys with 30-day data
+			items, catHasNext := getCategoryTrendingPageForWindow(appStore, cacheService, cat.ID, 1, 30)
+			cacheService.Set(fmt.Sprintf("CategorySectionHasNext:%s", cat.Key), catHasNext)
+			cacheService.SetSchematics(fmt.Sprintf("CategorySection:%s", cat.Key), items)
+		}(cat)
 	}
+	warmWg.Wait()
 
 	logger.Debug("Index page cache warmed (store)")
 }

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/gosimple/slug"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/riverqueue/river"
 )
@@ -100,6 +101,7 @@ type RegisterParams struct {
 	MailService        *mailer.Service
 	JobWorker          *jobs.Worker
 	MaintenanceMode    *atomic.Bool // runtime-togglable maintenance flag
+	DBPool             *pgxpool.Pool // used by readiness probe to verify DB connectivity
 }
 
 func Register(p RegisterParams) chi.Router {
@@ -199,17 +201,23 @@ func Register(p RegisterParams) chi.Router {
 		w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	// Readiness probe — returns 200 only when the search index is populated.
-	// Excluded from maintenance mode so Kubernetes can still probe.
-	r.Get("/api/ready", func(w http.ResponseWriter, _ *http.Request) {
+	// Readiness probe — returns 200 when the database is reachable.
+	// Decoupled from the in-memory search index build so new pods accept
+	// traffic sooner. Search uses Meilisearch; the in-memory index only
+	// provides autocomplete, slider bounds, and trending scores.
+	r.Get("/api/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if p.SearchService != nil && p.SearchService.Ready() {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"status":"ready"}`))
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte(`{"status":"not_ready"}`))
+		if p.DBPool != nil {
+			ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+			defer cancel()
+			if err := p.DBPool.Ping(ctx); err != nil {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte(`{"status":"not_ready","reason":"db_unreachable"}`))
+				return
+			}
 		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ready"}`))
 	})
 
 	// Prometheus metrics endpoint

--- a/k8s/createmod/dev/hpa.yaml
+++ b/k8s/createmod/dev/hpa.yaml
@@ -20,11 +20,11 @@ spec:
           averageUtilization: 70
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: 300
+      stabilizationWindowSeconds: 600
       policies:
         - type: Pods
           value: 1
-          periodSeconds: 120
+          periodSeconds: 300
     scaleUp:
       stabilizationWindowSeconds: 60
       policies:

--- a/k8s/createmod/dev/hpa.yaml
+++ b/k8s/createmod/dev/hpa.yaml
@@ -26,7 +26,7 @@ spec:
           value: 1
           periodSeconds: 120
     scaleUp:
-      stabilizationWindowSeconds: 30
+      stabilizationWindowSeconds: 60
       policies:
         - type: Pods
           value: 1

--- a/k8s/createmod/prod/hpa.yaml
+++ b/k8s/createmod/prod/hpa.yaml
@@ -20,11 +20,11 @@ spec:
           averageUtilization: 70
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: 300
+      stabilizationWindowSeconds: 600
       policies:
         - type: Pods
           value: 1
-          periodSeconds: 120
+          periodSeconds: 300
     scaleUp:
       stabilizationWindowSeconds: 60
       policies:

--- a/k8s/createmod/prod/hpa.yaml
+++ b/k8s/createmod/prod/hpa.yaml
@@ -26,8 +26,8 @@ spec:
           value: 1
           periodSeconds: 120
     scaleUp:
-      stabilizationWindowSeconds: 30
+      stabilizationWindowSeconds: 60
       policies:
         - type: Pods
-          value: 2
+          value: 1
           periodSeconds: 60

--- a/server/start.go
+++ b/server/start.go
@@ -306,6 +306,7 @@ func (s *Server) Start() {
 		MailService:        s.mailService,
 		JobWorker:          s.jobWorker,
 		MaintenanceMode:    s.conf.MaintenanceMode,
+		DBPool:             s.pool,
 	})
 
 	// Wrap the chi router with the language prefix stripper


### PR DESCRIPTION
- Parallelize category section fetching in IndexHandler (cold caches now fetched concurrently instead of sequentially)
- Parallelize category cache warming at startup with concurrency limit
- Decouple readiness probe from in-memory search index build; now checks DB connectivity so pods accept traffic sooner
- Tighten HPA scale-up to 1 pod/60s with 60s stabilization window to prevent CPU spike feedback loops from rapid pod additions
- Update CLAUDE.md to replace stale Bleve references with accurate Meilisearch/in-memory index documentation