### PR TITLE
Add HTML response caching for anonymous users on high-traffic pages

### DIFF
--- a/internal/cache/service.go
+++ b/internal/cache/service.go
@@ -158,6 +158,14 @@ func ModMetadataKey(namespace string) string {
 	return fmt.Sprintf("modmeta:%s", namespace)
 }
 
+func SchematicHTMLKey(name, lang string) string {
+	return fmt.Sprintf("html:schematic:%s:%s", name, lang)
+}
+
+func SchematicsListHTMLKey(page int, lang string) string {
+	return fmt.Sprintf("html:schematics:%d:%s", page, lang)
+}
+
 // --- Generic Set/Get (in-memory only for complex types) ---
 
 func (s *Service) Set(key string, value interface{}) {
@@ -249,6 +257,22 @@ func (s *Service) GetString(key string) (string, bool) {
 func (s *Service) SetSchematic(key string, value models.Schematic) {
 	s.c.Set(key, value, gocache.DefaultExpiration)
 	s.redisSet(key, "schematic", value)
+}
+
+var htmlCacheLanguages = []string{"en", "fr", "pt-BR", "pt-PT", "es", "de", "pl", "ru", "zh-Hans"}
+
+func (s *Service) DeleteSchematicHTML(name string) {
+	for _, lang := range htmlCacheLanguages {
+		s.c.Delete(SchematicHTMLKey(name, lang))
+	}
+}
+
+func (s *Service) DeleteSchematicsListHTML() {
+	for page := 1; page <= 20; page++ {
+		for _, lang := range htmlCacheLanguages {
+			s.c.Delete(SchematicsListHTMLKey(page, lang))
+		}
+	}
 }
 
 func (s *Service) DeleteSchematic(key string) {

--- a/internal/pages/admin_schematics.go
+++ b/internal/pages/admin_schematics.go
@@ -332,6 +332,8 @@ func AdminSchematicUpdateHandler(cacheService *cache.Service, appStore *store.St
 
 		// Clear cache
 		cacheService.DeleteSchematic(cache.SchematicKey(id))
+		cacheService.DeleteSchematicHTML(schem.Name)
+		cacheService.DeleteSchematicsListHTML()
 		RefreshIndexCache(cacheService, appStore, []int{7})
 
 		// If moderation just changed from non-public to public, notify the author
@@ -390,12 +392,18 @@ func AdminSchematicDeleteHandler(cacheService *cache.Service, appStore *store.St
 			return e.String(http.StatusBadRequest, "missing id")
 		}
 
+		schem, _ := appStore.Schematics.GetByIDAdmin(context.Background(), id)
+
 		if err := appStore.Schematics.SoftDelete(context.Background(), id); err != nil {
 			slog.Error("admin schematic delete: failed to soft-delete", "error", err, "id", id)
 			return e.String(http.StatusInternalServerError, "failed to delete schematic")
 		}
 
 		cacheService.DeleteSchematic(cache.SchematicKey(id))
+		if schem != nil {
+			cacheService.DeleteSchematicHTML(schem.Name)
+		}
+		cacheService.DeleteSchematicsListHTML()
 		RefreshIndexCache(cacheService, appStore, []int{7})
 
 		if e.Request.Header.Get("HX-Request") != "" {

--- a/internal/pages/api_schematic_edit.go
+++ b/internal/pages/api_schematic_edit.go
@@ -388,6 +388,8 @@ func SchematicUpdateHandler(
 
 		// --- Clear cache ---
 		cacheService.DeleteSchematic(cache.SchematicKey(schematicID))
+		cacheService.DeleteSchematicHTML(schem.Name)
+		cacheService.DeleteSchematicsListHTML()
 		RefreshIndexCache(cacheService, appStore, []int{7})
 
 		// --- Respond ---
@@ -447,6 +449,8 @@ func SchematicDeleteHandler(
 
 		// Clear cache
 		cacheService.DeleteSchematic(cache.SchematicKey(schematicID))
+		cacheService.DeleteSchematicHTML(schem.Name)
+		cacheService.DeleteSchematicsListHTML()
 		RefreshIndexCache(cacheService, appStore, []int{7})
 
 		// Respond

--- a/internal/pages/api_usersettings.go
+++ b/internal/pages/api_usersettings.go
@@ -91,8 +91,10 @@ func UserDeleteHandler(appStore *store.Store, cacheService *cache.Service, sessS
 		} else {
 			for _, schem := range schematics {
 				cacheService.DeleteSchematic(cache.SchematicKey(schem.ID))
+				cacheService.DeleteSchematicHTML(schem.Name)
 			}
 			if len(schematics) > 0 {
+				cacheService.DeleteSchematicsListHTML()
 				RefreshIndexCache(cacheService, appStore, []int{7})
 			}
 		}

--- a/internal/pages/default.go
+++ b/internal/pages/default.go
@@ -174,6 +174,13 @@ func (d *DefaultData) populateFromSession(e *server.RequestEvent, user *session.
 	// TODO: This will be set by handlers with store access
 }
 
+// setPublicCacheControl overrides the default "no-cache, private" header for
+// anonymous page responses that are safe to cache in browsers and CDNs.
+func setPublicCacheControl(e *server.RequestEvent, maxAge int) {
+	e.Response.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, stale-while-revalidate=%d", maxAge, maxAge*2))
+	e.Response.Header().Set("Vary", "Cookie, Accept-Language")
+}
+
 // isAuthenticated returns true if the request is authenticated via the PostgreSQL session store.
 func isAuthenticated(e *server.RequestEvent) bool {
 	return session.UserFromContext(e.Request.Context()) != nil

--- a/internal/pages/index.go
+++ b/internal/pages/index.go
@@ -122,6 +122,7 @@ func IndexHandler(cacheService *cache.Service, registry *server.Registry, appSto
 		// Authenticated pages contain user-specific data so are always rendered fresh.
 		isAuth := authenticatedUserID(e) != ""
 		if !isAuth {
+			setPublicCacheControl(e, 30)
 			lang := detectLanguageFromRequest(e.Request)
 			htmlCacheKey := indexHTMLCacheKeyWithWindow(lang, windowDays)
 			if cached, ok := cacheService.GetString(htmlCacheKey); ok {

--- a/internal/pages/schematic.go
+++ b/internal/pages/schematic.go
@@ -92,10 +92,22 @@ type ModInfo struct {
 	IconURL   string
 }
 
+const schematicHTMLCacheTTL = 30 * time.Second
+
 func SchematicHandler(searchEngine search.SearchEngine, cacheService *cache.Service, registry *server.Registry, discordService *discord.Service, translationService *translation.Service, appStore *store.Store, storageSvc *storage.Service, webhookSecret string) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		ctx := stdctx.Background()
 		name := e.Request.PathValue("name")
+
+		isAuth := authenticatedUserID(e) != ""
+		if !isAuth {
+			setPublicCacheControl(e, 30)
+			lang := detectLanguageFromRequest(e.Request)
+			if cached, ok := cacheService.GetString(cache.SchematicHTMLKey(name, lang)); ok {
+				return e.HTML(http.StatusOK, cached)
+			}
+		}
+
 		s, err := appStore.Schematics.GetByName(ctx, name)
 		if err != nil || s == nil || s.ModerationState == store.ModerationDeleted {
 			// Try to find and fix a schematic with percent-encoded characters in its name
@@ -353,6 +365,11 @@ func SchematicHandler(searchEngine search.SearchEngine, cacheService *cache.Serv
 		if err != nil {
 			return err
 		}
+
+		if !isAuth && store.IsPublicState(s.ModerationState) {
+			cacheService.SetWithTTL(cache.SchematicHTMLKey(name, d.Language), html, schematicHTMLCacheTTL)
+		}
+
 		return e.HTML(http.StatusOK, html)
 	}
 }

--- a/internal/pages/schematics.go
+++ b/internal/pages/schematics.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 var schematicsTemplates = append([]string{
@@ -31,6 +32,8 @@ type SchematicsData struct {
 	NextURL    string
 }
 
+const schematicsListHTMLCacheTTL = 30 * time.Second
+
 func SchematicsHandler(cacheService *cache.Service, registry *server.Registry, appStore *store.Store, translationService *translation.Service) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		// Pagination params
@@ -40,6 +43,16 @@ func SchematicsHandler(cacheService *cache.Service, registry *server.Registry, a
 				page = v
 			}
 		}
+
+		isAuth := authenticatedUserID(e) != ""
+		if !isAuth {
+			setPublicCacheControl(e, 30)
+			lang := detectLanguageFromRequest(e.Request)
+			if cached, ok := cacheService.GetString(cache.SchematicsListHTMLKey(page, lang)); ok {
+				return e.HTML(http.StatusOK, cached)
+			}
+		}
+
 		pageSize := 24
 		limit := pageSize + 1 // fetch one extra to detect next page
 		offset := (page - 1) * pageSize
@@ -83,6 +96,11 @@ func SchematicsHandler(cacheService *cache.Service, registry *server.Registry, a
 		if err != nil {
 			return err
 		}
+
+		if !isAuth {
+			cacheService.SetWithTTL(cache.SchematicsListHTMLKey(page, d.Language), html, schematicsListHTMLCacheTTL)
+		}
+
 		return e.HTML(http.StatusOK, html)
 	}
 }


### PR DESCRIPTION
Cache rendered HTML for anonymous visitors on schematic detail pages, schematics listing, and homepage with 30-second TTL. Authenticated users always get fresh renders to avoid leaking user-specific data.

- Schematic detail: cached by name+lang, invalidated on edit/delete
- Schematics listing: cached by page+lang, invalidated on any change
- Homepage: adds Cache-Control headers (already had HTML caching)
- Sets Cache-Control: public, max-age=30, stale-while-revalidate=60
  with Vary: Cookie, Accept-Language for anonymous responses