### PR TITLE
Make migration 032 idempotent to handle dirty retry

### DIFF
--- a/internal/database/migrations/032_cascade_user_soft_delete.up.sql
+++ b/internal/database/migrations/032_cascade_user_soft_delete.up.sql
@@ -1,5 +1,5 @@
-ALTER TABLE schematic_ratings ADD COLUMN deleted TIMESTAMPTZ;
-CREATE INDEX idx_schematic_ratings_deleted ON schematic_ratings (deleted) WHERE deleted IS NULL;
+ALTER TABLE schematic_ratings ADD COLUMN IF NOT EXISTS deleted TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_schematic_ratings_deleted ON schematic_ratings (deleted) WHERE deleted IS NULL;
 
-ALTER TABLE guides ADD COLUMN deleted TIMESTAMPTZ;
-CREATE INDEX idx_guides_deleted ON guides (deleted) WHERE deleted IS NULL;
+ALTER TABLE guides ADD COLUMN IF NOT EXISTS deleted TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_guides_deleted ON guides (deleted) WHERE deleted IS NULL;


### PR DESCRIPTION
The columns and indexes were already created manually on prod, so the migration fails on retry after a dirty state. Using IF NOT EXISTS lets it succeed regardless of prior state.