### PR TITLE
Align search trending window with homepage

### DIFF
--- a/internal/pages/index.go
+++ b/internal/pages/index.go
@@ -438,7 +438,9 @@ func RefreshIndexCache(cacheService *cache.Service, appStore *store.Store, windo
 // rating aggregates to the schematics table for pre-computed query support.
 func ComputeTrendingScoresFromStore(appStore *store.Store) map[string]float64 {
 	ctx := context.Background()
-	td, err := appStore.ViewRatings.FetchTrendingData(ctx, 30)
+	// 7-day window matches the index page (windowDays := 7) so that search
+	// trending (sort=8) ranks schematics identically to the homepage.
+	td, err := appStore.ViewRatings.FetchTrendingData(ctx, 7)
 	if err != nil || td == nil {
 		return nil
 	}


### PR DESCRIPTION
Search sort=8 used trending scores computed over a 30-day window, while the index page computes trending over 7 days (windowDays := 7 in IndexHandler, matched by WarmIndexCache([]int{7})). The divergent windows produced different rankings for the same schematics.

Switch ComputeTrendingScoresFromStore to 7 days so the in-memory trendingScores map used by the search engine matches the homepage.