### PR TITLE
Add admin panel sections for comments and users

### DIFF
--- a/internal/database/gen/comments.sql.go
+++ b/internal/database/gen/comments.sql.go
@@ -23,7 +23,7 @@ func (q *Queries) ApproveComment(ctx context.Context, id string) error {
 
 const countCommentsBySchematic = `-- name: CountCommentsBySchematic :one
 SELECT COUNT(*) FROM comments
-WHERE schematic_id = $1 AND approved = true
+WHERE schematic_id = $1 AND approved = true AND deleted IS NULL
 `
 
 func (q *Queries) CountCommentsBySchematic(ctx context.Context, schematicID *string) (int64, error) {
@@ -33,8 +33,34 @@ func (q *Queries) CountCommentsBySchematic(ctx context.Context, schematicID *str
 	return count, err
 }
 
+const countCommentsForAdmin = `-- name: CountCommentsForAdmin :one
+SELECT COUNT(*)
+FROM comments c
+LEFT JOIN users u ON u.id = c.author_id
+WHERE
+  ($1::text = 'all'
+     OR ($1::text = 'active' AND c.deleted IS NULL)
+     OR ($1::text = 'deleted' AND c.deleted IS NOT NULL)
+     OR ($1::text = 'unapproved' AND c.approved = false AND c.deleted IS NULL))
+  AND ($2::text = ''
+     OR c.content ILIKE '%' || $2::text || '%'
+     OR u.username ILIKE '%' || $2::text || '%')
+`
+
+type CountCommentsForAdminParams struct {
+	Filter string `json:"filter"`
+	Search string `json:"search"`
+}
+
+func (q *Queries) CountCommentsForAdmin(ctx context.Context, arg CountCommentsForAdminParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countCommentsForAdmin, arg.Filter, arg.Search)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countUserComments = `-- name: CountUserComments :one
-SELECT COUNT(*) FROM comments WHERE author_id = $1 AND approved = true
+SELECT COUNT(*) FROM comments WHERE author_id = $1 AND approved = true AND deleted IS NULL
 `
 
 func (q *Queries) CountUserComments(ctx context.Context, authorID *string) (int64, error) {
@@ -47,7 +73,7 @@ func (q *Queries) CountUserComments(ctx context.Context, authorID *string) (int6
 const createComment = `-- name: CreateComment :one
 INSERT INTO comments (id, author_id, schematic_id, parent_id, content, published, approved, type)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, author_id, schematic_id, parent_id, content, published, approved, type, karma, postdate, status, name, created, updated
+RETURNING id, author_id, schematic_id, parent_id, content, published, approved, type, karma, postdate, status, name, created, updated, deleted
 `
 
 type CreateCommentParams struct {
@@ -88,12 +114,13 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (C
 		&i.Name,
 		&i.Created,
 		&i.Updated,
+		&i.Deleted,
 	)
 	return i, err
 }
 
 const deleteComment = `-- name: DeleteComment :exec
-DELETE FROM comments WHERE id = $1
+UPDATE comments SET deleted = NOW() WHERE id = $1
 `
 
 func (q *Queries) DeleteComment(ctx context.Context, id string) error {
@@ -111,7 +138,7 @@ func (q *Queries) DisapproveComment(ctx context.Context, id string) error {
 }
 
 const getCommentByID = `-- name: GetCommentByID :one
-SELECT id, author_id, schematic_id, parent_id, content, published, approved, type, karma, postdate, status, name, created, updated FROM comments WHERE id = $1
+SELECT id, author_id, schematic_id, parent_id, content, published, approved, type, karma, postdate, status, name, created, updated, deleted FROM comments WHERE id = $1
 `
 
 func (q *Queries) GetCommentByID(ctx context.Context, id string) (Comment, error) {
@@ -132,17 +159,27 @@ func (q *Queries) GetCommentByID(ctx context.Context, id string) (Comment, error
 		&i.Name,
 		&i.Created,
 		&i.Updated,
+		&i.Deleted,
 	)
 	return i, err
 }
 
+const hardDeleteComment = `-- name: HardDeleteComment :exec
+DELETE FROM comments WHERE id = $1
+`
+
+func (q *Queries) HardDeleteComment(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, hardDeleteComment, id)
+	return err
+}
+
 const listCommentsBySchematic = `-- name: ListCommentsBySchematic :many
-SELECT c.id, c.author_id, c.schematic_id, c.parent_id, c.content, c.published, c.approved, c.type, c.karma, c.postdate, c.status, c.name, c.created, c.updated,
+SELECT c.id, c.author_id, c.schematic_id, c.parent_id, c.content, c.published, c.approved, c.type, c.karma, c.postdate, c.status, c.name, c.created, c.updated, c.deleted,
        u.username AS author_username,
        u.avatar AS author_avatar
 FROM comments c
 LEFT JOIN users u ON u.id = c.author_id
-WHERE c.schematic_id = $1 AND c.approved = true
+WHERE c.schematic_id = $1 AND c.approved = true AND c.deleted IS NULL
 ORDER BY c.created ASC
 `
 
@@ -161,6 +198,7 @@ type ListCommentsBySchematicRow struct {
 	Name           string             `json:"name"`
 	Created        time.Time          `json:"created"`
 	Updated        time.Time          `json:"updated"`
+	Deleted        pgtype.Timestamptz `json:"deleted"`
 	AuthorUsername *string            `json:"author_username"`
 	AuthorAvatar   *string            `json:"author_avatar"`
 }
@@ -189,6 +227,7 @@ func (q *Queries) ListCommentsBySchematic(ctx context.Context, schematicID *stri
 			&i.Name,
 			&i.Created,
 			&i.Updated,
+			&i.Deleted,
 			&i.AuthorUsername,
 			&i.AuthorAvatar,
 		); err != nil {
@@ -200,4 +239,108 @@ func (q *Queries) ListCommentsBySchematic(ctx context.Context, schematicID *stri
 		return nil, err
 	}
 	return items, nil
+}
+
+const listCommentsForAdmin = `-- name: ListCommentsForAdmin :many
+SELECT c.id, c.author_id, c.schematic_id, c.parent_id, c.content, c.published, c.approved, c.type, c.karma, c.postdate, c.status, c.name, c.created, c.updated, c.deleted,
+       u.username AS author_username,
+       u.avatar AS author_avatar,
+       s.name AS schematic_name,
+       s.title AS schematic_title
+FROM comments c
+LEFT JOIN users u ON u.id = c.author_id
+LEFT JOIN schematics s ON s.id = c.schematic_id
+WHERE
+  ($3::text = 'all'
+     OR ($3::text = 'active' AND c.deleted IS NULL)
+     OR ($3::text = 'deleted' AND c.deleted IS NOT NULL)
+     OR ($3::text = 'unapproved' AND c.approved = false AND c.deleted IS NULL))
+  AND ($4::text = ''
+     OR c.content ILIKE '%' || $4::text || '%'
+     OR u.username ILIKE '%' || $4::text || '%')
+ORDER BY c.created DESC
+LIMIT $1 OFFSET $2
+`
+
+type ListCommentsForAdminParams struct {
+	Limit  int32  `json:"limit"`
+	Offset int32  `json:"offset"`
+	Filter string `json:"filter"`
+	Search string `json:"search"`
+}
+
+type ListCommentsForAdminRow struct {
+	ID             string             `json:"id"`
+	AuthorID       *string            `json:"author_id"`
+	SchematicID    *string            `json:"schematic_id"`
+	ParentID       *string            `json:"parent_id"`
+	Content        string             `json:"content"`
+	Published      pgtype.Timestamptz `json:"published"`
+	Approved       bool               `json:"approved"`
+	Type           string             `json:"type"`
+	Karma          int32              `json:"karma"`
+	Postdate       pgtype.Timestamptz `json:"postdate"`
+	Status         string             `json:"status"`
+	Name           string             `json:"name"`
+	Created        time.Time          `json:"created"`
+	Updated        time.Time          `json:"updated"`
+	Deleted        pgtype.Timestamptz `json:"deleted"`
+	AuthorUsername *string            `json:"author_username"`
+	AuthorAvatar   *string            `json:"author_avatar"`
+	SchematicName  *string            `json:"schematic_name"`
+	SchematicTitle *string            `json:"schematic_title"`
+}
+
+func (q *Queries) ListCommentsForAdmin(ctx context.Context, arg ListCommentsForAdminParams) ([]ListCommentsForAdminRow, error) {
+	rows, err := q.db.Query(ctx, listCommentsForAdmin,
+		arg.Limit,
+		arg.Offset,
+		arg.Filter,
+		arg.Search,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListCommentsForAdminRow{}
+	for rows.Next() {
+		var i ListCommentsForAdminRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AuthorID,
+			&i.SchematicID,
+			&i.ParentID,
+			&i.Content,
+			&i.Published,
+			&i.Approved,
+			&i.Type,
+			&i.Karma,
+			&i.Postdate,
+			&i.Status,
+			&i.Name,
+			&i.Created,
+			&i.Updated,
+			&i.Deleted,
+			&i.AuthorUsername,
+			&i.AuthorAvatar,
+			&i.SchematicName,
+			&i.SchematicTitle,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const restoreComment = `-- name: RestoreComment :exec
+UPDATE comments SET deleted = NULL WHERE id = $1
+`
+
+func (q *Queries) RestoreComment(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, restoreComment, id)
+	return err
 }

--- a/internal/database/gen/models.go
+++ b/internal/database/gen/models.go
@@ -86,6 +86,7 @@ type Comment struct {
 	Name        string             `json:"name"`
 	Created     time.Time          `json:"created"`
 	Updated     time.Time          `json:"updated"`
+	Deleted     pgtype.Timestamptz `json:"deleted"`
 }
 
 type CommentTranslation struct {

--- a/internal/database/gen/querier.go
+++ b/internal/database/gen/querier.go
@@ -30,6 +30,7 @@ type Querier interface {
 	ConsumeDownloadToken(ctx context.Context, token string) (DownloadToken, error)
 	CountApprovedSchematics(ctx context.Context) (int64, error)
 	CountCommentsBySchematic(ctx context.Context, schematicID *string) (int64, error)
+	CountCommentsForAdmin(ctx context.Context, arg CountCommentsForAdminParams) (int64, error)
 	CountSchematicVariationsBySchematicAndUser(ctx context.Context, arg CountSchematicVariationsBySchematicAndUserParams) (int32, error)
 	CountSchematicsByAuthor(ctx context.Context, authorID *string) (int64, error)
 	CountSchematicsByAuthorAll(ctx context.Context, authorID *string) (int64, error)
@@ -42,6 +43,7 @@ type Querier interface {
 	CountUserGuides(ctx context.Context, authorID *string) (int64, error)
 	CountUserMessagesSinceLastModerator(ctx context.Context, threadID string) (int64, error)
 	CountUsers(ctx context.Context) (int64, error)
+	CountUsersForAdmin(ctx context.Context, arg CountUsersForAdminParams) (int64, error)
 	CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (ApiKey, error)
 	CreateCategory(ctx context.Context, arg CreateCategoryParams) (SchematicCategory, error)
 	CreateCollection(ctx context.Context, arg CreateCollectionParams) (Collection, error)
@@ -144,10 +146,12 @@ type Querier interface {
 	GetTotalViewCount(ctx context.Context, schematicID string) (int32, error)
 	GetUserByEmail(ctx context.Context, email string) (User, error)
 	GetUserByID(ctx context.Context, id string) (User, error)
+	GetUserByIDIncludingDeleted(ctx context.Context, id string) (User, error)
 	GetUserByUsername(ctx context.Context, lower string) (User, error)
 	GetUserIsContributor(ctx context.Context, authorID *string) (bool, error)
 	GetUserMeta(ctx context.Context, arg GetUserMetaParams) (UserMetum, error)
 	GetUserWebhookByUserID(ctx context.Context, userID string) (UserWebhook, error)
+	HardDeleteComment(ctx context.Context, id string) error
 	HasAchievement(ctx context.Context, arg HasAchievementParams) (bool, error)
 	HourlyCommentStats(ctx context.Context, created time.Time) ([]HourlyCommentStatsRow, error)
 	HourlyDownloadStats(ctx context.Context, created time.Time) ([]HourlyDownloadStatsRow, error)
@@ -173,6 +177,7 @@ type Querier interface {
 	ListCollectionsByAuthor(ctx context.Context, authorID *string) ([]Collection, error)
 	ListCollectionsForSitemap(ctx context.Context) ([]ListCollectionsForSitemapRow, error)
 	ListCommentsBySchematic(ctx context.Context, schematicID *string) ([]ListCommentsBySchematicRow, error)
+	ListCommentsForAdmin(ctx context.Context, arg ListCommentsForAdminParams) ([]ListCommentsForAdminRow, error)
 	ListCommentsWithoutTranslation(ctx context.Context, arg ListCommentsWithoutTranslationParams) ([]ListCommentsWithoutTranslationRow, error)
 	ListExpiredUnclaimedTempUploads(ctx context.Context, arg ListExpiredUnclaimedTempUploadsParams) ([]ListExpiredUnclaimedTempUploadsRow, error)
 	ListExternalAuthsByUser(ctx context.Context, userID string) ([]ExternalAuth, error)
@@ -216,6 +221,7 @@ type Querier interface {
 	ListTopSearches(ctx context.Context, limit int32) ([]SearchQueryCount, error)
 	ListUserAchievements(ctx context.Context, userID string) ([]Achievement, error)
 	ListUsers(ctx context.Context, arg ListUsersParams) ([]User, error)
+	ListUsersForAdmin(ctx context.Context, arg ListUsersForAdminParams) ([]User, error)
 	ListUsersForSitemap(ctx context.Context) ([]ListUsersForSitemapRow, error)
 	ListVersions(ctx context.Context) ([]CreatemodVersion, error)
 	LogAPIKeyUsage(ctx context.Context, arg LogAPIKeyUsageParams) error
@@ -232,6 +238,8 @@ type Querier interface {
 	RefreshSearchQueryCounts(ctx context.Context) error
 	RemoveSchematicFromCollection(ctx context.Context, arg RemoveSchematicFromCollectionParams) error
 	ResetWebhookFailures(ctx context.Context, id string) error
+	RestoreComment(ctx context.Context, id string) error
+	RestoreUser(ctx context.Context, id string) error
 	SchematicNameExists(ctx context.Context, name string) (bool, error)
 	SetModerationState(ctx context.Context, arg SetModerationStateParams) error
 	SetSchematicCategories(ctx context.Context, schematicID string) error

--- a/internal/database/gen/translations.sql.go
+++ b/internal/database/gen/translations.sql.go
@@ -117,7 +117,7 @@ const listCommentsWithoutTranslation = `-- name: ListCommentsWithoutTranslation 
 SELECT c.id, c.author_id, c.schematic_id, c.parent_id, c.content,
        c.published, c.approved, c.type, c.karma, c.created, c.updated
 FROM comments c
-WHERE c.approved = true
+WHERE c.approved = true AND c.deleted IS NULL
   AND NOT EXISTS (
       SELECT 1 FROM comment_translations ct
       WHERE ct.comment_id = c.id AND ct.language = $1

--- a/internal/database/gen/users.sql.go
+++ b/internal/database/gen/users.sql.go
@@ -21,6 +21,31 @@ func (q *Queries) CountUsers(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const countUsersForAdmin = `-- name: CountUsersForAdmin :one
+SELECT COUNT(*)
+FROM users
+WHERE
+  ($1::text = 'all'
+     OR ($1::text = 'active' AND deleted IS NULL)
+     OR ($1::text = 'deleted' AND deleted IS NOT NULL)
+     OR ($1::text = 'admin' AND is_admin = true AND deleted IS NULL))
+  AND ($2::text = ''
+     OR username ILIKE '%' || $2::text || '%'
+     OR email ILIKE '%' || $2::text || '%')
+`
+
+type CountUsersForAdminParams struct {
+	Filter string `json:"filter"`
+	Search string `json:"search"`
+}
+
+func (q *Queries) CountUsersForAdmin(ctx context.Context, arg CountUsersForAdminParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countUsersForAdmin, arg.Filter, arg.Search)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (id, email, username, password_hash, old_password, avatar, verified)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -95,6 +120,30 @@ SELECT id, email, username, password_hash, old_password, avatar, points, verifie
 
 func (q *Queries) GetUserByID(ctx context.Context, id string) (User, error) {
 	row := q.db.QueryRow(ctx, getUserByID, id)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.Username,
+		&i.PasswordHash,
+		&i.OldPassword,
+		&i.Avatar,
+		&i.Points,
+		&i.Verified,
+		&i.IsAdmin,
+		&i.Deleted,
+		&i.Created,
+		&i.Updated,
+	)
+	return i, err
+}
+
+const getUserByIDIncludingDeleted = `-- name: GetUserByIDIncludingDeleted :one
+SELECT id, email, username, password_hash, old_password, avatar, points, verified, is_admin, deleted, created, updated FROM users WHERE id = $1
+`
+
+func (q *Queries) GetUserByIDIncludingDeleted(ctx context.Context, id string) (User, error) {
+	row := q.db.QueryRow(ctx, getUserByIDIncludingDeleted, id)
 	var i User
 	err := row.Scan(
 		&i.ID,
@@ -221,6 +270,66 @@ func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]User, e
 	return items, nil
 }
 
+const listUsersForAdmin = `-- name: ListUsersForAdmin :many
+SELECT id, email, username, password_hash, old_password, avatar, points, verified, is_admin, deleted, created, updated
+FROM users
+WHERE
+  ($3::text = 'all'
+     OR ($3::text = 'active' AND deleted IS NULL)
+     OR ($3::text = 'deleted' AND deleted IS NOT NULL)
+     OR ($3::text = 'admin' AND is_admin = true AND deleted IS NULL))
+  AND ($4::text = ''
+     OR username ILIKE '%' || $4::text || '%'
+     OR email ILIKE '%' || $4::text || '%')
+ORDER BY created DESC
+LIMIT $1 OFFSET $2
+`
+
+type ListUsersForAdminParams struct {
+	Limit  int32  `json:"limit"`
+	Offset int32  `json:"offset"`
+	Filter string `json:"filter"`
+	Search string `json:"search"`
+}
+
+func (q *Queries) ListUsersForAdmin(ctx context.Context, arg ListUsersForAdminParams) ([]User, error) {
+	rows, err := q.db.Query(ctx, listUsersForAdmin,
+		arg.Limit,
+		arg.Offset,
+		arg.Filter,
+		arg.Search,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []User{}
+	for rows.Next() {
+		var i User
+		if err := rows.Scan(
+			&i.ID,
+			&i.Email,
+			&i.Username,
+			&i.PasswordHash,
+			&i.OldPassword,
+			&i.Avatar,
+			&i.Points,
+			&i.Verified,
+			&i.IsAdmin,
+			&i.Deleted,
+			&i.Created,
+			&i.Updated,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUsersForSitemap = `-- name: ListUsersForSitemap :many
 SELECT id, username, updated FROM users
 WHERE deleted IS NULL
@@ -251,6 +360,15 @@ func (q *Queries) ListUsersForSitemap(ctx context.Context) ([]ListUsersForSitema
 		return nil, err
 	}
 	return items, nil
+}
+
+const restoreUser = `-- name: RestoreUser :exec
+UPDATE users SET deleted = NULL WHERE id = $1
+`
+
+func (q *Queries) RestoreUser(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, restoreUser, id)
+	return err
 }
 
 const softDeleteUser = `-- name: SoftDeleteUser :exec

--- a/internal/database/migrations/031_comment_soft_delete.down.sql
+++ b/internal/database/migrations/031_comment_soft_delete.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_comments_deleted;
+ALTER TABLE comments DROP COLUMN IF EXISTS deleted;

--- a/internal/database/migrations/031_comment_soft_delete.up.sql
+++ b/internal/database/migrations/031_comment_soft_delete.up.sql
@@ -1,0 +1,4 @@
+-- Add soft-delete column to comments so admins can hide comments without losing data.
+ALTER TABLE comments ADD COLUMN deleted TIMESTAMPTZ;
+
+CREATE INDEX idx_comments_deleted ON comments (deleted) WHERE deleted IS NULL;

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -151,6 +151,7 @@ func commentFromDB(c db.Comment, authorUsername, authorAvatar string) store.Comm
 		Karma:          int(c.Karma),
 		AuthorUsername: authorUsername,
 		AuthorAvatar:   authorAvatar,
+		Deleted:        fromPgTimestamptz(c.Deleted),
 		Created:        c.Created,
 		Updated:        c.Updated,
 	}
@@ -366,6 +367,42 @@ func (us *UserStoreImpl) UpdateUserAvatar(ctx context.Context, id string, avatar
 
 func (us *UserStoreImpl) SoftDeleteUser(ctx context.Context, id string) error {
 	return us.q.SoftDeleteUser(ctx, id)
+}
+
+func (us *UserStoreImpl) RestoreUser(ctx context.Context, id string) error {
+	return us.q.RestoreUser(ctx, id)
+}
+
+func (us *UserStoreImpl) GetByIDIncludingDeleted(ctx context.Context, id string) (*store.User, error) {
+	u, err := us.q.GetUserByIDIncludingDeleted(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return userFromDB(u), nil
+}
+
+func (us *UserStoreImpl) ListForAdmin(ctx context.Context, filter, search string, limit, offset int) ([]store.User, error) {
+	rows, err := us.q.ListUsersForAdmin(ctx, db.ListUsersForAdminParams{
+		Limit:  int32(limit),
+		Offset: int32(offset),
+		Filter: filter,
+		Search: search,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.User, len(rows))
+	for i, r := range rows {
+		result[i] = *userFromDB(r)
+	}
+	return result, nil
+}
+
+func (us *UserStoreImpl) CountForAdmin(ctx context.Context, filter, search string) (int64, error) {
+	return us.q.CountUsersForAdmin(ctx, db.CountUsersForAdminParams{
+		Filter: filter,
+		Search: search,
+	})
 }
 
 func (us *UserStoreImpl) IsContributor(ctx context.Context, userID string) (bool, error) {
@@ -1338,6 +1375,7 @@ func (cs *CommentStoreImpl) ListBySchematic(ctx context.Context, schematicID str
 			Karma:          int(r.Karma),
 			AuthorUsername: derefStr(r.AuthorUsername),
 			AuthorAvatar:   derefStr(r.AuthorAvatar),
+			Deleted:        fromPgTimestamptz(r.Deleted),
 			Created:        r.Created,
 			Updated:        r.Updated,
 		}
@@ -1378,8 +1416,53 @@ func (cs *CommentStoreImpl) Delete(ctx context.Context, id string) error {
 	return cs.q.DeleteComment(ctx, id)
 }
 
+func (cs *CommentStoreImpl) Restore(ctx context.Context, id string) error {
+	return cs.q.RestoreComment(ctx, id)
+}
+
 func (cs *CommentStoreImpl) CountByUser(ctx context.Context, userID string) (int64, error) {
 	return cs.q.CountUserComments(ctx, &userID)
+}
+
+func (cs *CommentStoreImpl) ListForAdmin(ctx context.Context, filter, search string, limit, offset int) ([]store.Comment, error) {
+	rows, err := cs.q.ListCommentsForAdmin(ctx, db.ListCommentsForAdminParams{
+		Limit:  int32(limit),
+		Offset: int32(offset),
+		Filter: filter,
+		Search: search,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.Comment, len(rows))
+	for i, r := range rows {
+		result[i] = store.Comment{
+			ID:             r.ID,
+			AuthorID:       r.AuthorID,
+			SchematicID:    r.SchematicID,
+			ParentID:       r.ParentID,
+			Content:        r.Content,
+			Published:      fromPgTimestamptz(r.Published),
+			Approved:       r.Approved,
+			Type:           r.Type,
+			Karma:          int(r.Karma),
+			AuthorUsername: derefStr(r.AuthorUsername),
+			AuthorAvatar:   derefStr(r.AuthorAvatar),
+			Deleted:        fromPgTimestamptz(r.Deleted),
+			SchematicName:  derefStr(r.SchematicName),
+			SchematicTitle: derefStr(r.SchematicTitle),
+			Created:        r.Created,
+			Updated:        r.Updated,
+		}
+	}
+	return result, nil
+}
+
+func (cs *CommentStoreImpl) CountForAdmin(ctx context.Context, filter, search string) (int64, error) {
+	return cs.q.CountCommentsForAdmin(ctx, db.CountCommentsForAdminParams{
+		Filter: filter,
+		Search: search,
+	})
 }
 
 // GuideStoreImpl implements store.GuideStore.

--- a/internal/database/queries/comments.sql
+++ b/internal/database/queries/comments.sql
@@ -7,12 +7,12 @@ SELECT c.*,
        u.avatar AS author_avatar
 FROM comments c
 LEFT JOIN users u ON u.id = c.author_id
-WHERE c.schematic_id = $1 AND c.approved = true
+WHERE c.schematic_id = $1 AND c.approved = true AND c.deleted IS NULL
 ORDER BY c.created ASC;
 
 -- name: CountCommentsBySchematic :one
 SELECT COUNT(*) FROM comments
-WHERE schematic_id = $1 AND approved = true;
+WHERE schematic_id = $1 AND approved = true AND deleted IS NULL;
 
 -- name: CreateComment :one
 INSERT INTO comments (id, author_id, schematic_id, parent_id, content, published, approved, type)
@@ -23,10 +23,49 @@ RETURNING *;
 UPDATE comments SET approved = true WHERE id = $1;
 
 -- name: DeleteComment :exec
+UPDATE comments SET deleted = NOW() WHERE id = $1;
+
+-- name: RestoreComment :exec
+UPDATE comments SET deleted = NULL WHERE id = $1;
+
+-- name: HardDeleteComment :exec
 DELETE FROM comments WHERE id = $1;
 
 -- name: DisapproveComment :exec
 UPDATE comments SET approved = false WHERE id = $1;
 
 -- name: CountUserComments :one
-SELECT COUNT(*) FROM comments WHERE author_id = $1 AND approved = true;
+SELECT COUNT(*) FROM comments WHERE author_id = $1 AND approved = true AND deleted IS NULL;
+
+-- name: ListCommentsForAdmin :many
+SELECT c.*,
+       u.username AS author_username,
+       u.avatar AS author_avatar,
+       s.name AS schematic_name,
+       s.title AS schematic_title
+FROM comments c
+LEFT JOIN users u ON u.id = c.author_id
+LEFT JOIN schematics s ON s.id = c.schematic_id
+WHERE
+  (sqlc.arg('filter')::text = 'all'
+     OR (sqlc.arg('filter')::text = 'active' AND c.deleted IS NULL)
+     OR (sqlc.arg('filter')::text = 'deleted' AND c.deleted IS NOT NULL)
+     OR (sqlc.arg('filter')::text = 'unapproved' AND c.approved = false AND c.deleted IS NULL))
+  AND (sqlc.arg('search')::text = ''
+     OR c.content ILIKE '%' || sqlc.arg('search')::text || '%'
+     OR u.username ILIKE '%' || sqlc.arg('search')::text || '%')
+ORDER BY c.created DESC
+LIMIT $1 OFFSET $2;
+
+-- name: CountCommentsForAdmin :one
+SELECT COUNT(*)
+FROM comments c
+LEFT JOIN users u ON u.id = c.author_id
+WHERE
+  (sqlc.arg('filter')::text = 'all'
+     OR (sqlc.arg('filter')::text = 'active' AND c.deleted IS NULL)
+     OR (sqlc.arg('filter')::text = 'deleted' AND c.deleted IS NOT NULL)
+     OR (sqlc.arg('filter')::text = 'unapproved' AND c.approved = false AND c.deleted IS NULL))
+  AND (sqlc.arg('search')::text = ''
+     OR c.content ILIKE '%' || sqlc.arg('search')::text || '%'
+     OR u.username ILIKE '%' || sqlc.arg('search')::text || '%');

--- a/internal/database/queries/translations.sql
+++ b/internal/database/queries/translations.sql
@@ -60,7 +60,7 @@ RETURNING *;
 SELECT c.id, c.author_id, c.schematic_id, c.parent_id, c.content,
        c.published, c.approved, c.type, c.karma, c.created, c.updated
 FROM comments c
-WHERE c.approved = true
+WHERE c.approved = true AND c.deleted IS NULL
   AND NOT EXISTS (
       SELECT 1 FROM comment_translations ct
       WHERE ct.comment_id = c.id AND ct.language = $1

--- a/internal/database/queries/users.sql
+++ b/internal/database/queries/users.sql
@@ -60,3 +60,35 @@ ORDER BY updated DESC;
 
 -- name: ListAdminEmails :many
 SELECT email FROM users WHERE is_admin = true AND deleted IS NULL;
+
+-- name: GetUserByIDIncludingDeleted :one
+SELECT * FROM users WHERE id = $1;
+
+-- name: RestoreUser :exec
+UPDATE users SET deleted = NULL WHERE id = $1;
+
+-- name: ListUsersForAdmin :many
+SELECT *
+FROM users
+WHERE
+  (sqlc.arg('filter')::text = 'all'
+     OR (sqlc.arg('filter')::text = 'active' AND deleted IS NULL)
+     OR (sqlc.arg('filter')::text = 'deleted' AND deleted IS NOT NULL)
+     OR (sqlc.arg('filter')::text = 'admin' AND is_admin = true AND deleted IS NULL))
+  AND (sqlc.arg('search')::text = ''
+     OR username ILIKE '%' || sqlc.arg('search')::text || '%'
+     OR email ILIKE '%' || sqlc.arg('search')::text || '%')
+ORDER BY created DESC
+LIMIT $1 OFFSET $2;
+
+-- name: CountUsersForAdmin :one
+SELECT COUNT(*)
+FROM users
+WHERE
+  (sqlc.arg('filter')::text = 'all'
+     OR (sqlc.arg('filter')::text = 'active' AND deleted IS NULL)
+     OR (sqlc.arg('filter')::text = 'deleted' AND deleted IS NOT NULL)
+     OR (sqlc.arg('filter')::text = 'admin' AND is_admin = true AND deleted IS NULL))
+  AND (sqlc.arg('search')::text = ''
+     OR username ILIKE '%' || sqlc.arg('search')::text || '%'
+     OR email ILIKE '%' || sqlc.arg('search')::text || '%');

--- a/internal/pages/admin_comments.go
+++ b/internal/pages/admin_comments.go
@@ -1,0 +1,231 @@
+package pages
+
+import (
+	"context"
+	"createmod/internal/cache"
+	"createmod/internal/i18n"
+	"createmod/internal/server"
+	"createmod/internal/store"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var adminCommentsTemplates = append([]string{
+	"./template/admin_comments.html",
+}, commonTemplates...)
+
+type AdminCommentItem struct {
+	ID             string
+	Content        string
+	Approved       bool
+	Deleted        *time.Time
+	AuthorID       string
+	AuthorUsername string
+	AuthorAvatar   string
+	SchematicID    string
+	SchematicName  string
+	SchematicTitle string
+	SchematicURL   string
+	Created        time.Time
+}
+
+type AdminCommentsData struct {
+	DefaultData
+	Comments   []AdminCommentItem
+	Filter     string
+	Search     string
+	Page       int
+	TotalPages int
+	Total      int64
+	PrevPage   int
+	NextPage   int
+	QueryStr   string // encoded filter+search for pagination links
+}
+
+const adminCommentsPerPage = 30
+
+// AdminCommentsHandler renders the admin comment listing page at GET /admin/comments.
+func AdminCommentsHandler(registry *server.Registry, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+
+		ctx := context.Background()
+
+		filter := e.Request.URL.Query().Get("filter")
+		switch filter {
+		case "all", "active", "deleted", "unapproved":
+		default:
+			filter = "active"
+		}
+
+		search := strings.TrimSpace(e.Request.URL.Query().Get("q"))
+
+		pageStr := e.Request.URL.Query().Get("page")
+		page, _ := strconv.Atoi(pageStr)
+		if page < 1 {
+			page = 1
+		}
+		offset := (page - 1) * adminCommentsPerPage
+
+		comments, err := appStore.Comments.ListForAdmin(ctx, filter, search, adminCommentsPerPage, offset)
+		if err != nil {
+			slog.Error("admin comments: list failed", "error", err)
+			return e.String(http.StatusInternalServerError, "failed to list comments")
+		}
+
+		total, err := appStore.Comments.CountForAdmin(ctx, filter, search)
+		if err != nil {
+			slog.Error("admin comments: count failed", "error", err)
+			return e.String(http.StatusInternalServerError, "failed to count comments")
+		}
+
+		totalPages := int(total) / adminCommentsPerPage
+		if int(total)%adminCommentsPerPage != 0 {
+			totalPages++
+		}
+		if totalPages < 1 {
+			totalPages = 1
+		}
+
+		items := make([]AdminCommentItem, 0, len(comments))
+		for _, c := range comments {
+			authorID := ""
+			if c.AuthorID != nil {
+				authorID = *c.AuthorID
+			}
+			schematicID := ""
+			if c.SchematicID != nil {
+				schematicID = *c.SchematicID
+			}
+			schURL := ""
+			if c.SchematicName != "" {
+				schURL = "/schematics/" + c.SchematicName + "#comment-" + c.ID
+			}
+			items = append(items, AdminCommentItem{
+				ID:             c.ID,
+				Content:        c.Content,
+				Approved:       c.Approved,
+				Deleted:        c.Deleted,
+				AuthorID:       authorID,
+				AuthorUsername: c.AuthorUsername,
+				AuthorAvatar:   c.AuthorAvatar,
+				SchematicID:    schematicID,
+				SchematicName:  c.SchematicName,
+				SchematicTitle: c.SchematicTitle,
+				SchematicURL:   schURL,
+				Created:        c.Created,
+			})
+		}
+
+		q := url.Values{}
+		q.Set("filter", filter)
+		if search != "" {
+			q.Set("q", search)
+		}
+
+		d := AdminCommentsData{
+			Comments:   items,
+			Filter:     filter,
+			Search:     search,
+			Page:       page,
+			TotalPages: totalPages,
+			Total:      total,
+			PrevPage:   page - 1,
+			NextPage:   page + 1,
+			QueryStr:   q.Encode(),
+		}
+		d.Populate(e)
+		d.AdminSection = "comments"
+		d.Breadcrumbs = NewBreadcrumbs(d.Language, i18n.T(d.Language, "Admin"), "/admin", i18n.T(d.Language, "Comments"))
+		d.Title = i18n.T(d.Language, "Admin: Comments")
+		d.SubCategory = "Admin"
+		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
+
+		html, err := registry.LoadFiles(adminCommentsTemplates...).Render(d)
+		if err != nil {
+			return err
+		}
+		return e.HTML(http.StatusOK, html)
+	}
+}
+
+// AdminCommentDeleteHandler soft-deletes a comment at POST /admin/comments/{id}/delete.
+func AdminCommentDeleteHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		if e.Request.Method != http.MethodPost {
+			return e.String(http.StatusMethodNotAllowed, "method not allowed")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		if err := appStore.Comments.Delete(context.Background(), id); err != nil {
+			slog.Error("admin comments: delete failed", "error", err, "id", id)
+			return e.String(http.StatusInternalServerError, "failed to delete comment")
+		}
+		return adminCommentsRedirect(e)
+	}
+}
+
+// AdminCommentRestoreHandler restores a soft-deleted comment at POST /admin/comments/{id}/restore.
+func AdminCommentRestoreHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		if e.Request.Method != http.MethodPost {
+			return e.String(http.StatusMethodNotAllowed, "method not allowed")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		if err := appStore.Comments.Restore(context.Background(), id); err != nil {
+			slog.Error("admin comments: restore failed", "error", err, "id", id)
+			return e.String(http.StatusInternalServerError, "failed to restore comment")
+		}
+		return adminCommentsRedirect(e)
+	}
+}
+
+// AdminCommentApproveHandler approves a pending comment at POST /admin/comments/{id}/approve.
+func AdminCommentApproveHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		if e.Request.Method != http.MethodPost {
+			return e.String(http.StatusMethodNotAllowed, "method not allowed")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		if err := appStore.Comments.Approve(context.Background(), id); err != nil {
+			slog.Error("admin comments: approve failed", "error", err, "id", id)
+			return e.String(http.StatusInternalServerError, "failed to approve comment")
+		}
+		return adminCommentsRedirect(e)
+	}
+}
+
+func adminCommentsRedirect(e *server.RequestEvent) error {
+	dest := strings.TrimSpace(e.Request.FormValue("return"))
+	if dest == "" || !strings.HasPrefix(dest, "/admin/comments") {
+		dest = "/admin/comments"
+	}
+	if e.Request.Header.Get("HX-Request") != "" {
+		e.Response.Header().Set("HX-Redirect", dest)
+		return e.HTML(http.StatusNoContent, "")
+	}
+	return e.Redirect(http.StatusSeeOther, dest)
+}

--- a/internal/pages/admin_users.go
+++ b/internal/pages/admin_users.go
@@ -1,0 +1,200 @@
+package pages
+
+import (
+	"context"
+	"createmod/internal/cache"
+	"createmod/internal/i18n"
+	"createmod/internal/server"
+	"createmod/internal/session"
+	"createmod/internal/store"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var adminUsersTemplates = append([]string{
+	"./template/admin_users.html",
+}, commonTemplates...)
+
+type AdminUserItem struct {
+	ID              string
+	Username        string
+	Email           string
+	Avatar          string
+	Points          int
+	Verified        bool
+	IsAdmin         bool
+	Deleted         *time.Time
+	SchematicsCount int64
+	Created         time.Time
+}
+
+type AdminUsersData struct {
+	DefaultData
+	Users      []AdminUserItem
+	Filter     string
+	Search     string
+	Page       int
+	TotalPages int
+	Total      int64
+	PrevPage   int
+	NextPage   int
+	QueryStr   string
+}
+
+const adminUsersPerPage = 30
+
+// AdminUsersHandler renders the admin user listing page at GET /admin/users.
+func AdminUsersHandler(registry *server.Registry, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+
+		ctx := context.Background()
+
+		filter := e.Request.URL.Query().Get("filter")
+		switch filter {
+		case "all", "active", "deleted", "admin":
+		default:
+			filter = "active"
+		}
+
+		search := strings.TrimSpace(e.Request.URL.Query().Get("q"))
+
+		pageStr := e.Request.URL.Query().Get("page")
+		page, _ := strconv.Atoi(pageStr)
+		if page < 1 {
+			page = 1
+		}
+		offset := (page - 1) * adminUsersPerPage
+
+		users, err := appStore.Users.ListForAdmin(ctx, filter, search, adminUsersPerPage, offset)
+		if err != nil {
+			slog.Error("admin users: list failed", "error", err)
+			return e.String(http.StatusInternalServerError, "failed to list users")
+		}
+
+		total, err := appStore.Users.CountForAdmin(ctx, filter, search)
+		if err != nil {
+			slog.Error("admin users: count failed", "error", err)
+			return e.String(http.StatusInternalServerError, "failed to count users")
+		}
+
+		totalPages := int(total) / adminUsersPerPage
+		if int(total)%adminUsersPerPage != 0 {
+			totalPages++
+		}
+		if totalPages < 1 {
+			totalPages = 1
+		}
+
+		items := make([]AdminUserItem, 0, len(users))
+		for _, u := range users {
+			count, _ := appStore.Schematics.CountByAuthorAll(ctx, u.ID)
+			items = append(items, AdminUserItem{
+				ID:              u.ID,
+				Username:        u.Username,
+				Email:           u.Email,
+				Avatar:          u.Avatar,
+				Points:          u.Points,
+				Verified:        u.Verified,
+				IsAdmin:         u.IsAdmin,
+				Deleted:         u.Deleted,
+				SchematicsCount: count,
+				Created:         u.Created,
+			})
+		}
+
+		q := url.Values{}
+		q.Set("filter", filter)
+		if search != "" {
+			q.Set("q", search)
+		}
+
+		d := AdminUsersData{
+			Users:      items,
+			Filter:     filter,
+			Search:     search,
+			Page:       page,
+			TotalPages: totalPages,
+			Total:      total,
+			PrevPage:   page - 1,
+			NextPage:   page + 1,
+			QueryStr:   q.Encode(),
+		}
+		d.Populate(e)
+		d.AdminSection = "users"
+		d.Breadcrumbs = NewBreadcrumbs(d.Language, i18n.T(d.Language, "Admin"), "/admin", i18n.T(d.Language, "Users"))
+		d.Title = i18n.T(d.Language, "Admin: Users")
+		d.SubCategory = "Admin"
+		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
+
+		html, err := registry.LoadFiles(adminUsersTemplates...).Render(d)
+		if err != nil {
+			return err
+		}
+		return e.HTML(http.StatusOK, html)
+	}
+}
+
+// AdminUserDeleteHandler soft-deletes a user at POST /admin/users/{id}/delete.
+func AdminUserDeleteHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		if e.Request.Method != http.MethodPost {
+			return e.String(http.StatusMethodNotAllowed, "method not allowed")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		// Guard: prevent an admin from deleting themselves.
+		if current := session.UserFromContext(e.Request.Context()); current != nil && current.ID == id {
+			return e.String(http.StatusBadRequest, "cannot delete your own account from this panel")
+		}
+		if err := appStore.Users.SoftDeleteUser(context.Background(), id); err != nil {
+			slog.Error("admin users: delete failed", "error", err, "id", id)
+			return e.String(http.StatusInternalServerError, "failed to delete user")
+		}
+		return adminUsersRedirect(e)
+	}
+}
+
+// AdminUserRestoreHandler restores a soft-deleted user at POST /admin/users/{id}/restore.
+func AdminUserRestoreHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		if e.Request.Method != http.MethodPost {
+			return e.String(http.StatusMethodNotAllowed, "method not allowed")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		if err := appStore.Users.RestoreUser(context.Background(), id); err != nil {
+			slog.Error("admin users: restore failed", "error", err, "id", id)
+			return e.String(http.StatusInternalServerError, "failed to restore user")
+		}
+		return adminUsersRedirect(e)
+	}
+}
+
+func adminUsersRedirect(e *server.RequestEvent) error {
+	dest := strings.TrimSpace(e.Request.FormValue("return"))
+	if dest == "" || !strings.HasPrefix(dest, "/admin/users") {
+		dest = "/admin/users"
+	}
+	if e.Request.Header.Get("HX-Request") != "" {
+		e.Response.Header().Set("HX-Redirect", dest)
+		return e.HTML(http.StatusNoContent, "")
+	}
+	return e.Redirect(http.StatusSeeOther, dest)
+}

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -401,6 +401,13 @@ func Register(p RegisterParams) chi.Router {
 	r.Get("/admin/mods", Adapt(pages.AdminModsHandler(registry, p.CacheService, p.AppStore)))
 	r.Get("/admin/mods/{namespace}", Adapt(pages.AdminModEditHandler(registry, p.CacheService, p.AppStore)))
 	r.Post("/admin/mods/{namespace}", Adapt(pages.AdminModUpdateHandler(p.AppStore)))
+	r.Get("/admin/comments", Adapt(pages.AdminCommentsHandler(registry, p.CacheService, p.AppStore)))
+	r.Post("/admin/comments/{id}/delete", Adapt(pages.AdminCommentDeleteHandler(p.AppStore)))
+	r.Post("/admin/comments/{id}/restore", Adapt(pages.AdminCommentRestoreHandler(p.AppStore)))
+	r.Post("/admin/comments/{id}/approve", Adapt(pages.AdminCommentApproveHandler(p.AppStore)))
+	r.Get("/admin/users", Adapt(pages.AdminUsersHandler(registry, p.CacheService, p.AppStore)))
+	r.Post("/admin/users/{id}/delete", Adapt(pages.AdminUserDeleteHandler(p.AppStore)))
+	r.Post("/admin/users/{id}/restore", Adapt(pages.AdminUserRestoreHandler(p.AppStore)))
 	// Auth — rate-limited to 10 POST requests per IP per minute
 	authRateLimit := rateLimitMiddlewareNew(p.RateLimiter, 10, time.Minute)
 	r.Get("/login", Adapt(pages.LoginHandler(registry, p.AppStore)))

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -128,6 +128,9 @@ type Comment struct {
 	Karma          int
 	AuthorUsername string
 	AuthorAvatar   string
+	Deleted        *time.Time
+	SchematicName  string
+	SchematicTitle string
 	Created        time.Time
 	Updated        time.Time
 }
@@ -363,11 +366,16 @@ type UserStore interface {
 	UpdateUserPassword(ctx context.Context, id string, hash string) error
 	UpdateUserAvatar(ctx context.Context, id string, avatar string) error
 	SoftDeleteUser(ctx context.Context, id string) error
+	RestoreUser(ctx context.Context, id string) error
 	IsContributor(ctx context.Context, userID string) (bool, error)
 	ListUsers(ctx context.Context, limit, offset int) ([]User, error)
 	CountUsers(ctx context.Context) (int64, error)
 	ListForSitemap(ctx context.Context) ([]SitemapUser, error)
 	ListAdminEmails(ctx context.Context) ([]string, error)
+	// Admin queries
+	GetByIDIncludingDeleted(ctx context.Context, id string) (*User, error)
+	ListForAdmin(ctx context.Context, filter, search string, limit, offset int) ([]User, error)
+	CountForAdmin(ctx context.Context, filter, search string) (int64, error)
 }
 
 // SessionStore handles session persistence.
@@ -503,7 +511,11 @@ type CommentStore interface {
 	Approve(ctx context.Context, id string) error
 	Disapprove(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
+	Restore(ctx context.Context, id string) error
 	CountByUser(ctx context.Context, userID string) (int64, error)
+	// Admin queries
+	ListForAdmin(ctx context.Context, filter, search string, limit, offset int) ([]Comment, error)
+	CountForAdmin(ctx context.Context, filter, search string) (int64, error)
 }
 
 // GuideStore handles guides.

--- a/template/admin_comments.html
+++ b/template/admin_comments.html
@@ -1,0 +1,167 @@
+{{template "head.html" .}}
+<div class="page">
+  {{template "sidebar.html" .}}
+  <div class="page-wrapper">
+    {{template "header.html" .}}
+    <main class="page-body">
+      <div class="container-wide">
+        {{template "admin_nav.html" .}}
+        <div class="page-header d-print-none">
+          <div class="row align-items-center">
+            <div class="col">
+              <h2 class="page-title">{{ T .Language "Admin: Comments" }}</h2>
+              <div class="text-secondary">{{ .Total }} {{ T .Language "comments matching filter" }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <ul class="nav nav-tabs card-header-tabs">
+              <li class="nav-item">
+                <a class="nav-link{{ if eq .Filter "active" }} active{{ end }}" href="/admin/comments?filter=active{{ if .Search }}&q={{.Search}}{{ end }}">{{ T .Language "Active" }}</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link{{ if eq .Filter "unapproved" }} active{{ end }}" href="/admin/comments?filter=unapproved{{ if .Search }}&q={{.Search}}{{ end }}">{{ T .Language "Unapproved" }}</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link{{ if eq .Filter "deleted" }} active{{ end }}" href="/admin/comments?filter=deleted{{ if .Search }}&q={{.Search}}{{ end }}">{{ T .Language "Deleted" }}</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link{{ if eq .Filter "all" }} active{{ end }}" href="/admin/comments?filter=all{{ if .Search }}&q={{.Search}}{{ end }}">{{ T .Language "All" }}</a>
+              </li>
+            </ul>
+          </div>
+          <div class="card-body border-bottom py-2">
+            <form method="get" action="/admin/comments" class="row g-2 align-items-center" hx-boost="false">
+              <input type="hidden" name="filter" value="{{.Filter}}">
+              <div class="col">
+                <input type="search" class="form-control" name="q" value="{{.Search}}" placeholder="{{ T .Language "Search by content or author username" }}">
+              </div>
+              <div class="col-auto">
+                <button type="submit" class="btn btn-primary">{{ T .Language "Search" }}</button>
+                {{if .Search}}
+                <a href="/admin/comments?filter={{.Filter}}" class="btn btn-link">{{ T .Language "Clear" }}</a>
+                {{end}}
+              </div>
+            </form>
+          </div>
+          <div class="table-responsive">
+            <table class="table card-table table-vcenter">
+              <thead>
+                <tr>
+                  <th>{{ T .Language "Author" }}</th>
+                  <th>{{ T .Language "Content" }}</th>
+                  <th>{{ T .Language "Schematic" }}</th>
+                  <th>{{ T .Language "Status" }}</th>
+                  <th>{{ T .Language "Created" }}</th>
+                  <th class="text-end">{{ T .Language "Actions" }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{range .Comments}}
+                <tr>
+                  <td class="text-nowrap">
+                    {{if .AuthorUsername}}
+                      <a href="/user/{{.AuthorUsername}}" target="_blank">{{.AuthorUsername}}</a>
+                    {{else}}
+                      <span class="text-secondary">—</span>
+                    {{end}}
+                  </td>
+                  <td style="max-width:420px;white-space:normal;">
+                    <div class="text-break" style="max-height:6em;overflow:hidden;">{{.Content}}</div>
+                  </td>
+                  <td>
+                    {{if .SchematicURL}}
+                      <a href="{{.SchematicURL}}" target="_blank" title="{{.SchematicTitle}}">{{.SchematicTitle}}</a>
+                    {{else}}
+                      <span class="text-secondary">—</span>
+                    {{end}}
+                  </td>
+                  <td class="text-nowrap">
+                    {{if .Deleted}}
+                      <span class="badge bg-red-lt">{{ T $.Language "Deleted" }}</span>
+                    {{else if not .Approved}}
+                      <span class="badge bg-yellow-lt">{{ T $.Language "Unapproved" }}</span>
+                    {{else}}
+                      <span class="badge bg-green-lt">{{ T $.Language "Active" }}</span>
+                    {{end}}
+                  </td>
+                  <td class="text-nowrap">{{HumanDate .Created}}</td>
+                  <td class="text-end text-nowrap">
+                    {{if .Deleted}}
+                      <form method="post" action="/admin/comments/{{.ID}}/restore" class="d-inline" hx-boost="false">
+                        <input type="hidden" name="return" value="/admin/comments?{{$.QueryStr}}&page={{$.Page}}">
+                        <button type="submit" class="btn btn-sm btn-success">{{ T $.Language "Restore" }}</button>
+                      </form>
+                    {{else}}
+                      {{if not .Approved}}
+                      <form method="post" action="/admin/comments/{{.ID}}/approve" class="d-inline" hx-boost="false">
+                        <input type="hidden" name="return" value="/admin/comments?{{$.QueryStr}}&page={{$.Page}}">
+                        <button type="submit" class="btn btn-sm btn-success">{{ T $.Language "Approve" }}</button>
+                      </form>
+                      {{end}}
+                      <button type="button" class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#comment-delete-modal-{{.ID}}">{{ T $.Language "Delete" }}</button>
+                    {{end}}
+                  </td>
+                </tr>
+                {{else}}
+                <tr>
+                  <td colspan="6" class="text-center text-secondary">{{ T .Language "No comments match this filter." }}</td>
+                </tr>
+                {{end}}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {{if gt .TotalPages 1}}
+        <div class="d-flex justify-content-center">
+          <ul class="pagination">
+            {{if gt .Page 1}}
+            <li class="page-item">
+              <a class="page-link" href="/admin/comments?{{.QueryStr}}&page={{.PrevPage}}">{{ T .Language "Previous" }}</a>
+            </li>
+            {{else}}
+            <li class="page-item disabled"><span class="page-link">{{ T .Language "Previous" }}</span></li>
+            {{end}}
+            <li class="page-item disabled"><span class="page-link">{{ T .Language "Page" }} {{.Page}} / {{.TotalPages}}</span></li>
+            {{if lt .Page .TotalPages}}
+            <li class="page-item">
+              <a class="page-link" href="/admin/comments?{{.QueryStr}}&page={{.NextPage}}">{{ T .Language "Next" }}</a>
+            </li>
+            {{else}}
+            <li class="page-item disabled"><span class="page-link">{{ T .Language "Next" }}</span></li>
+            {{end}}
+          </ul>
+        </div>
+        {{end}}
+
+        {{range .Comments}}
+        {{if not .Deleted}}
+        <div class="modal modal-blur fade" id="comment-delete-modal-{{.ID}}" tabindex="-1" role="dialog" aria-hidden="true">
+          <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+            <div class="modal-content">
+              <div class="modal-body">
+                <div class="modal-title">{{ T $.Language "Delete comment?" }}</div>
+                <div class="text-secondary mt-2">{{ T $.Language "The comment will be hidden from the site but preserved in the database and can be restored." }}</div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-link link-secondary me-auto" data-bs-dismiss="modal">{{ T $.Language "Cancel" }}</button>
+                <form method="post" action="/admin/comments/{{.ID}}/delete" hx-boost="false">
+                  <input type="hidden" name="return" value="/admin/comments?{{$.QueryStr}}&page={{$.Page}}">
+                  <button type="submit" class="btn btn-danger">{{ T $.Language "Yes, delete" }}</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+        {{end}}
+        {{end}}
+
+      </div>
+    </main>
+    {{template "footer.html" .}}
+  </div>
+</div>
+{{template "foot.html" .}}

--- a/template/admin_dashboard.html
+++ b/template/admin_dashboard.html
@@ -71,6 +71,30 @@
               </div>
             </div>
           </div>
+          <div class="col-sm-6 col-lg-3">
+            <div class="card">
+              <div class="card-body">
+                <div class="d-flex align-items-center">
+                  <div class="subheader">Users</div>
+                </div>
+                <div class="mt-3">
+                  <a href="/admin/users" class="btn btn-primary btn-sm">Manage Users</a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-sm-6 col-lg-3">
+            <div class="card">
+              <div class="card-body">
+                <div class="d-flex align-items-center">
+                  <div class="subheader">Comments</div>
+                </div>
+                <div class="mt-3">
+                  <a href="/admin/comments" class="btn btn-primary btn-sm">Manage Comments</a>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <!-- Stats -->
         <div class="row row-deck row-cards mb-3">

--- a/template/admin_reports.html
+++ b/template/admin_reports.html
@@ -131,7 +131,7 @@
               <div class="modal-body">
                 <div class="modal-title">{{ T $.Language "Are you sure?" }}</div>
                 <div class="text-secondary mt-2">
-                  This will {{if eq .TargetType "schematic"}}soft-delete the schematic{{else if eq .TargetType "comment"}}permanently delete the comment{{else if eq .TargetType "collection"}}soft-delete the collection{{else}}delete the reported item{{end}} and dismiss all reports for it.
+                  This will {{if eq .TargetType "schematic"}}soft-delete the schematic{{else if eq .TargetType "comment"}}soft-delete the comment{{else if eq .TargetType "collection"}}soft-delete the collection{{else}}delete the reported item{{end}} and dismiss all reports for it.
                 </div>
               </div>
               <div class="modal-footer">

--- a/template/admin_users.html
+++ b/template/admin_users.html
@@ -1,0 +1,156 @@
+{{template "head.html" .}}
+<div class="page">
+  {{template "sidebar.html" .}}
+  <div class="page-wrapper">
+    {{template "header.html" .}}
+    <main class="page-body">
+      <div class="container-wide">
+        {{template "admin_nav.html" .}}
+        <div class="page-header d-print-none">
+          <div class="row align-items-center">
+            <div class="col">
+              <h2 class="page-title">{{ T .Language "Admin: Users" }}</h2>
+              <div class="text-secondary">{{ .Total }} {{ T .Language "users matching filter" }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <ul class="nav nav-tabs card-header-tabs">
+              <li class="nav-item">
+                <a class="nav-link{{ if eq .Filter "active" }} active{{ end }}" href="/admin/users?filter=active{{ if .Search }}&q={{.Search}}{{ end }}">{{ T .Language "Active" }}</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link{{ if eq .Filter "admin" }} active{{ end }}" href="/admin/users?filter=admin{{ if .Search }}&q={{.Search}}{{ end }}">{{ T .Language "Admins" }}</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link{{ if eq .Filter "deleted" }} active{{ end }}" href="/admin/users?filter=deleted{{ if .Search }}&q={{.Search}}{{ end }}">{{ T .Language "Deleted" }}</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link{{ if eq .Filter "all" }} active{{ end }}" href="/admin/users?filter=all{{ if .Search }}&q={{.Search}}{{ end }}">{{ T .Language "All" }}</a>
+              </li>
+            </ul>
+          </div>
+          <div class="card-body border-bottom py-2">
+            <form method="get" action="/admin/users" class="row g-2 align-items-center" hx-boost="false">
+              <input type="hidden" name="filter" value="{{.Filter}}">
+              <div class="col">
+                <input type="search" class="form-control" name="q" value="{{.Search}}" placeholder="{{ T .Language "Search by username or email" }}">
+              </div>
+              <div class="col-auto">
+                <button type="submit" class="btn btn-primary">{{ T .Language "Search" }}</button>
+                {{if .Search}}
+                <a href="/admin/users?filter={{.Filter}}" class="btn btn-link">{{ T .Language "Clear" }}</a>
+                {{end}}
+              </div>
+            </form>
+          </div>
+          <div class="table-responsive">
+            <table class="table card-table table-vcenter">
+              <thead>
+                <tr>
+                  <th>{{ T .Language "Username" }}</th>
+                  <th>{{ T .Language "Email" }}</th>
+                  <th>{{ T .Language "Roles" }}</th>
+                  <th>{{ T .Language "Schematics" }}</th>
+                  <th>{{ T .Language "Points" }}</th>
+                  <th>{{ T .Language "Status" }}</th>
+                  <th>{{ T .Language "Joined" }}</th>
+                  <th class="text-end">{{ T .Language "Actions" }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{range .Users}}
+                <tr>
+                  <td class="text-nowrap">
+                    <a href="/user/{{.Username}}" target="_blank">{{.Username}}</a>
+                  </td>
+                  <td class="text-nowrap">{{.Email}}</td>
+                  <td class="text-nowrap">
+                    {{if .IsAdmin}}<span class="badge bg-purple-lt">{{ T $.Language "Admin" }}</span>{{end}}
+                    {{if .Verified}}<span class="badge bg-blue-lt">{{ T $.Language "Verified" }}</span>{{end}}
+                  </td>
+                  <td>{{.SchematicsCount}}</td>
+                  <td>{{.Points}}</td>
+                  <td class="text-nowrap">
+                    {{if .Deleted}}
+                      <span class="badge bg-red-lt">{{ T $.Language "Deleted" }}</span>
+                    {{else}}
+                      <span class="badge bg-green-lt">{{ T $.Language "Active" }}</span>
+                    {{end}}
+                  </td>
+                  <td class="text-nowrap">{{HumanDate .Created}}</td>
+                  <td class="text-end text-nowrap">
+                    {{if .Deleted}}
+                      <form method="post" action="/admin/users/{{.ID}}/restore" class="d-inline" hx-boost="false">
+                        <input type="hidden" name="return" value="/admin/users?{{$.QueryStr}}&page={{$.Page}}">
+                        <button type="submit" class="btn btn-sm btn-success">{{ T $.Language "Restore" }}</button>
+                      </form>
+                    {{else}}
+                      <button type="button" class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#user-delete-modal-{{.ID}}">{{ T $.Language "Delete" }}</button>
+                    {{end}}
+                  </td>
+                </tr>
+                {{else}}
+                <tr>
+                  <td colspan="8" class="text-center text-secondary">{{ T .Language "No users match this filter." }}</td>
+                </tr>
+                {{end}}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {{if gt .TotalPages 1}}
+        <div class="d-flex justify-content-center">
+          <ul class="pagination">
+            {{if gt .Page 1}}
+            <li class="page-item">
+              <a class="page-link" href="/admin/users?{{.QueryStr}}&page={{.PrevPage}}">{{ T .Language "Previous" }}</a>
+            </li>
+            {{else}}
+            <li class="page-item disabled"><span class="page-link">{{ T .Language "Previous" }}</span></li>
+            {{end}}
+            <li class="page-item disabled"><span class="page-link">{{ T .Language "Page" }} {{.Page}} / {{.TotalPages}}</span></li>
+            {{if lt .Page .TotalPages}}
+            <li class="page-item">
+              <a class="page-link" href="/admin/users?{{.QueryStr}}&page={{.NextPage}}">{{ T .Language "Next" }}</a>
+            </li>
+            {{else}}
+            <li class="page-item disabled"><span class="page-link">{{ T .Language "Next" }}</span></li>
+            {{end}}
+          </ul>
+        </div>
+        {{end}}
+
+        {{range .Users}}
+        {{if not .Deleted}}
+        <div class="modal modal-blur fade" id="user-delete-modal-{{.ID}}" tabindex="-1" role="dialog" aria-hidden="true">
+          <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+            <div class="modal-content">
+              <div class="modal-body">
+                <div class="modal-title">{{ T $.Language "Delete user?" }}</div>
+                <div class="text-secondary mt-2">
+                  {{ T $.Language "The account for" }} <strong>{{.Username}}</strong> {{ T $.Language "will be soft-deleted. Their sign-in will be disabled but their content is preserved and the action can be reversed." }}
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-link link-secondary me-auto" data-bs-dismiss="modal">{{ T $.Language "Cancel" }}</button>
+                <form method="post" action="/admin/users/{{.ID}}/delete" hx-boost="false">
+                  <input type="hidden" name="return" value="/admin/users?{{$.QueryStr}}&page={{$.Page}}">
+                  <button type="submit" class="btn btn-danger">{{ T $.Language "Yes, delete" }}</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+        {{end}}
+        {{end}}
+
+      </div>
+    </main>
+    {{template "footer.html" .}}
+  </div>
+</div>
+{{template "foot.html" .}}

--- a/template/include/admin_nav.html
+++ b/template/include/admin_nav.html
@@ -11,6 +11,12 @@
       <a class="nav-link{{ if eq .AdminSection "reports" }} active{{ end }}" href="/admin/reports">Reports</a>
     </li>
     <li class="nav-item">
+      <a class="nav-link{{ if eq .AdminSection "comments" }} active{{ end }}" href="/admin/comments">Comments</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link{{ if eq .AdminSection "users" }} active{{ end }}" href="/admin/users">Users</a>
+    </li>
+    <li class="nav-item">
       <a class="nav-link{{ if eq .AdminSection "tags" }} active{{ end }}" href="/admin/tags">Tags & Categories</a>
     </li>
     <li class="nav-item">


### PR DESCRIPTION
- Comments: soft-delete support via new `deleted` column (migration 031), admin listing with filter (active/unapproved/deleted/all), search over content and author, soft-delete/restore/approve actions.
- Users: admin listing with filter (active/admin/deleted/all), search over username and email, soft-delete/restore actions (with self-delete guard).
- Dashboard and nav updated; report delete modal copy reflects that comment deletes are now soft.