### PR TITLE
Cascade soft delete user content (schematics, collections, comments, …

### DIFF
--- a/internal/database/gen/collections.sql.go
+++ b/internal/database/gen/collections.sql.go
@@ -406,12 +406,30 @@ func (q *Queries) RemoveSchematicFromCollection(ctx context.Context, arg RemoveS
 	return err
 }
 
+const restoreCollectionsByAuthor = `-- name: RestoreCollectionsByAuthor :exec
+UPDATE collections SET deleted = '' WHERE author_id = $1 AND deleted = 'deleted'
+`
+
+func (q *Queries) RestoreCollectionsByAuthor(ctx context.Context, authorID *string) error {
+	_, err := q.db.Exec(ctx, restoreCollectionsByAuthor, authorID)
+	return err
+}
+
 const softDeleteCollection = `-- name: SoftDeleteCollection :exec
 UPDATE collections SET deleted = 'deleted' WHERE id = $1
 `
 
 func (q *Queries) SoftDeleteCollection(ctx context.Context, id string) error {
 	_, err := q.db.Exec(ctx, softDeleteCollection, id)
+	return err
+}
+
+const softDeleteCollectionsByAuthor = `-- name: SoftDeleteCollectionsByAuthor :exec
+UPDATE collections SET deleted = 'deleted' WHERE author_id = $1 AND deleted = ''
+`
+
+func (q *Queries) SoftDeleteCollectionsByAuthor(ctx context.Context, authorID *string) error {
+	_, err := q.db.Exec(ctx, softDeleteCollectionsByAuthor, authorID)
 	return err
 }
 

--- a/internal/database/gen/comments.sql.go
+++ b/internal/database/gen/comments.sql.go
@@ -344,3 +344,21 @@ func (q *Queries) RestoreComment(ctx context.Context, id string) error {
 	_, err := q.db.Exec(ctx, restoreComment, id)
 	return err
 }
+
+const restoreCommentsByAuthor = `-- name: RestoreCommentsByAuthor :exec
+UPDATE comments SET deleted = NULL WHERE author_id = $1 AND deleted IS NOT NULL
+`
+
+func (q *Queries) RestoreCommentsByAuthor(ctx context.Context, authorID *string) error {
+	_, err := q.db.Exec(ctx, restoreCommentsByAuthor, authorID)
+	return err
+}
+
+const softDeleteCommentsByAuthor = `-- name: SoftDeleteCommentsByAuthor :exec
+UPDATE comments SET deleted = NOW() WHERE author_id = $1 AND deleted IS NULL
+`
+
+func (q *Queries) SoftDeleteCommentsByAuthor(ctx context.Context, authorID *string) error {
+	_, err := q.db.Exec(ctx, softDeleteCommentsByAuthor, authorID)
+	return err
+}

--- a/internal/database/gen/guides.sql.go
+++ b/internal/database/gen/guides.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const countUserGuides = `-- name: CountUserGuides :one
-SELECT COUNT(*) FROM guides WHERE author_id = $1
+SELECT COUNT(*) FROM guides WHERE author_id = $1 AND deleted IS NULL
 `
 
 func (q *Queries) CountUserGuides(ctx context.Context, authorID *string) (int64, error) {
@@ -24,7 +24,7 @@ func (q *Queries) CountUserGuides(ctx context.Context, authorID *string) (int64,
 const createGuide = `-- name: CreateGuide :one
 INSERT INTO guides (id, author_id, title, description, content, slug, upload_link, banner_url)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url
+RETURNING id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url, deleted
 `
 
 type CreateGuideParams struct {
@@ -62,6 +62,7 @@ func (q *Queries) CreateGuide(ctx context.Context, arg CreateGuideParams) (Guide
 		&i.Updated,
 		&i.Views,
 		&i.BannerUrl,
+		&i.Deleted,
 	)
 	return i, err
 }
@@ -76,7 +77,7 @@ func (q *Queries) DeleteGuide(ctx context.Context, id string) error {
 }
 
 const getGuideByID = `-- name: GetGuideByID :one
-SELECT id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url FROM guides WHERE id = $1
+SELECT id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url, deleted FROM guides WHERE id = $1 AND deleted IS NULL
 `
 
 func (q *Queries) GetGuideByID(ctx context.Context, id string) (Guide, error) {
@@ -94,12 +95,13 @@ func (q *Queries) GetGuideByID(ctx context.Context, id string) (Guide, error) {
 		&i.Updated,
 		&i.Views,
 		&i.BannerUrl,
+		&i.Deleted,
 	)
 	return i, err
 }
 
 const getGuideBySlug = `-- name: GetGuideBySlug :one
-SELECT id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url FROM guides WHERE slug = $1
+SELECT id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url, deleted FROM guides WHERE slug = $1 AND deleted IS NULL
 `
 
 func (q *Queries) GetGuideBySlug(ctx context.Context, slug string) (Guide, error) {
@@ -117,6 +119,7 @@ func (q *Queries) GetGuideBySlug(ctx context.Context, slug string) (Guide, error
 		&i.Updated,
 		&i.Views,
 		&i.BannerUrl,
+		&i.Deleted,
 	)
 	return i, err
 }
@@ -131,7 +134,7 @@ func (q *Queries) IncrementGuideViews(ctx context.Context, id string) error {
 }
 
 const listGuides = `-- name: ListGuides :many
-SELECT id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url FROM guides ORDER BY created DESC LIMIT $1 OFFSET $2
+SELECT id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url, deleted FROM guides WHERE deleted IS NULL ORDER BY created DESC LIMIT $1 OFFSET $2
 `
 
 type ListGuidesParams struct {
@@ -160,6 +163,7 @@ func (q *Queries) ListGuides(ctx context.Context, arg ListGuidesParams) ([]Guide
 			&i.Updated,
 			&i.Views,
 			&i.BannerUrl,
+			&i.Deleted,
 		); err != nil {
 			return nil, err
 		}
@@ -172,7 +176,7 @@ func (q *Queries) ListGuides(ctx context.Context, arg ListGuidesParams) ([]Guide
 }
 
 const listGuidesForSitemap = `-- name: ListGuidesForSitemap :many
-SELECT id, slug, updated FROM guides ORDER BY updated DESC
+SELECT id, slug, updated FROM guides WHERE deleted IS NULL ORDER BY updated DESC
 `
 
 type ListGuidesForSitemapRow struct {
@@ -201,6 +205,33 @@ func (q *Queries) ListGuidesForSitemap(ctx context.Context) ([]ListGuidesForSite
 	return items, nil
 }
 
+const restoreGuidesByAuthor = `-- name: RestoreGuidesByAuthor :exec
+UPDATE guides SET deleted = NULL WHERE author_id = $1 AND deleted IS NOT NULL
+`
+
+func (q *Queries) RestoreGuidesByAuthor(ctx context.Context, authorID *string) error {
+	_, err := q.db.Exec(ctx, restoreGuidesByAuthor, authorID)
+	return err
+}
+
+const softDeleteGuide = `-- name: SoftDeleteGuide :exec
+UPDATE guides SET deleted = NOW() WHERE id = $1
+`
+
+func (q *Queries) SoftDeleteGuide(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, softDeleteGuide, id)
+	return err
+}
+
+const softDeleteGuidesByAuthor = `-- name: SoftDeleteGuidesByAuthor :exec
+UPDATE guides SET deleted = NOW() WHERE author_id = $1 AND deleted IS NULL
+`
+
+func (q *Queries) SoftDeleteGuidesByAuthor(ctx context.Context, authorID *string) error {
+	_, err := q.db.Exec(ctx, softDeleteGuidesByAuthor, authorID)
+	return err
+}
+
 const updateGuide = `-- name: UpdateGuide :one
 UPDATE guides SET
     title = COALESCE($2, title),
@@ -209,7 +240,7 @@ UPDATE guides SET
     upload_link = COALESCE($5, upload_link),
     banner_url = COALESCE($6, banner_url)
 WHERE id = $1
-RETURNING id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url
+RETURNING id, author_id, title, description, content, slug, upload_link, created, updated, views, banner_url, deleted
 `
 
 type UpdateGuideParams struct {
@@ -243,6 +274,7 @@ func (q *Queries) UpdateGuide(ctx context.Context, arg UpdateGuideParams) (Guide
 		&i.Updated,
 		&i.Views,
 		&i.BannerUrl,
+		&i.Deleted,
 	)
 	return i, err
 }

--- a/internal/database/gen/models.go
+++ b/internal/database/gen/models.go
@@ -137,17 +137,18 @@ type ExternalAuth struct {
 }
 
 type Guide struct {
-	ID          string    `json:"id"`
-	AuthorID    *string   `json:"author_id"`
-	Title       string    `json:"title"`
-	Description string    `json:"description"`
-	Content     string    `json:"content"`
-	Slug        string    `json:"slug"`
-	UploadLink  string    `json:"upload_link"`
-	Created     time.Time `json:"created"`
-	Updated     time.Time `json:"updated"`
-	Views       int32     `json:"views"`
-	BannerUrl   string    `json:"banner_url"`
+	ID          string             `json:"id"`
+	AuthorID    *string            `json:"author_id"`
+	Title       string             `json:"title"`
+	Description string             `json:"description"`
+	Content     string             `json:"content"`
+	Slug        string             `json:"slug"`
+	UploadLink  string             `json:"upload_link"`
+	Created     time.Time          `json:"created"`
+	Updated     time.Time          `json:"updated"`
+	Views       int32              `json:"views"`
+	BannerUrl   string             `json:"banner_url"`
+	Deleted     pgtype.Timestamptz `json:"deleted"`
 }
 
 type GuideTranslation struct {
@@ -355,13 +356,14 @@ type SchematicFile struct {
 }
 
 type SchematicRating struct {
-	ID          string    `json:"id"`
-	UserID      string    `json:"user_id"`
-	SchematicID string    `json:"schematic_id"`
-	Rating      float32   `json:"rating"`
-	RatedAt     time.Time `json:"rated_at"`
-	Created     time.Time `json:"created"`
-	Updated     time.Time `json:"updated"`
+	ID          string             `json:"id"`
+	UserID      string             `json:"user_id"`
+	SchematicID string             `json:"schematic_id"`
+	Rating      float32            `json:"rating"`
+	RatedAt     time.Time          `json:"rated_at"`
+	Created     time.Time          `json:"created"`
+	Updated     time.Time          `json:"updated"`
+	Deleted     pgtype.Timestamptz `json:"deleted"`
 }
 
 type SchematicTag struct {

--- a/internal/database/gen/querier.go
+++ b/internal/database/gen/querier.go
@@ -238,14 +238,25 @@ type Querier interface {
 	RefreshSearchQueryCounts(ctx context.Context) error
 	RemoveSchematicFromCollection(ctx context.Context, arg RemoveSchematicFromCollectionParams) error
 	ResetWebhookFailures(ctx context.Context, id string) error
+	RestoreCollectionsByAuthor(ctx context.Context, authorID *string) error
 	RestoreComment(ctx context.Context, id string) error
+	RestoreCommentsByAuthor(ctx context.Context, authorID *string) error
+	RestoreGuidesByAuthor(ctx context.Context, authorID *string) error
+	RestoreRatingsByUser(ctx context.Context, userID string) error
+	RestoreSchematicsByAuthor(ctx context.Context, authorID *string) error
 	RestoreUser(ctx context.Context, id string) error
 	SchematicNameExists(ctx context.Context, name string) (bool, error)
 	SetModerationState(ctx context.Context, arg SetModerationStateParams) error
 	SetSchematicCategories(ctx context.Context, schematicID string) error
 	SetSchematicTags(ctx context.Context, schematicID string) error
 	SoftDeleteCollection(ctx context.Context, id string) error
+	SoftDeleteCollectionsByAuthor(ctx context.Context, authorID *string) error
+	SoftDeleteCommentsByAuthor(ctx context.Context, authorID *string) error
+	SoftDeleteGuide(ctx context.Context, id string) error
+	SoftDeleteGuidesByAuthor(ctx context.Context, authorID *string) error
+	SoftDeleteRatingsByUser(ctx context.Context, userID string) error
 	SoftDeleteSchematic(ctx context.Context, id string) error
+	SoftDeleteSchematicsByAuthor(ctx context.Context, authorID *string) error
 	SoftDeleteUser(ctx context.Context, id string) error
 	SumUserPoints(ctx context.Context, userID string) (int32, error)
 	UpdateCollection(ctx context.Context, arg UpdateCollectionParams) (Collection, error)

--- a/internal/database/gen/schematics.sql.go
+++ b/internal/database/gen/schematics.sql.go
@@ -1637,6 +1637,16 @@ func (q *Queries) RefreshSchematicRatingAggregates(ctx context.Context, id strin
 	return err
 }
 
+const restoreSchematicsByAuthor = `-- name: RestoreSchematicsByAuthor :exec
+UPDATE schematics SET deleted = NULL, deleted_at = NULL, moderation_state = 'approved'
+WHERE author_id = $1 AND deleted IS NOT NULL
+`
+
+func (q *Queries) RestoreSchematicsByAuthor(ctx context.Context, authorID *string) error {
+	_, err := q.db.Exec(ctx, restoreSchematicsByAuthor, authorID)
+	return err
+}
+
 const schematicNameExists = `-- name: SchematicNameExists :one
 SELECT EXISTS(
     SELECT 1 FROM schematics WHERE name = $1 AND moderation_state != 'deleted'
@@ -1689,6 +1699,16 @@ UPDATE schematics SET deleted = NOW(), deleted_at = NOW(), moderation_state = 'd
 
 func (q *Queries) SoftDeleteSchematic(ctx context.Context, id string) error {
 	_, err := q.db.Exec(ctx, softDeleteSchematic, id)
+	return err
+}
+
+const softDeleteSchematicsByAuthor = `-- name: SoftDeleteSchematicsByAuthor :exec
+UPDATE schematics SET deleted = NOW(), deleted_at = NOW(), moderation_state = 'deleted'
+WHERE author_id = $1 AND deleted IS NULL
+`
+
+func (q *Queries) SoftDeleteSchematicsByAuthor(ctx context.Context, authorID *string) error {
+	_, err := q.db.Exec(ctx, softDeleteSchematicsByAuthor, authorID)
 	return err
 }
 

--- a/internal/database/gen/views_ratings.sql.go
+++ b/internal/database/gen/views_ratings.sql.go
@@ -45,7 +45,7 @@ func (q *Queries) BatchGetDownloadCounts(ctx context.Context, dollar_1 []string)
 const batchGetRatings = `-- name: BatchGetRatings :many
 SELECT schematic_id, COALESCE(AVG(rating), 0)::REAL AS avg_rating, COUNT(*)::INTEGER AS rating_count
 FROM schematic_ratings
-WHERE schematic_id = ANY($1::text[])
+WHERE schematic_id = ANY($1::text[]) AND deleted IS NULL
 GROUP BY schematic_id
 `
 
@@ -109,6 +109,7 @@ func (q *Queries) BatchGetViewCounts(ctx context.Context, dollar_1 []string) ([]
 const fetchRatingCountBySchematic = `-- name: FetchRatingCountBySchematic :many
 SELECT schematic_id AS id, COUNT(rating)::REAL AS v
 FROM schematic_ratings
+WHERE deleted IS NULL
 GROUP BY schematic_id
 `
 
@@ -140,6 +141,7 @@ func (q *Queries) FetchRatingCountBySchematic(ctx context.Context) ([]FetchRatin
 const fetchRatingSumBySchematic = `-- name: FetchRatingSumBySchematic :many
 SELECT schematic_id AS id, SUM(rating)::REAL AS v
 FROM schematic_ratings
+WHERE deleted IS NULL
 GROUP BY schematic_id
 `
 
@@ -344,7 +346,7 @@ SELECT
     COALESCE(AVG(rating), 0)::REAL AS avg_rating,
     COUNT(*)::INTEGER AS rating_count
 FROM schematic_ratings
-WHERE schematic_id = $1
+WHERE schematic_id = $1 AND deleted IS NULL
 `
 
 type GetSchematicRatingRow struct {
@@ -403,12 +405,31 @@ func (q *Queries) RecordSchematicDownload(ctx context.Context, arg RecordSchemat
 	return err
 }
 
+const restoreRatingsByUser = `-- name: RestoreRatingsByUser :exec
+UPDATE schematic_ratings SET deleted = NULL WHERE user_id = $1 AND deleted IS NOT NULL
+`
+
+func (q *Queries) RestoreRatingsByUser(ctx context.Context, userID string) error {
+	_, err := q.db.Exec(ctx, restoreRatingsByUser, userID)
+	return err
+}
+
+const softDeleteRatingsByUser = `-- name: SoftDeleteRatingsByUser :exec
+UPDATE schematic_ratings SET deleted = NOW() WHERE user_id = $1 AND deleted IS NULL
+`
+
+func (q *Queries) SoftDeleteRatingsByUser(ctx context.Context, userID string) error {
+	_, err := q.db.Exec(ctx, softDeleteRatingsByUser, userID)
+	return err
+}
+
 const upsertSchematicRating = `-- name: UpsertSchematicRating :exec
 INSERT INTO schematic_ratings (id, user_id, schematic_id, rating, rated_at)
 VALUES ($1, $2, $3, $4, NOW())
 ON CONFLICT (user_id, schematic_id) DO UPDATE SET
     rating = EXCLUDED.rating,
-    rated_at = NOW()
+    rated_at = NOW(),
+    deleted = NULL
 `
 
 type UpsertSchematicRatingParams struct {

--- a/internal/database/migrations/032_cascade_user_soft_delete.down.sql
+++ b/internal/database/migrations/032_cascade_user_soft_delete.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_guides_deleted;
+ALTER TABLE guides DROP COLUMN IF EXISTS deleted;
+
+DROP INDEX IF EXISTS idx_schematic_ratings_deleted;
+ALTER TABLE schematic_ratings DROP COLUMN IF EXISTS deleted;

--- a/internal/database/migrations/032_cascade_user_soft_delete.up.sql
+++ b/internal/database/migrations/032_cascade_user_soft_delete.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE schematic_ratings ADD COLUMN deleted TIMESTAMPTZ;
+CREATE INDEX idx_schematic_ratings_deleted ON schematic_ratings (deleted) WHERE deleted IS NULL;
+
+ALTER TABLE guides ADD COLUMN deleted TIMESTAMPTZ;
+CREATE INDEX idx_guides_deleted ON guides (deleted) WHERE deleted IS NULL;

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -373,6 +373,44 @@ func (us *UserStoreImpl) RestoreUser(ctx context.Context, id string) error {
 	return us.q.RestoreUser(ctx, id)
 }
 
+func (us *UserStoreImpl) CascadeSoftDelete(ctx context.Context, id string) error {
+	if err := us.q.SoftDeleteUser(ctx, id); err != nil {
+		return err
+	}
+	if err := us.q.SoftDeleteSchematicsByAuthor(ctx, &id); err != nil {
+		return err
+	}
+	if err := us.q.SoftDeleteCollectionsByAuthor(ctx, &id); err != nil {
+		return err
+	}
+	if err := us.q.SoftDeleteCommentsByAuthor(ctx, &id); err != nil {
+		return err
+	}
+	if err := us.q.SoftDeleteRatingsByUser(ctx, id); err != nil {
+		return err
+	}
+	return us.q.SoftDeleteGuidesByAuthor(ctx, &id)
+}
+
+func (us *UserStoreImpl) CascadeRestore(ctx context.Context, id string) error {
+	if err := us.q.RestoreUser(ctx, id); err != nil {
+		return err
+	}
+	if err := us.q.RestoreSchematicsByAuthor(ctx, &id); err != nil {
+		return err
+	}
+	if err := us.q.RestoreCollectionsByAuthor(ctx, &id); err != nil {
+		return err
+	}
+	if err := us.q.RestoreCommentsByAuthor(ctx, &id); err != nil {
+		return err
+	}
+	if err := us.q.RestoreRatingsByUser(ctx, id); err != nil {
+		return err
+	}
+	return us.q.RestoreGuidesByAuthor(ctx, &id)
+}
+
 func (us *UserStoreImpl) GetByIDIncludingDeleted(ctx context.Context, id string) (*store.User, error) {
 	u, err := us.q.GetUserByIDIncludingDeleted(ctx, id)
 	if err != nil {

--- a/internal/database/queries/collections.sql
+++ b/internal/database/queries/collections.sql
@@ -40,6 +40,12 @@ RETURNING *;
 -- name: SoftDeleteCollection :exec
 UPDATE collections SET deleted = 'deleted' WHERE id = $1;
 
+-- name: SoftDeleteCollectionsByAuthor :exec
+UPDATE collections SET deleted = 'deleted' WHERE author_id = $1 AND deleted = '';
+
+-- name: RestoreCollectionsByAuthor :exec
+UPDATE collections SET deleted = '' WHERE author_id = $1 AND deleted = 'deleted';
+
 -- name: GetCollectionSchematicIDs :many
 SELECT schematic_id FROM collections_schematics
 WHERE collection_id = $1

--- a/internal/database/queries/comments.sql
+++ b/internal/database/queries/comments.sql
@@ -25,6 +25,12 @@ UPDATE comments SET approved = true WHERE id = $1;
 -- name: DeleteComment :exec
 UPDATE comments SET deleted = NOW() WHERE id = $1;
 
+-- name: SoftDeleteCommentsByAuthor :exec
+UPDATE comments SET deleted = NOW() WHERE author_id = $1 AND deleted IS NULL;
+
+-- name: RestoreCommentsByAuthor :exec
+UPDATE comments SET deleted = NULL WHERE author_id = $1 AND deleted IS NOT NULL;
+
 -- name: RestoreComment :exec
 UPDATE comments SET deleted = NULL WHERE id = $1;
 

--- a/internal/database/queries/guides.sql
+++ b/internal/database/queries/guides.sql
@@ -1,11 +1,11 @@
 -- name: GetGuideByID :one
-SELECT * FROM guides WHERE id = $1;
+SELECT * FROM guides WHERE id = $1 AND deleted IS NULL;
 
 -- name: GetGuideBySlug :one
-SELECT * FROM guides WHERE slug = $1;
+SELECT * FROM guides WHERE slug = $1 AND deleted IS NULL;
 
 -- name: ListGuides :many
-SELECT * FROM guides ORDER BY created DESC LIMIT $1 OFFSET $2;
+SELECT * FROM guides WHERE deleted IS NULL ORDER BY created DESC LIMIT $1 OFFSET $2;
 
 -- name: CreateGuide :one
 INSERT INTO guides (id, author_id, title, description, content, slug, upload_link, banner_url)
@@ -25,11 +25,20 @@ RETURNING *;
 -- name: DeleteGuide :exec
 DELETE FROM guides WHERE id = $1;
 
+-- name: SoftDeleteGuide :exec
+UPDATE guides SET deleted = NOW() WHERE id = $1;
+
+-- name: SoftDeleteGuidesByAuthor :exec
+UPDATE guides SET deleted = NOW() WHERE author_id = $1 AND deleted IS NULL;
+
+-- name: RestoreGuidesByAuthor :exec
+UPDATE guides SET deleted = NULL WHERE author_id = $1 AND deleted IS NOT NULL;
+
 -- name: CountUserGuides :one
-SELECT COUNT(*) FROM guides WHERE author_id = $1;
+SELECT COUNT(*) FROM guides WHERE author_id = $1 AND deleted IS NULL;
 
 -- name: IncrementGuideViews :exec
 UPDATE guides SET views = views + 1 WHERE id = $1;
 
 -- name: ListGuidesForSitemap :many
-SELECT id, slug, updated FROM guides ORDER BY updated DESC;
+SELECT id, slug, updated FROM guides WHERE deleted IS NULL ORDER BY updated DESC;

--- a/internal/database/queries/schematics.sql
+++ b/internal/database/queries/schematics.sql
@@ -106,6 +106,14 @@ UPDATE schematics SET moderation_state = $2, moderation_reason = $3, updated = N
 -- name: SoftDeleteSchematic :exec
 UPDATE schematics SET deleted = NOW(), deleted_at = NOW(), moderation_state = 'deleted' WHERE id = $1;
 
+-- name: SoftDeleteSchematicsByAuthor :exec
+UPDATE schematics SET deleted = NOW(), deleted_at = NOW(), moderation_state = 'deleted'
+WHERE author_id = $1 AND deleted IS NULL;
+
+-- name: RestoreSchematicsByAuthor :exec
+UPDATE schematics SET deleted = NULL, deleted_at = NULL, moderation_state = 'approved'
+WHERE author_id = $1 AND deleted IS NOT NULL;
+
 -- name: UpdateSchematicViews :exec
 UPDATE schematics SET views = $2 WHERE id = $1;
 

--- a/internal/database/queries/views_ratings.sql
+++ b/internal/database/queries/views_ratings.sql
@@ -23,14 +23,21 @@ SELECT
     COALESCE(AVG(rating), 0)::REAL AS avg_rating,
     COUNT(*)::INTEGER AS rating_count
 FROM schematic_ratings
-WHERE schematic_id = $1;
+WHERE schematic_id = $1 AND deleted IS NULL;
+
+-- name: SoftDeleteRatingsByUser :exec
+UPDATE schematic_ratings SET deleted = NOW() WHERE user_id = $1 AND deleted IS NULL;
+
+-- name: RestoreRatingsByUser :exec
+UPDATE schematic_ratings SET deleted = NULL WHERE user_id = $1 AND deleted IS NOT NULL;
 
 -- name: UpsertSchematicRating :exec
 INSERT INTO schematic_ratings (id, user_id, schematic_id, rating, rated_at)
 VALUES ($1, $2, $3, $4, NOW())
 ON CONFLICT (user_id, schematic_id) DO UPDATE SET
     rating = EXCLUDED.rating,
-    rated_at = NOW();
+    rated_at = NOW(),
+    deleted = NULL;
 
 -- name: UpsertSchematicViewCount :exec
 INSERT INTO schematic_views (id, schematic_id, type, period, count)
@@ -59,11 +66,13 @@ GROUP BY schematic_id;
 -- name: FetchRatingSumBySchematic :many
 SELECT schematic_id AS id, SUM(rating)::REAL AS v
 FROM schematic_ratings
+WHERE deleted IS NULL
 GROUP BY schematic_id;
 
 -- name: FetchRatingCountBySchematic :many
 SELECT schematic_id AS id, COUNT(rating)::REAL AS v
 FROM schematic_ratings
+WHERE deleted IS NULL
 GROUP BY schematic_id;
 
 -- name: FetchRecentDownloadsBySchematic :many
@@ -96,5 +105,5 @@ GROUP BY schematic_id;
 -- name: BatchGetRatings :many
 SELECT schematic_id, COALESCE(AVG(rating), 0)::REAL AS avg_rating, COUNT(*)::INTEGER AS rating_count
 FROM schematic_ratings
-WHERE schematic_id = ANY($1::text[])
+WHERE schematic_id = ANY($1::text[]) AND deleted IS NULL
 GROUP BY schematic_id;

--- a/internal/pages/admin_users.go
+++ b/internal/pages/admin_users.go
@@ -158,7 +158,7 @@ func AdminUserDeleteHandler(appStore *store.Store) func(e *server.RequestEvent) 
 		if current := session.UserFromContext(e.Request.Context()); current != nil && current.ID == id {
 			return e.String(http.StatusBadRequest, "cannot delete your own account from this panel")
 		}
-		if err := appStore.Users.SoftDeleteUser(context.Background(), id); err != nil {
+		if err := appStore.Users.CascadeSoftDelete(context.Background(), id); err != nil {
 			slog.Error("admin users: delete failed", "error", err, "id", id)
 			return e.String(http.StatusInternalServerError, "failed to delete user")
 		}
@@ -179,7 +179,7 @@ func AdminUserRestoreHandler(appStore *store.Store) func(e *server.RequestEvent)
 		if id == "" {
 			return e.String(http.StatusBadRequest, "missing id")
 		}
-		if err := appStore.Users.RestoreUser(context.Background(), id); err != nil {
+		if err := appStore.Users.CascadeRestore(context.Background(), id); err != nil {
 			slog.Error("admin users: restore failed", "error", err, "id", id)
 			return e.String(http.StatusInternalServerError, "failed to restore user")
 		}

--- a/internal/pages/api_usersettings.go
+++ b/internal/pages/api_usersettings.go
@@ -84,23 +84,22 @@ func UserDeleteHandler(appStore *store.Store, cacheService *cache.Service, sessS
 
 		ctx := context.Background()
 
-		// Soft-delete all schematics belonging to this user
+		// Invalidate schematic caches before cascade delete
 		schematics, err := appStore.Schematics.ListByAuthor(ctx, userID, -1, 0)
 		if err != nil {
-			slog.Error("failed to list user schematics for deletion", "error", err)
+			slog.Error("failed to list user schematics for cache invalidation", "error", err)
 		} else {
 			for _, schem := range schematics {
 				cacheService.DeleteSchematic(cache.SchematicKey(schem.ID))
-				_ = appStore.Schematics.SoftDelete(ctx, schem.ID)
 			}
 			if len(schematics) > 0 {
 				RefreshIndexCache(cacheService, appStore, nil)
 			}
 		}
 
-		// Soft-delete the user
-		if err := appStore.Users.SoftDeleteUser(ctx, userID); err != nil {
-			slog.Error("failed to soft-delete user", "error", err)
+		// Cascade soft-delete: user + schematics, collections, comments, ratings, guides
+		if err := appStore.Users.CascadeSoftDelete(ctx, userID); err != nil {
+			slog.Error("failed to cascade soft-delete user", "error", err)
 			return e.InternalServerError("could not delete account", nil)
 		}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -367,6 +367,8 @@ type UserStore interface {
 	UpdateUserAvatar(ctx context.Context, id string, avatar string) error
 	SoftDeleteUser(ctx context.Context, id string) error
 	RestoreUser(ctx context.Context, id string) error
+	CascadeSoftDelete(ctx context.Context, id string) error
+	CascadeRestore(ctx context.Context, id string) error
 	IsContributor(ctx context.Context, userID string) (bool, error)
 	ListUsers(ctx context.Context, limit, offset int) ([]User, error)
 	CountUsers(ctx context.Context) (int64, error)


### PR DESCRIPTION
…ratings, guides)

When a user is soft-deleted, all their schematics, collections, comments, ratings, and guides are now also soft-deleted. Restoring a user restores all cascaded content. Adds deleted column to schematic_ratings and guides tables, and filters soft-deleted ratings/guides from all read queries.