### PR TITLE
Style YouTube button with soft red background and light text

### DIFF
--- a/template/schematic.html
+++ b/template/schematic.html
@@ -578,7 +578,7 @@
                                  data-plyr-embed-id="{{ .Schematic.Video }}"></div>
                             <a href="{{ SignedOutURL (printf "https://www.youtube.com/watch?v=%s" .Schematic.Video) }}"
                                class="card-footer d-flex align-items-center justify-content-center gap-2 text-decoration-none py-3" id="yt-link"
-                               style="font-size:1.05rem;font-weight:600;color:#ff0000;border-top:1px solid rgba(255,0,0,0.15);">
+                               style="font-size:1.05rem;font-weight:600;color:#f0f0f0;background:rgba(180,40,40,0.25);border-top:1px solid rgba(180,40,40,0.3);">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M2 8a4 4 0 0 1 4 -4h12a4 4 0 0 1 4 4v8a4 4 0 0 1 -4 4h-12a4 4 0 0 1 -4 -4v-8z" /><path d="M10 9l5 3l-5 3z" /></svg>
                                 {{ T .Language "View on YouTube" }}
                             </a>


### PR DESCRIPTION
Use a subtle, semi-transparent red background for the card footer and near-white text so it reads as YouTube without being loud.