### PR TITLE
Fix sail block property in NBT export

### DIFF
--- a/internal/generator/nbt.go
+++ b/internal/generator/nbt.go
@@ -159,7 +159,7 @@ func blockToPalette(b Block, mat MaterialConfig) (string, map[string]string) {
 
 	case BlockSail:
 		if mat.BladeMaterial == "sail" {
-			return sailBlock(mat.BladeColor), map[string]string{"axis": "y"}
+			return sailBlock(mat.BladeColor), map[string]string{"facing": "up"}
 		}
 		return woolBlock(mat.BladeColor), nil
 


### PR DESCRIPTION
Create mod sails use facing property (up/down/north/south/east/west) not axis. Changed from axis:y to facing:up for horizontal sails.