### PR TITLE
Fix sticky-stack overlapping video-nc ad on schematic page

### DIFF
--- a/template/schematic.html
+++ b/template/schematic.html
@@ -1237,13 +1237,30 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     },
     "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
   });
+  // Keep the sticky-stack container offset in sync with the video-nc's actual
+  // rendered height so both pin below each other without overlapping.
+  var videoNcEl = document.getElementById('schematic-video-nc-top-right');
+  var adRailEl = videoNcEl && videoNcEl.closest('.ad-rail');
+  var videoNcGap = 16; // matches the mb-3 margin + 1rem in the CSS calc()
+  var stickyStackTop = 110 + 200 + videoNcGap; // fallback matches CSS default
+  if (videoNcEl && adRailEl && typeof ResizeObserver !== 'undefined') {
+    var updateOffset = function () {
+      var h = videoNcEl.getBoundingClientRect().height;
+      if (h > 0) {
+        adRailEl.style.setProperty('--video-nc-height', h + 'px');
+      }
+    };
+    new ResizeObserver(updateOffset).observe(videoNcEl);
+    updateOffset();
+  }
+
   // Wide ad rail — sticky-stack for long schematic pages (xl+: 1200px+)
   window['nitroAds'].createAd('schematic-sticky-adrail', {
     "refreshVisibleOnly": true,
     "format": "sticky-stack",
     "stickyStackLimit": 15,
     "stickyStackSpace": 2.5,
-    "stickyStackOffset": 110,
+    "stickyStackOffset": stickyStackTop,
     "stickyStackResizable": false,
     "keywords": kwString,
     "targeting": targeting,

--- a/template/src/style.css
+++ b/template/src/style.css
@@ -820,6 +820,12 @@ body.theme-dark .img-light, body[data-bs-theme=dark] .img-light {
     top: 110px;
 }
 
+/* Sticky-stack sits below the video-nc so both pin without overlapping.
+   --video-nc-height is updated by JS once the video-nc ad renders. */
+.ad-rail > #schematic-sticky-adrail {
+    top: calc(110px + var(--video-nc-height, 200px) + 1rem);
+}
+
 /* Desktop LG ad rail (160px wide — schematic page only) */
 .ad-rail-sm {
     width: 160px;

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -201,6 +201,11 @@ a:hover {
   position: sticky;
   top: 110px;
 }
+/* Sticky-stack sits below the video-nc so both pin without overlapping.
+   --video-nc-height is updated by JS once the video-nc ad renders. */
+.ad-rail > #schematic-sticky-adrail {
+  top: calc(110px + var(--video-nc-height, 200px) + 1rem);
+}
 
 /***************
   Featured cards


### PR DESCRIPTION
Both ad-rail children were pinned at top: 110px, causing the sticky-stack to render on top of the video-nc while scrolling. Offset the sticky-stack by the video-nc's rendered height (tracked via ResizeObserver into a CSS variable) and bump NitroPay's stickyStackOffset to match.