### PR TITLE
Fix NBT export stair/sail orientation and optimize generator performance

### DIFF
--- a/internal/generator/balloon.go
+++ b/internal/generator/balloon.go
@@ -205,22 +205,29 @@ func GenerateBalloon(p BalloonParams) (*GenerateResult, error) {
 		}
 
 		// Pass 1c: Thicken shell inward for shell > 1
-		for layer := 1; layer < p.Shell; layer++ {
-			var newLayer []coord
-			for pos := range insideSet {
-				if shellSet[pos] {
-					continue
-				}
+		// Use frontier-based BFS: only check neighbors of the current shell boundary
+		if p.Shell > 1 {
+			frontier := make(map[coord]bool)
+			for pos := range shellSet {
 				for _, d := range dirs {
 					nb := coordKey(pos[0]+d[0], pos[1]+d[1], pos[2]+d[2])
-					if shellSet[nb] {
-						newLayer = append(newLayer, pos)
-						break
+					if insideSet[nb] && !shellSet[nb] {
+						frontier[nb] = true
 					}
 				}
 			}
-			for _, pos := range newLayer {
-				shellSet[pos] = true
+			for layer := 1; layer < p.Shell; layer++ {
+				nextFrontier := make(map[coord]bool)
+				for pos := range frontier {
+					shellSet[pos] = true
+					for _, d := range dirs {
+						nb := coordKey(pos[0]+d[0], pos[1]+d[1], pos[2]+d[2])
+						if insideSet[nb] && !shellSet[nb] && !frontier[nb] {
+							nextFrontier[nb] = true
+						}
+					}
+				}
+				frontier = nextFrontier
 			}
 		}
 

--- a/internal/generator/nbt.go
+++ b/internal/generator/nbt.go
@@ -159,7 +159,7 @@ func blockToPalette(b Block, mat MaterialConfig) (string, map[string]string) {
 
 	case BlockSail:
 		if mat.BladeMaterial == "sail" {
-			return sailBlock(mat.BladeColor), nil
+			return sailBlock(mat.BladeColor), map[string]string{"axis": "y"}
 		}
 		return woolBlock(mat.BladeColor), nil
 
@@ -189,6 +189,16 @@ func blockToPalette(b Block, mat MaterialConfig) (string, map[string]string) {
 			for k, v := range b.Props {
 				props[k] = v
 			}
+		}
+		switch props["facing"] {
+		case "north":
+			props["facing"] = "south"
+		case "south":
+			props["facing"] = "north"
+		case "east":
+			props["facing"] = "west"
+		case "west":
+			props["facing"] = "east"
 		}
 		return woodStairs(mat), props
 

--- a/internal/generator/types.go
+++ b/internal/generator/types.go
@@ -49,20 +49,17 @@ var ValidWoolColors = []string{
 	"gray", "light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black",
 }
 
-func isValidWoodType(s string) bool {
+var validWoodTypes = make(map[string]bool)
+var validWoolColors = make(map[string]bool)
+
+func init() {
 	for _, v := range ValidWoodTypes {
-		if s == v {
-			return true
-		}
+		validWoodTypes[v] = true
 	}
-	return false
+	for _, v := range ValidWoolColors {
+		validWoolColors[v] = true
+	}
 }
 
-func isValidWoolColor(s string) bool {
-	for _, v := range ValidWoolColors {
-		if s == v {
-			return true
-		}
-	}
-	return false
-}
+func isValidWoodType(s string) bool  { return validWoodTypes[s] }
+func isValidWoolColor(s string) bool { return validWoolColors[s] }

--- a/template/static/generator.js
+++ b/template/static/generator.js
@@ -298,38 +298,16 @@ function renderBlocks(data) {
   var FACING_ROT = { south: 0, west: -Math.PI / 2, north: Math.PI, east: Math.PI / 2 };
 
   var fencePostGeo = new THREE.BoxGeometry(0.25, 1, 0.25);
-  var fenceBarGeo = new THREE.BoxGeometry(0.125, 0.19, 0.35);
-
-  function buildFenceMesh(block, mat, cx, cy, cz) {
-    var group = new THREE.Group();
-    var post = new THREE.Mesh(fencePostGeo, mat);
-    group.add(post);
-    var props = block.props || {};
-    var dirs = [
-      { key: 'north', dx: 0, dz: -1 },
-      { key: 'south', dx: 0, dz: 1 },
-      { key: 'east',  dx: 1, dz: 0 },
-      { key: 'west',  dx: -1, dz: 0 }
-    ];
-    for (var di = 0; di < dirs.length; di++) {
-      var d = dirs[di];
-      if (props[d.key] !== 'true') continue;
-      var offX = d.dx * 0.35;
-      var offZ = d.dz * 0.35;
-      var barW = d.dx !== 0 ? 0.35 : 0.125;
-      var barD = d.dz !== 0 ? 0.35 : 0.125;
-      var barGeoH = new THREE.BoxGeometry(barW, 0.125, barD);
-      var barHi = new THREE.Mesh(barGeoH, mat);
-      barHi.position.set(offX, 0.18, offZ);
-      group.add(barHi);
-      var barGeoL = new THREE.BoxGeometry(barW, 0.125, barD);
-      var barLo = new THREE.Mesh(barGeoL, mat);
-      barLo.position.set(offX, -0.18, offZ);
-      group.add(barLo);
-    }
-    group.position.set(block.x - cx, (block.y - cy), block.z - cz);
-    return group;
-  }
+  var fenceBarGeos = {
+    x: new THREE.BoxGeometry(0.35, 0.125, 0.125),
+    z: new THREE.BoxGeometry(0.125, 0.125, 0.35)
+  };
+  var fenceBarDirs = [
+    { key: 'north', dx: 0, dz: -1, axis: 'z' },
+    { key: 'south', dx: 0, dz: 1,  axis: 'z' },
+    { key: 'east',  dx: 1, dz: 0,  axis: 'x' },
+    { key: 'west',  dx: -1, dz: 0, axis: 'x' }
+  ];
 
   for (var type in groups) {
     var arr = groups[type];
@@ -382,11 +360,12 @@ function renderBlocks(data) {
         sMesh.instanceMatrix.needsUpdate = true;
         scene.add(sMesh);
         blockMeshes.push(sMesh);
-        if (sArr.length <= 5000) {
+        if (sArr.length <= 2000) {
           var stairEdgeGeo = new THREE.EdgesGeometry(sGeo);
           var stairEPosAttr = stairEdgeGeo.getAttribute('position');
           var stairECount = stairEPosAttr.count;
           var stairEdgePos = new Float32Array(sArr.length * stairECount * 3);
+          var sv = new THREE.Vector3();
           for (var sei = 0; sei < sArr.length; sei++) {
             dummy.position.set(sArr[sei].x - cx, (sArr[sei].y - cy), sArr[sei].z - cz);
             dummy.rotation.set(0, 0, 0);
@@ -394,7 +373,7 @@ function renderBlocks(data) {
             dummy.rotation.y = FACING_ROT[sFacing] || 0;
             dummy.updateMatrix();
             for (var sev = 0; sev < stairECount; sev++) {
-              var sv = new THREE.Vector3(stairEPosAttr.getX(sev), stairEPosAttr.getY(sev), stairEPosAttr.getZ(sev));
+              sv.set(stairEPosAttr.getX(sev), stairEPosAttr.getY(sev), stairEPosAttr.getZ(sev));
               sv.applyMatrix4(dummy.matrix);
               stairEdgePos[(sei * stairECount + sev) * 3]     = sv.x;
               stairEdgePos[(sei * stairECount + sev) * 3 + 1] = sv.y;
@@ -416,12 +395,51 @@ function renderBlocks(data) {
     }
 
     if (t === 5) {
+      // Instanced fence posts
+      var postMesh = new THREE.InstancedMesh(fencePostGeo, mat, arr.length);
       for (var fi = 0; fi < arr.length; fi++) {
-        var fMesh = buildFenceMesh(arr[fi], mat, cx, cy, cz);
-        scene.add(fMesh);
-        blockMeshes.push(fMesh);
+        dummy.position.set(arr[fi].x - cx, arr[fi].y - cy, arr[fi].z - cz);
+        dummy.rotation.set(0, 0, 0);
+        dummy.scale.set(1, 1, 1);
+        dummy.updateMatrix();
+        postMesh.setMatrixAt(fi, dummy.matrix);
       }
-      if (arr.length <= 5000) {
+      postMesh.instanceMatrix.needsUpdate = true;
+      scene.add(postMesh);
+      blockMeshes.push(postMesh);
+
+      // Instanced fence bars: collect all bar positions per axis
+      var barPositions = { x: [], z: [] };
+      for (var fbi = 0; fbi < arr.length; fbi++) {
+        var fProps = arr[fbi].props || {};
+        var fbx = arr[fbi].x - cx, fby = arr[fbi].y - cy, fbz = arr[fbi].z - cz;
+        for (var fdi = 0; fdi < fenceBarDirs.length; fdi++) {
+          var fd = fenceBarDirs[fdi];
+          if (fProps[fd.key] !== 'true') continue;
+          var bOffX = fd.dx * 0.35, bOffZ = fd.dz * 0.35;
+          barPositions[fd.axis].push(fbx + bOffX, fby + 0.18, fbz + bOffZ);
+          barPositions[fd.axis].push(fbx + bOffX, fby - 0.18, fbz + bOffZ);
+        }
+      }
+      for (var axis in barPositions) {
+        var bpos = barPositions[axis];
+        var barCount = bpos.length / 3;
+        if (barCount === 0) continue;
+        var barMesh = new THREE.InstancedMesh(fenceBarGeos[axis], mat, barCount);
+        for (var bi = 0; bi < barCount; bi++) {
+          dummy.position.set(bpos[bi * 3], bpos[bi * 3 + 1], bpos[bi * 3 + 2]);
+          dummy.rotation.set(0, 0, 0);
+          dummy.scale.set(1, 1, 1);
+          dummy.updateMatrix();
+          barMesh.setMatrixAt(bi, dummy.matrix);
+        }
+        barMesh.instanceMatrix.needsUpdate = true;
+        scene.add(barMesh);
+        blockMeshes.push(barMesh);
+      }
+
+      // Fence post edge outlines
+      if (arr.length <= 2000) {
         var fenceEdgeGeo = new THREE.EdgesGeometry(fencePostGeo);
         var fenceEPosAttr = fenceEdgeGeo.getAttribute('position');
         var fenceECount = fenceEPosAttr.count;
@@ -527,7 +545,7 @@ function renderBlocks(data) {
     blockMeshes.push(mesh);
 
     // Block edge outlines — merge all edges into one LineSegments
-    if (arr.length <= 5000) {
+    if (arr.length <= 2000) {
       var edgeTemplate = new THREE.EdgesGeometry(geo);
       var ePosAttr = edgeTemplate.getAttribute('position');
       var eCount = ePosAttr.count;

--- a/template/static/generators.js
+++ b/template/static/generators.js
@@ -206,23 +206,29 @@ function generateBalloon(p) {
       }
     }
 
-    // Pass 1c: thicken shell
-    for (var layer = 1; layer < shell; layer++) {
-      var newLayer = [];
-      for (var ik3 in insideKeys) {
-        if (shellKeys[ik3]) continue;
-        var parts2 = ik3.split(',');
-        var px2 = parseInt(parts2[0]), py2 = parseInt(parts2[1]), pz2 = parseInt(parts2[2]);
-        for (var di2 = 0; di2 < 6; di2++) {
-          var nbk2 = coordKey(px2 + dirs[di2][0], py2 + dirs[di2][1], pz2 + dirs[di2][2]);
-          if (shellKeys[nbk2]) {
-            newLayer.push(ik3);
-            break;
-          }
+    // Pass 1c: thicken shell using frontier-based BFS
+    if (shell > 1) {
+      var frontier = {};
+      for (var fk in shellKeys) {
+        var fp = fk.split(',');
+        var fpx = parseInt(fp[0]), fpy = parseInt(fp[1]), fpz = parseInt(fp[2]);
+        for (var fdi = 0; fdi < 6; fdi++) {
+          var fnb = coordKey(fpx + dirs[fdi][0], fpy + dirs[fdi][1], fpz + dirs[fdi][2]);
+          if (insideKeys[fnb] && !shellKeys[fnb]) frontier[fnb] = true;
         }
       }
-      for (var ni = 0; ni < newLayer.length; ni++) {
-        shellKeys[newLayer[ni]] = true;
+      for (var layer = 1; layer < shell; layer++) {
+        var nextFrontier = {};
+        for (var ffk in frontier) {
+          shellKeys[ffk] = true;
+          var ffp = ffk.split(',');
+          var ffpx = parseInt(ffp[0]), ffpy = parseInt(ffp[1]), ffpz = parseInt(ffp[2]);
+          for (var fdi2 = 0; fdi2 < 6; fdi2++) {
+            var fnb2 = coordKey(ffpx + dirs[fdi2][0], ffpy + dirs[fdi2][1], ffpz + dirs[fdi2][2]);
+            if (insideKeys[fnb2] && !shellKeys[fnb2] && !frontier[fnb2]) nextFrontier[fnb2] = true;
+          }
+        }
+        frontier = nextFrontier;
       }
     }
 


### PR DESCRIPTION
- Fix stair facing inverted in NBT export (north↔south, east↔west)
- Fix Create mod sails exporting without axis property (flat instead of vertical)
- Instance fence meshes instead of creating individual Groups per block
- Reuse Vector3 in stair edge rendering, lower edge threshold to 2000
- Convert wood/wool validation from linear search to map lookups
- Optimize balloon shell thickening with frontier-based BFS in Go and JS