### PR TITLE
Fix HPA flapping causing constant pod restarts

### DIFF
--- a/k8s/createmod/prod/deployment.yaml
+++ b/k8s/createmod/prod/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app: createmod
     environment: prod
 spec:
-  replicas: 2
+  replicas: 4
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/k8s/createmod/prod/hpa.yaml
+++ b/k8s/createmod/prod/hpa.yaml
@@ -23,10 +23,10 @@ spec:
         name: memory
         target:
           type: Utilization
-          averageUtilization: 75
+          averageUtilization: 85
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: 600
+      stabilizationWindowSeconds: 900
       policies:
         - type: Pods
           value: 1


### PR DESCRIPTION
The deployment spec had replicas: 2 while the HPA minReplicas was 4. Each ArgoCD sync reset replicas to 2, then the HPA immediately scaled back up to 4, killing and recreating pods in a loop.

Fixes:
- Set deployment replicas to 4 to match HPA minReplicas
- Raise memory target from 75% to 85% — pods settle at ~65% of requests and spike during index rebuilds, causing unnecessary scale-up pressure
- Increase scaleDown stabilizationWindow from 600s to 900s to reduce churn