### PR TITLE
Fix generator HTMX navigation, harden hash security, fix guide tooltip

### DIFF
--- a/template/generator-balloon.html
+++ b/template/generator-balloon.html
@@ -214,10 +214,10 @@
     </div>
 </div>
 <div id="gen-init-data" data-hash="{{ .InitHash }}" hidden></div>
-<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" crossorigin="anonymous"></script>
-<script src="/assets/x/generator.js?v={{ AssetVer }}" hx-disable></script>
-<script src="/assets/x/guide.js?v={{ AssetVer }}" hx-disable></script>
-<script hx-disable>
+<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" integrity="sha384-qOkzR5Ke/XkQxuGVJ9hpFEpDlcoLtWwVYhnJf06cLIZa2vaIptSqaubivErzmD5O" crossorigin="anonymous"></script>
+<script src="/assets/x/generator.js?v={{ AssetVer }}"></script>
+<script src="/assets/x/guide.js?v={{ AssetVer }}"></script>
+<script>
 (function(){
   var PRESETS = {
     roundBlimp:     { lengthX:36, widthZ:18, heightY:16, cylinderMid:0,    frontTaper:0,    rearTaper:0,    topFlatten:0,    bottomFlatten:0,    hollow:true, shell:1, ribEnabled:false, ribSpacing:4, keelEnabled:false, keelDepth:1, finEnabled:true, sideFinEnabled:false, finHeight:4, finLength:5, envelopeMaterial:'wool', envelopeColor:'white', frameMaterial:'wood', frameWoodType:'spruce' },
@@ -320,7 +320,7 @@
   }
 
   function init() {
-    if (!GeneratorApp.initScene('generator-viewport')) {
+    if (!window.GeneratorApp || !GeneratorApp.initScene('generator-viewport')) {
       setTimeout(init, 100);
       return;
     }

--- a/template/generator-guide.html
+++ b/template/generator-guide.html
@@ -73,10 +73,19 @@
     </div>
 </div>
 <div id="gen-init-data" data-hash="{{ .InitHash }}" data-type="{{ .GeneratorType }}" hidden></div>
-<script src="/assets/x/generator.js?v={{ AssetVer }}" hx-disable></script>
-<script src="/assets/x/guide.js?v={{ AssetVer }}" hx-disable></script>
-<script hx-disable>
+<script src="/assets/x/generator.js?v={{ AssetVer }}"></script>
+<script src="/assets/x/guide.js?v={{ AssetVer }}"></script>
+<script>
 (function(){
+  function tryInit() {
+    if (!window.GeneratorApp || !window.GeneratorGuide) {
+      setTimeout(tryInit, 100);
+      return;
+    }
+    run();
+  }
+
+  function run() {
   var initEl = document.getElementById('gen-init-data');
   var hash = initEl ? initEl.dataset.hash : '';
   var genType = initEl ? initEl.dataset.type : '';
@@ -137,6 +146,13 @@
         setTimeout(function() { textNode.textContent = originalText; copyBtn.classList.remove('copied'); }, 2000);
       });
     });
+  }
+  } // end run()
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', tryInit);
+  } else {
+    tryInit();
   }
 
   window['nitroAds'] = window['nitroAds'] || { createAd: function() { return new Promise(function(e) { window['nitroAds'].queue.push(['createAd', arguments, e]); }); }, queue: [] };

--- a/template/generator-hull.html
+++ b/template/generator-hull.html
@@ -246,10 +246,10 @@
     </div>
 </div>
 <div id="gen-init-data" data-hash="{{ .InitHash }}" hidden></div>
-<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" crossorigin="anonymous"></script>
-<script src="/assets/x/generator.js?v={{ AssetVer }}" hx-disable></script>
-<script src="/assets/x/guide.js?v={{ AssetVer }}" hx-disable></script>
-<script hx-disable>
+<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" integrity="sha384-qOkzR5Ke/XkQxuGVJ9hpFEpDlcoLtWwVYhnJf06cLIZa2vaIptSqaubivErzmD5O" crossorigin="anonymous"></script>
+<script src="/assets/x/generator.js?v={{ AssetVer }}"></script>
+<script src="/assets/x/guide.js?v={{ AssetVer }}"></script>
+<script>
 (function(){
   var PRESETS = {
     sloop:    { woodType:'spruce', length:26, beam:8, depth:5, bottomPinch:0.3, hullFlare:0.15, flareCurve:2.6, tumblehome:0.12, tumbleCurve:3, sheerCurve:0.15, sheerCurveExp:2, bowLength:7, bowSharpness:1.4, bowKeelRise:0.4, bowKeelLength:6, bowCurve:0, sternStyle:'round', sternLength:4, sternSharpness:0.7, sternKeelRise:0.15, sternKeelLength:5, sternOverhang:0, keelCurve:1.7, midWidthBias:0, castleBlend:4, hasRailings:true, hasTrim:true, hasWindows:true, castleHeight:1, castleLength:5, forecastleHeight:0, forecastleLength:0, hasGunPorts:false, gunPortRow:2, gunPortSpacing:4 },
@@ -343,7 +343,7 @@
   }
 
   function init() {
-    if (!GeneratorApp.initScene('generator-viewport')) {
+    if (!window.GeneratorApp || !GeneratorApp.initScene('generator-viewport')) {
       setTimeout(init, 100);
       return;
     }

--- a/template/generator-propeller.html
+++ b/template/generator-propeller.html
@@ -135,10 +135,10 @@
     </div>
 </div>
 <div id="gen-init-data" data-hash="{{ .InitHash }}" hidden></div>
-<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" crossorigin="anonymous"></script>
-<script src="/assets/x/generator.js?v={{ AssetVer }}" hx-disable></script>
-<script src="/assets/x/guide.js?v={{ AssetVer }}" hx-disable></script>
-<script hx-disable>
+<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" integrity="sha384-qOkzR5Ke/XkQxuGVJ9hpFEpDlcoLtWwVYhnJf06cLIZa2vaIptSqaubivErzmD5O" crossorigin="anonymous"></script>
+<script src="/assets/x/generator.js?v={{ AssetVer }}"></script>
+<script src="/assets/x/guide.js?v={{ AssetVer }}"></script>
+<script>
 (function(){
   var PRESETS = {
     basic:    { blades:4, length:10, rootChord:3, tipChord:1, sweepDegrees:25, swept:true,  airfoilShape:'curved', bladeMaterial:'wool', bladeColor:'white' },
@@ -207,7 +207,7 @@
   }
 
   function init() {
-    if (!GeneratorApp.initScene('generator-viewport')) {
+    if (!window.GeneratorApp || !GeneratorApp.initScene('generator-viewport')) {
       setTimeout(init, 100);
       return;
     }

--- a/template/static/generator.js
+++ b/template/static/generator.js
@@ -1,8 +1,9 @@
 (function(){
 'use strict';
 
-if (window._generatorInit) return;
-window._generatorInit = true;
+if (window.GeneratorApp && window.GeneratorApp._cleanup) {
+  window.GeneratorApp._cleanup();
+}
 
 var THREE;
 var scene, camera, renderer, controls;
@@ -11,6 +12,7 @@ var container;
 var animId;
 var currentData = null;
 var cameraUserInteracted = false;
+var resizeHandler = null;
 
 var WOOD_COLORS = {
   oak:      { plank: 0xb8945f, log: 0x6b5839 },
@@ -151,15 +153,15 @@ function initScene(containerId) {
 
   animate();
 
-  window.addEventListener('resize', onResize);
+  resizeHandler = onResize;
+  window.addEventListener('resize', resizeHandler);
 
   if (!window._genCleanupInit) {
     window._genCleanupInit = true;
     document.addEventListener('htmx:beforeSwap', function() {
-      if (animId) { cancelAnimationFrame(animId); animId = null; }
-      clearBlocks();
-      if (renderer) { renderer.dispose(); renderer = null; }
-      scene = null; camera = null; controls = null; container = null;
+      if (window.GeneratorApp && window.GeneratorApp._cleanup) {
+        window.GeneratorApp._cleanup();
+      }
     });
   }
 
@@ -865,7 +867,14 @@ function encodeCompact(prefix, params) {
       case 'f': vals.push(String(Math.round(Number(v) * 100))); break;
       case 'e':
         var map = ENUM_MAPS[s.m];
-        vals.push(map && map[v] ? map[v] : String(v).slice(0, 3));
+        if (map && map[v]) {
+          vals.push(map[v]);
+        } else if (map) {
+          var firstKey = Object.keys(map)[0];
+          vals.push(map[firstKey]);
+        } else {
+          vals.push('');
+        }
         break;
     }
   }
@@ -902,7 +911,12 @@ function decodeCompact(hash) {
         break;
       case 'e':
         var rev = ENUM_REVERSE[s.m];
-        params[s.k] = rev && rev[raw] ? rev[raw] : raw;
+        if (rev && rev[raw]) {
+          params[s.k] = rev[raw];
+        } else {
+          var fwd = ENUM_MAPS[s.m];
+          if (fwd) params[s.k] = Object.keys(fwd)[0];
+        }
         break;
     }
   }
@@ -983,6 +997,15 @@ function applyHashParams(setParamsFn, initHash, generatorType) {
   return { params: {} };
 }
 
+function cleanup() {
+  if (animId) { cancelAnimationFrame(animId); animId = null; }
+  clearBlocks();
+  if (resizeHandler) { window.removeEventListener('resize', resizeHandler); resizeHandler = null; }
+  if (renderer) { renderer.dispose(); renderer = null; }
+  scene = null; camera = null; controls = null; container = null;
+  currentData = null; cameraUserInteracted = false;
+}
+
 window.GeneratorApp = {
   initScene: initScene,
   renderBlocks: renderBlocks,
@@ -994,7 +1017,8 @@ window.GeneratorApp = {
   decodeCompact: decodeCompact,
   encodeCompact: encodeCompact,
   toBase64Url: toBase64Url,
-  fromBase64Url: fromBase64Url
+  fromBase64Url: fromBase64Url,
+  _cleanup: cleanup
 };
 
 })();

--- a/template/static/guide.js
+++ b/template/static/guide.js
@@ -831,8 +831,9 @@ function renderPage(data, mode) {
     if (block) {
       tooltip.textContent = getBlockLabel(block.type, materials);
       tooltip.style.display = 'block';
-      var tx = e.clientX - rect.left + 12;
-      var ty = e.clientY - rect.top - 28;
+      var parentRect = canvas.parentElement.getBoundingClientRect();
+      var tx = e.clientX - parentRect.left + canvas.parentElement.scrollLeft + 12;
+      var ty = e.clientY - parentRect.top + canvas.parentElement.scrollTop - 28;
       tooltip.style.left = tx + 'px';
       tooltip.style.top = ty + 'px';
       canvas.style.cursor = 'crosshair';


### PR DESCRIPTION
- Remove hx-disable from generator script tags so HTMX re-executes them during body swaps, fixing 3D viewer not loading without hard refresh
- Add _cleanup() to GeneratorApp for proper scene disposal on navigation
- Guard inline init scripts against GeneratorApp not yet being defined
- Add SRI integrity hashes to THREE.js CDN script tags
- Validate enum values in encodeCompact/decodeCompact against whitelist instead of falling back to raw untrusted strings
- Fix guide tooltip positioning to account for scroll offset in wrapper