### PR TITLE
Fix stale dev deploy PRs not being closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,10 +211,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr list --state open --head "deploy/dev-" --json number --jq '.[].number' | while read pr_number; do
+          gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("deploy/dev-")) | .number' | while read pr_number; do
             if [ -n "$pr_number" ]; then
               echo "Closing stale PR #${pr_number}"
-              gh pr close "$pr_number" --delete-branch || true
+              gh pr close "$pr_number" --repo "$GITHUB_REPOSITORY" --delete-branch || true
             fi
           done
 
@@ -262,10 +263,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr list --state open --head "deploy/prod-" --json number --jq '.[].number' | while read pr_number; do
+          gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("deploy/prod-")) | .number' | while read pr_number; do
             if [ -n "$pr_number" ]; then
               echo "Closing stale PR #${pr_number}"
-              gh pr close "$pr_number" --delete-branch || true
+              gh pr close "$pr_number" --repo "$GITHUB_REPOSITORY" --delete-branch || true
             fi
           done
 

--- a/.github/workflows/close-stale-deploys.yml
+++ b/.github/workflows/close-stale-deploys.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
     branches: [master]
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 6 * * *'
 
 jobs:
   close-stale:

--- a/.github/workflows/close-stale-deploys.yml
+++ b/.github/workflows/close-stale-deploys.yml
@@ -4,11 +4,14 @@ on:
   pull_request:
     types: [closed]
     branches: [master]
+  schedule:
+    - cron: '*/15 * * * *'
 
 jobs:
   close-stale:
     runs-on: ubuntu-latest
     if: |
+      github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
       startsWith(github.head_ref, 'deploy/')
     permissions:
@@ -46,4 +49,34 @@ jobs:
               echo "Closing stale PR #${pr_number}"
               gh pr close "$pr_number" --repo "$GITHUB_REPOSITORY" --delete-branch || true
             fi
+          done
+
+  close-stale-scheduled:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Close stale dev deploy PRs (keep newest)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("deploy/dev-"))] | sort_by(.number) | reverse | .[1:] | .[].number')
+          for pr_number in $prs; do
+            echo "Closing stale dev PR #${pr_number}"
+            gh pr close "$pr_number" --repo "$GITHUB_REPOSITORY" --delete-branch || true
+          done
+
+      - name: Close stale prod deploy PRs (keep newest)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("deploy/prod-"))] | sort_by(.number) | reverse | .[1:] | .[].number')
+          for pr_number in $prs; do
+            echo "Closing stale prod PR #${pr_number}"
+            gh pr close "$pr_number" --repo "$GITHUB_REPOSITORY" --delete-branch || true
           done


### PR DESCRIPTION
Two issues prevented cleanup of old deploy/dev-* PRs:

1. CI workflow used `gh pr list --head "deploy/dev-"` which does exact branch name matching, not prefix matching. Changed to use --json/--jq with startswith() filter for both dev and prod close steps.

2. Dev deploy PRs have [skip ci] in their only commit message, which causes GitHub to skip all workflow triggers (including pull_request closed events). Added a scheduled fallback (every 15 min) that keeps only the newest open deploy PR for each environment.