### PR TITLE
Stop stacking multiple sticky children in the ad rail

### DIFF
--- a/template/src/style.css
+++ b/template/src/style.css
@@ -815,7 +815,10 @@ body.theme-dark .img-light, body[data-bs-theme=dark] .img-light {
     align-self: stretch;
 }
 
-.ad-rail > div {
+/* Only the last child in the rail is sticky. Preceding slots (e.g. the
+   video-nc ad) scroll with the page so they don't stack on top of the
+   sticky-stack adrail at the same top offset. */
+.ad-rail > div:last-child {
     position: sticky;
     top: 110px;
 }
@@ -828,7 +831,7 @@ body.theme-dark .img-light, body[data-bs-theme=dark] .img-light {
     align-self: stretch;
 }
 
-.ad-rail-sm > div {
+.ad-rail-sm > div:last-child {
     position: sticky;
     top: 110px;
 }
@@ -840,13 +843,13 @@ body.theme-dark .img-light, body[data-bs-theme=dark] .img-light {
     align-self: stretch;
 }
 
-.search-ad-rail > div {
+.search-ad-rail > div:last-child {
     position: sticky;
     top: 110px;
 }
 
 /* Search page left sidebar ad container */
-.search-under-container > div {
+.search-under-container > div:last-child {
     position: sticky;
     top: 110px;
 }

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -197,7 +197,10 @@ a:hover {
   flex-shrink: 0;
   align-self: stretch;
 }
-.ad-rail > div {
+/* Only the last child in the rail is sticky. Preceding slots (e.g. the
+   video-nc ad) scroll with the page so they don't stack on top of the
+   sticky-stack adrail at the same top offset. */
+.ad-rail > div:last-child {
   position: sticky;
   top: 110px;
 }
@@ -264,7 +267,7 @@ a:hover {
   flex-shrink: 0;
   align-self: stretch;
 }
-.ad-rail-sm > div {
+.ad-rail-sm > div:last-child {
   position: sticky;
   top: 110px;
 }
@@ -753,7 +756,7 @@ body.sidebar-open::after {
   flex-shrink: 0;
   align-self: stretch;
 }
-.search-ad-rail > div {
+.search-ad-rail > div:last-child {
   position: sticky;
   top: 110px;
 }

--- a/tests/e2e/specs/ad_sticky.spec.ts
+++ b/tests/e2e/specs/ad_sticky.spec.ts
@@ -2,14 +2,17 @@ import { test, expect } from '@playwright/test';
 
 // Test that the ad rail CSS is correctly applied so NitroPay sticky-stack works.
 // The outer .ad-rail uses align-self:stretch for full height,
-// while the inner > div uses position:sticky to stay visible during scroll.
+// while only the LAST inner > div uses position:sticky to stay visible
+// during scroll. Preceding slots (e.g. the video-nc ad) scroll with the
+// page — making every child sticky caused them to stack on each other at
+// the same top offset.
 // Uses /explore because it always renders .ad-rail (the homepage does not have one).
 // In CI no ad scripts load, so we verify computed styles rather than visible content.
 
 test.describe('Ad rail stickiness', () => {
   test.use({ viewport: { width: 1400, height: 900 } });
 
-  test('ad rail inner divs have sticky positioning', async ({ page, baseURL }) => {
+  test('only the last inner div of the ad rail is sticky', async ({ page, baseURL }) => {
     const url = baseURL ?? 'http://localhost:8080';
     await page.goto(url + '/explore', { waitUntil: 'domcontentloaded' });
 
@@ -18,7 +21,7 @@ test.describe('Ad rail stickiness', () => {
     const adRail = page.locator('.ad-rail').first();
     await expect(adRail).toBeAttached({ timeout: 10000 });
 
-    // Verify the inner child divs have position: sticky applied via CSS
+    // Verify the last inner child is sticky and preceding ones are not.
     const innerStyles = await adRail.evaluate((el) => {
       const children = el.querySelectorAll(':scope > div');
       return Array.from(children).map((child) => {
@@ -28,9 +31,11 @@ test.describe('Ad rail stickiness', () => {
     });
 
     expect(innerStyles.length).toBeGreaterThan(0);
-    for (const style of innerStyles) {
-      expect(style.position).toBe('sticky');
-      expect(style.top).toBe('110px');
+    const last = innerStyles[innerStyles.length - 1];
+    expect(last.position).toBe('sticky');
+    expect(last.top).toBe('110px');
+    for (let i = 0; i < innerStyles.length - 1; i++) {
+      expect(innerStyles[i].position).not.toBe('sticky');
     }
   });
 


### PR DESCRIPTION
.ad-rail > div used position: sticky; top: 110px for every direct child, so pages with both a video-nc ad and a sticky-stack adrail in the same column rendered both siblings at the same top offset and they overlapped on scroll.

Target :last-child instead so only the bottom slot (the sticky-stack rail) sticks; slots above it scroll with the page. Applied to .ad-rail, .ad-rail-sm, .search-ad-rail, and .search-under-container in both the PostCSS source (template/src/style.css) and the served template/static/app.css. Updated the ad_sticky Playwright spec to assert the new expectation.