### PR TITLE
Fix YouTube URL doubling in View on YouTube link

### DIFF
--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -153,6 +153,19 @@ func Register(p RegisterParams) chi.Router {
 		"Hreflangs": func(barePath string) []pages.HreflangEntry {
 			return pages.AllHreflangs()
 		},
+		"YouTubeWatchURL": func(video string) string {
+			if strings.Contains(video, "/embed/") {
+				parts := strings.Split(video, "/embed/")
+				if len(parts) == 2 && parts[1] != "" {
+					id := strings.SplitN(parts[1], "?", 2)[0]
+					return "https://www.youtube.com/watch?v=" + id
+				}
+			}
+			if strings.Contains(video, "watch?v=") {
+				return video
+			}
+			return "https://www.youtube.com/watch?v=" + video
+		},
 		"externalDomain": pages.ExternalDomain,
 		"LangFlag": func(code string) html.HTML {
 			cc := "gb"

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -576,7 +576,7 @@
                         <div class="card mb-3">
                             <div id="player-youtube" data-plyr-provider="youtube"
                                  data-plyr-embed-id="{{ .Schematic.Video }}"></div>
-                            <a href="{{ SignedOutURL (printf "https://www.youtube.com/watch?v=%s" .Schematic.Video) }}"
+                            <a href="{{ SignedOutURL (YouTubeWatchURL .Schematic.Video) }}"
                                class="card-footer d-flex align-items-center justify-content-center gap-2 text-decoration-none py-3" id="yt-link"
                                style="font-size:1.05rem;font-weight:600;color:#f0f0f0;background:rgba(180,40,40,0.25);border-top:1px solid rgba(180,40,40,0.3);">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M2 8a4 4 0 0 1 4 -4h12a4 4 0 0 1 4 4v8a4 4 0 0 1 -4 4h-12a4 4 0 0 1 -4 -4v-8z" /><path d="M10 9l5 3l-5 3z" /></svg>


### PR DESCRIPTION
The Video field stores embed URLs (e.g. youtube.com/embed/ID) not bare IDs. Added YouTubeWatchURL template func to extract the video ID and build the correct watch URL.