### PR TITLE
Fix hourly charts by reusing working area chart config

### DIFF
--- a/template/schematic-stats.html
+++ b/template/schematic-stats.html
@@ -116,21 +116,23 @@
   var fg = isDark ? '#a0aec0' : '#616876';
   var grid = isDark ? '#3a3f4b' : '#e0e0e0';
 
+  var commonOpts = {
+    chart: { type: 'area', height: 250, toolbar: { show: false }, zoom: { enabled: false }, foreColor: fg },
+    dataLabels: { enabled: false },
+    stroke: { curve: 'smooth', width: 2 },
+    grid: { borderColor: grid, strokeDashArray: 4 },
+    xaxis: { type: 'category', labels: { show: true, rotate: 0, hideOverlappingLabels: true, maxHeight: 40, style: { colors: fg, fontSize: '10px' } }, tickAmount: 6 },
+    yaxis: { min: 0, labels: { style: { colors: fg } } },
+    tooltip: { theme: isDark ? 'dark' : 'light' }
+  };
+
   function makeChart(elId, data, name, color) {
     var el = document.getElementById(elId);
     if (!el) return;
-    new ApexCharts(el, {
-      chart: { type: 'line', height: 250, toolbar: { show: false }, zoom: { enabled: false }, foreColor: fg },
+    new ApexCharts(el, Object.assign({}, commonOpts, {
       series: [{ name: name, data: data }],
-      dataLabels: { enabled: false },
-      xaxis: { type: 'category', labels: { show: true, rotate: 0, hideOverlappingLabels: true, maxHeight: 40, style: { colors: fg, fontSize: '10px' } }, tickAmount: 6 },
-      yaxis: { min: 0, labels: { style: { colors: fg } } },
-      stroke: { curve: 'smooth', width: 2 },
-      colors: [color],
-      fill: { opacity: 0 },
-      grid: { borderColor: grid, strokeDashArray: 4 },
-      tooltip: { theme: isDark ? 'dark' : 'light' }
-    }).render();
+      colors: [color]
+    })).render();
   }
 
   makeChart('chart-views', {{ .ViewsJSON }}, 'Views', '#4299e1');

--- a/template/user-statistics.html
+++ b/template/user-statistics.html
@@ -225,21 +225,16 @@
             })).render();
         }
 
-        // Hourly charts
+        // Hourly charts – reuse the same config as the monthly charts above
         function makeHourlyChart(elId, data, name, color) {
             var el = document.getElementById(elId);
             if (!el) return;
-            new ApexCharts(el, {
-                chart: { type: 'line', height: 200, sparkline: { enabled: false }, toolbar: { show: false }, foreColor: labelColor },
+            new ApexCharts(el, Object.assign({}, commonOpts, {
+                chart: Object.assign({}, commonOpts.chart, { height: 200 }),
                 series: [{ name: name, data: data }],
                 xaxis: { type: 'category', labels: { show: false } },
-                yaxis: { min: 0 },
-                stroke: { curve: 'smooth', width: 2 },
-                colors: [color],
-                fill: { opacity: 0 },
-                grid: { borderColor: gridColor },
-                tooltip: { theme: isDark ? 'dark' : 'light' }
-            }).render();
+                colors: [color]
+            })).render();
         }
 
         makeHourlyChart('chart-hourly-views', {{ .HourlyViewsJSON }}, 'Views', '#4299e1');


### PR DESCRIPTION
The line chart type with fill opacity 0 produced invisible lines. Reuse the same area chart commonOpts that the monthly views/downloads charts use successfully, which renders smooth lines with a subtle gradient fill.