### PR TITLE
Improve search quality with ranking rules, synonyms, typo tolerance, …

### DIFF
--- a/internal/jobs/moderation.go
+++ b/internal/jobs/moderation.go
@@ -184,8 +184,14 @@ func (w *ModerationWorker) Work(ctx context.Context, job *river.Job[ModerationAr
 		w.deps.Translation.DetectAndTranslate(args.SchematicID)
 	}
 
-	if schem.ModerationState == store.ModerationPublished && w.deps.Cache != nil {
-		pages.RefreshIndexCache(w.deps.Cache, w.deps.Store, []int{7})
+	if schem.ModerationState == store.ModerationPublished {
+		if w.deps.Cache != nil {
+			pages.RefreshIndexCache(w.deps.Cache, w.deps.Store, []int{7})
+		}
+		// Immediately index the newly published schematic in Meilisearch.
+		if w.deps.MeiliClient != nil {
+			upsertSchematicToMeili(ctx, w.deps, args.SchematicID)
+		}
 	}
 
 	slog.Info("async moderation complete", "schematic_id", args.SchematicID, "moderation_state", schem.ModerationState)

--- a/internal/jobs/search_index.go
+++ b/internal/jobs/search_index.go
@@ -53,14 +53,16 @@ func (w *SearchIndexWorker) Work(ctx context.Context, job *river.Job[SearchIndex
 	mapped := pages.MapStoreSchematicsNoCache(w.deps.Store, storeSchematics, w.deps.Cache)
 	w.deps.Search.BuildIndex(mapped, modDisplayNames)
 
-	// Also refresh trending scores so they're available right after index rebuild.
+	// Compute trending scores and store them for Meilisearch indexing.
+	var trendingScores map[string]float64
 	if scores := pages.ComputeTrendingScoresFromStore(w.deps.Store); scores != nil {
+		trendingScores = scores
 		w.deps.Search.SetTrendingScores(scores)
 	}
 
 	// Sync Meilisearch indexes if client is available.
 	if w.deps.MeiliClient != nil {
-		w.syncMeiliIndexes()
+		w.syncMeiliIndexes(trendingScores)
 	}
 
 	slog.Info("search index rebuild complete", "count", len(mapped))
@@ -69,13 +71,13 @@ func (w *SearchIndexWorker) Work(ctx context.Context, job *river.Job[SearchIndex
 
 // syncMeiliIndexes converts the in-memory index to Meilisearch documents
 // and syncs the Meilisearch index.
-func (w *SearchIndexWorker) syncMeiliIndexes() {
+func (w *SearchIndexWorker) syncMeiliIndexes(trendingScores map[string]float64) {
 	filterIndex := w.deps.Search.GetIndex()
 	if len(filterIndex) == 0 {
 		return
 	}
 
-	docs := search.MapToMeiliDocuments(filterIndex)
+	docs := search.MapToMeiliDocuments(filterIndex, trendingScores)
 	if err := search.SyncMeiliIndex(w.deps.MeiliClient, search.MeiliIndex, docs); err != nil {
 		slog.Error("meili sync failed", "index", search.MeiliIndex, "error", err)
 	} else {

--- a/internal/jobs/search_index_upsert.go
+++ b/internal/jobs/search_index_upsert.go
@@ -1,0 +1,142 @@
+package jobs
+
+import (
+	"context"
+	"log/slog"
+
+	"createmod/internal/pages"
+	"createmod/internal/search"
+	"createmod/internal/store"
+
+	"github.com/riverqueue/river"
+)
+
+// SearchIndexUpsertArgs triggers an incremental Meilisearch upsert for a single schematic.
+type SearchIndexUpsertArgs struct {
+	SchematicID string `json:"schematic_id"`
+}
+
+func (SearchIndexUpsertArgs) Kind() string { return "search_index_upsert" }
+
+// SearchIndexUpsertWorker updates a single schematic in the Meilisearch index.
+type SearchIndexUpsertWorker struct {
+	river.WorkerDefaults[SearchIndexUpsertArgs]
+	deps Deps
+}
+
+func (w *SearchIndexUpsertWorker) Work(ctx context.Context, job *river.Job[SearchIndexUpsertArgs]) error {
+	id := job.Args.SchematicID
+	if id == "" || w.deps.Store == nil || w.deps.MeiliClient == nil {
+		return nil
+	}
+
+	s, err := w.deps.Store.Schematics.GetByID(ctx, id)
+	if err != nil {
+		slog.Warn("search upsert: failed to load schematic", "id", id, "error", err)
+		return nil
+	}
+
+	// Only index publicly visible schematics; delete from index otherwise.
+	if s == nil || !store.IsPublicState(s.ModerationState) {
+		return w.deleteFromIndex(id)
+	}
+
+	// Build a full models.Schematic with categories, tags, views, etc.
+	mapped := pages.MapStoreSchematicsNoCache(w.deps.Store, []store.Schematic{*s}, w.deps.Cache)
+	if len(mapped) == 0 {
+		return nil
+	}
+
+	modDisplayNames := make(map[string]string)
+	if allMeta, err := w.deps.Store.ModMetadata.ListAll(ctx); err == nil {
+		for _, m := range allMeta {
+			if m.DisplayName != "" {
+				modDisplayNames[m.Namespace] = m.DisplayName
+			}
+		}
+	}
+
+	trendingScores := w.deps.Search.GetTrendingScores()
+	doc := search.BuildSingleDocument(mapped[0], modDisplayNames, trendingScores)
+
+	if err := search.SyncMeiliIndex(w.deps.MeiliClient, search.MeiliIndex, []search.MeiliDocument{doc}); err != nil {
+		slog.Error("search upsert: sync failed", "id", id, "error", err)
+		return err
+	}
+
+	slog.Info("search upsert: indexed", "id", id)
+	return nil
+}
+
+func (w *SearchIndexUpsertWorker) deleteFromIndex(id string) error {
+	index := w.deps.MeiliClient.Index(search.MeiliIndex)
+	_, err := index.DeleteDocument(id, nil)
+	if err != nil {
+		slog.Error("search upsert: delete failed", "id", id, "error", err)
+		return err
+	}
+	slog.Info("search upsert: removed from index", "id", id)
+	return nil
+}
+
+// upsertSchematicToMeili builds and syncs a single schematic to Meilisearch.
+// Used by both the upsert worker and other jobs that publish schematics.
+func upsertSchematicToMeili(ctx context.Context, deps Deps, schematicID string) {
+	s, err := deps.Store.Schematics.GetByID(ctx, schematicID)
+	if err != nil || s == nil || !store.IsPublicState(s.ModerationState) {
+		return
+	}
+
+	mapped := pages.MapStoreSchematicsNoCache(deps.Store, []store.Schematic{*s}, deps.Cache)
+	if len(mapped) == 0 {
+		return
+	}
+
+	modDisplayNames := make(map[string]string)
+	if allMeta, err := deps.Store.ModMetadata.ListAll(ctx); err == nil {
+		for _, m := range allMeta {
+			if m.DisplayName != "" {
+				modDisplayNames[m.Namespace] = m.DisplayName
+			}
+		}
+	}
+
+	var trendingScores map[string]float64
+	if deps.Search != nil {
+		trendingScores = deps.Search.GetTrendingScores()
+	}
+
+	doc := search.BuildSingleDocument(mapped[0], modDisplayNames, trendingScores)
+	if err := search.SyncMeiliIndex(deps.MeiliClient, search.MeiliIndex, []search.MeiliDocument{doc}); err != nil {
+		slog.Error("search upsert: sync failed", "id", schematicID, "error", err)
+	}
+}
+
+// SearchIndexDeleteArgs triggers removal of a schematic from the Meilisearch index.
+type SearchIndexDeleteArgs struct {
+	SchematicID string `json:"schematic_id"`
+}
+
+func (SearchIndexDeleteArgs) Kind() string { return "search_index_delete" }
+
+// SearchIndexDeleteWorker removes a single schematic from the Meilisearch index.
+type SearchIndexDeleteWorker struct {
+	river.WorkerDefaults[SearchIndexDeleteArgs]
+	deps Deps
+}
+
+func (w *SearchIndexDeleteWorker) Work(ctx context.Context, job *river.Job[SearchIndexDeleteArgs]) error {
+	id := job.Args.SchematicID
+	if id == "" || w.deps.MeiliClient == nil {
+		return nil
+	}
+
+	index := w.deps.MeiliClient.Index(search.MeiliIndex)
+	_, err := index.DeleteDocument(id, nil)
+	if err != nil {
+		slog.Error("search delete: failed", "id", id, "error", err)
+		return err
+	}
+	slog.Info("search delete: removed from index", "id", id)
+	return nil
+}

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -74,6 +74,8 @@ func New(ctx context.Context, cfg Config) (*Worker, error) {
 	river.AddWorker(workers, &CommentModerationWorker{deps: cfg.Deps})
 	river.AddWorker(workers, &CommentTranslationWorker{deps: cfg.Deps})
 	river.AddWorker(workers, &SearchCleanupWorker{deps: cfg.Deps})
+	river.AddWorker(workers, &SearchIndexUpsertWorker{deps: cfg.Deps})
+	river.AddWorker(workers, &SearchIndexDeleteWorker{deps: cfg.Deps})
 	river.AddWorker(workers, &AnalyticsCleanupWorker{deps: cfg.Deps})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(cfg.Pool), &river.Config{
@@ -229,4 +231,26 @@ func (w *Worker) Client() *river.Client[pgx.Tx] {
 func (w *Worker) Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) error {
 	_, err := w.client.Insert(ctx, args, opts)
 	return err
+}
+
+// EnqueueSearchIndexUpsert enqueues an incremental search index update for a schematic.
+// Safe to call with a nil Worker (no-ops gracefully).
+func (w *Worker) EnqueueSearchIndexUpsert(ctx context.Context, schematicID string) {
+	if w == nil || schematicID == "" {
+		return
+	}
+	_, _ = w.client.Insert(ctx, SearchIndexUpsertArgs{SchematicID: schematicID}, &river.InsertOpts{
+		UniqueOpts: river.UniqueOpts{ByArgs: true, ByPeriod: 30 * time.Second},
+	})
+}
+
+// EnqueueSearchIndexDelete enqueues removal of a schematic from the search index.
+// Safe to call with a nil Worker (no-ops gracefully).
+func (w *Worker) EnqueueSearchIndexDelete(ctx context.Context, schematicID string) {
+	if w == nil || schematicID == "" {
+		return
+	}
+	_, _ = w.client.Insert(ctx, SearchIndexDeleteArgs{SchematicID: schematicID}, &river.InsertOpts{
+		UniqueOpts: river.UniqueOpts{ByArgs: true, ByPeriod: 30 * time.Second},
+	})
 }

--- a/internal/pages/admin_schematics.go
+++ b/internal/pages/admin_schematics.go
@@ -223,7 +223,7 @@ func AdminSchematicEditHandler(registry *server.Registry, cacheService *cache.Se
 }
 
 // AdminSchematicUpdateHandler handles POST /admin/schematics/{id} to update a schematic as admin.
-func AdminSchematicUpdateHandler(cacheService *cache.Service, appStore *store.Store, mailService *mailer.Service, storageSvc *storage.Service) func(e *server.RequestEvent) error {
+func AdminSchematicUpdateHandler(cacheService *cache.Service, appStore *store.Store, mailService *mailer.Service, storageSvc *storage.Service, enqueueSearchUpsert SearchIndexEnqueuer) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if !isSuperAdmin(e) {
 			return e.String(http.StatusForbidden, "forbidden")
@@ -389,6 +389,11 @@ func AdminSchematicUpdateHandler(cacheService *cache.Service, appStore *store.St
 			}()
 		}
 
+		// Enqueue incremental search index update
+		if enqueueSearchUpsert != nil {
+			_ = enqueueSearchUpsert(ctx, id)
+		}
+
 		// Redirect back to edit page with success
 		dest := fmt.Sprintf("/admin/schematics/%s?success=1", id)
 		if e.Request.Header.Get("HX-Request") != "" {
@@ -400,7 +405,7 @@ func AdminSchematicUpdateHandler(cacheService *cache.Service, appStore *store.St
 }
 
 // AdminSchematicDeleteHandler handles POST /admin/schematics/{id}/delete to soft-delete a schematic.
-func AdminSchematicDeleteHandler(cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+func AdminSchematicDeleteHandler(cacheService *cache.Service, appStore *store.Store, enqueueSearchDelete SearchIndexEnqueuer) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if !isSuperAdmin(e) {
 			return e.String(http.StatusForbidden, "forbidden")
@@ -440,6 +445,11 @@ func AdminSchematicDeleteHandler(cacheService *cache.Service, appStore *store.St
 		}
 		cacheService.DeleteSchematicsListHTML()
 		RefreshIndexCache(cacheService, appStore, []int{7})
+
+		// Remove from search index
+		if enqueueSearchDelete != nil {
+			_ = enqueueSearchDelete(context.Background(), id)
+		}
 
 		if e.Request.Header.Get("HX-Request") != "" {
 			e.Response.Header().Set("HX-Redirect", "/admin/schematics")

--- a/internal/pages/api_schematic_edit.go
+++ b/internal/pages/api_schematic_edit.go
@@ -36,6 +36,7 @@ func SchematicUpdateHandler(
 	storageSvc *storage.Service,
 	appStore *store.Store,
 	moderationSvc *moderation.Service,
+	enqueueSearchUpsert SearchIndexEnqueuer,
 ) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if ok, err := requireAuth(e); !ok {
@@ -394,6 +395,11 @@ func SchematicUpdateHandler(
 		cacheService.DeleteSchematicsListHTML()
 		RefreshIndexCache(cacheService, appStore, []int{7})
 
+		// --- Enqueue incremental search index update ---
+		if enqueueSearchUpsert != nil {
+			_ = enqueueSearchUpsert(ctx, schematicID)
+		}
+
 		// --- Respond ---
 		if e.Request.Header.Get("HX-Request") != "" {
 			dest := "/schematics/" + schem.Name
@@ -414,6 +420,7 @@ func SchematicUpdateHandler(
 func SchematicDeleteHandler(
 	cacheService *cache.Service,
 	appStore *store.Store,
+	enqueueSearchDelete SearchIndexEnqueuer,
 ) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if ok, err := requireAuth(e); !ok {
@@ -454,6 +461,11 @@ func SchematicDeleteHandler(
 		cacheService.DeleteSchematicHTML(schem.Name)
 		cacheService.DeleteSchematicsListHTML()
 		RefreshIndexCache(cacheService, appStore, []int{7})
+
+		// Remove from search index
+		if enqueueSearchDelete != nil {
+			_ = enqueueSearchDelete(ctx, schematicID)
+		}
 
 		// Respond
 		if e.Request.Header.Get("HX-Request") != "" {

--- a/internal/pages/upload.go
+++ b/internal/pages/upload.go
@@ -45,6 +45,10 @@ type ModerationJobArgs struct {
 // Nil means no async moderation is available.
 type ModerationEnqueuer func(ctx context.Context, args ModerationJobArgs) error
 
+// SearchIndexEnqueuer is a callback that enqueues a search index upsert or delete job.
+// Nil means no incremental indexing is available (falls back to periodic rebuild).
+type SearchIndexEnqueuer func(ctx context.Context, schematicID string) error
+
 const uploadPendingTemplate = "./template/upload_pending.html"
 
 // maxUploadSize is the maximum allowed NBT file size (10 MB).
@@ -262,7 +266,7 @@ func UploadPendingHandler(registry *server.Registry, cacheService *cache.Service
 // UploadMakePublicHandler accepts POSTs to publish a previously uploaded temp schematic.
 // Creates a real Schematic record, uploads images and copies NBT files from temp to
 // schematics S3 prefix, handles additional files (variations), then cleans up temp data.
-func UploadMakePublicHandler(registry *server.Registry, cacheService *cache.Service, appStore *store.Store, storageSvc *storage.Service, moderationSvc *moderation.Service, mailService *mailer.Service, enqueueModeration ModerationEnqueuer) func(e *server.RequestEvent) error {
+func UploadMakePublicHandler(registry *server.Registry, cacheService *cache.Service, appStore *store.Store, storageSvc *storage.Service, moderationSvc *moderation.Service, mailService *mailer.Service, enqueueModeration ModerationEnqueuer, enqueueSearchUpsert SearchIndexEnqueuer) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if e.Request.Method != http.MethodPost {
 			return e.String(http.StatusMethodNotAllowed, "method not allowed")
@@ -685,6 +689,12 @@ func UploadMakePublicHandler(registry *server.Registry, cacheService *cache.Serv
 			}); insertErr != nil {
 				slog.Error("make-public: failed to enqueue moderation job", "error", insertErr, "id", schem.ID)
 			}
+		}
+
+		// For trusted users (auto-approved), immediately index in search.
+		// Non-trusted users get indexed via the moderation job when approved.
+		if autoApproved && enqueueSearchUpsert != nil {
+			_ = enqueueSearchUpsert(ctx, schem.ID)
 		}
 
 		// Async image moderation for gallery images (featured is handled by the moderation job).

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -344,7 +344,20 @@ func Register(p RegisterParams) chi.Router {
 			}, &river.InsertOpts{Queue: "ai"})
 		}
 	}
-	r.Post("/u/{token}/make-public", Adapt(pages.UploadMakePublicHandler(registry, p.CacheService, p.AppStore, p.StorageService, p.ModerationService, p.MailService, enqueueModeration)))
+	// Build the search index enqueuer callbacks that close over the job worker.
+	var enqueueSearchUpsert, enqueueSearchDelete pages.SearchIndexEnqueuer
+	if p.JobWorker != nil {
+		jw := p.JobWorker
+		enqueueSearchUpsert = func(ctx context.Context, schematicID string) error {
+			jw.EnqueueSearchIndexUpsert(ctx, schematicID)
+			return nil
+		}
+		enqueueSearchDelete = func(ctx context.Context, schematicID string) error {
+			jw.EnqueueSearchIndexDelete(ctx, schematicID)
+			return nil
+		}
+	}
+	r.Post("/u/{token}/make-public", Adapt(pages.UploadMakePublicHandler(registry, p.CacheService, p.AppStore, p.StorageService, p.ModerationService, p.MailService, enqueueModeration, enqueueSearchUpsert)))
 	// Publish form for temporary uploads (requires auth)
 	r.Get("/u/{token}/publish", Adapt(pages.UploadPublishHandler(registry, p.CacheService, p.AppStore)))
 	// Upload moderation pending confirmation page
@@ -375,8 +388,8 @@ func Register(p RegisterParams) chi.Router {
 	r.Patch("/api/users/{id}", Adapt(pages.UserUpdateHandler(p.AppStore)))
 	r.Delete("/api/users/{id}", Adapt(pages.UserDeleteHandler(p.AppStore, p.CacheService, p.SessionStore)))
 	// Schematic edit/delete API (replaces PB REST endpoints)
-	r.Post("/schematics/{id}/update", Adapt(pages.SchematicUpdateHandler(p.CacheService, p.StorageService, p.AppStore, p.ModerationService)))
-	r.Delete("/schematics/{id}", Adapt(pages.SchematicDeleteHandler(p.CacheService, p.AppStore)))
+	r.Post("/schematics/{id}/update", Adapt(pages.SchematicUpdateHandler(p.CacheService, p.StorageService, p.AppStore, p.ModerationService, enqueueSearchUpsert)))
+	r.Delete("/schematics/{id}", Adapt(pages.SchematicDeleteHandler(p.CacheService, p.AppStore, enqueueSearchDelete)))
 	r.Get("/blacklist-request", func(w http.ResponseWriter, req *http.Request) {
 		http.Redirect(w, req, pages.LangRedirectURLFromRequest(req, "/settings/blacklist"), http.StatusMovedPermanently)
 	})
@@ -428,8 +441,8 @@ func Register(p RegisterParams) chi.Router {
 	r.Post("/admin/reports/{id}/ignore", Adapt(pages.AdminReportIgnoreHandler(p.AppStore)))
 	r.Get("/admin/schematics", Adapt(pages.AdminSchematicsHandler(registry, p.CacheService, p.AppStore)))
 	r.Get("/admin/schematics/{id}", Adapt(pages.AdminSchematicEditHandler(registry, p.CacheService, p.AppStore)))
-	r.Post("/admin/schematics/{id}", Adapt(pages.AdminSchematicUpdateHandler(p.CacheService, p.AppStore, p.MailService, p.StorageService)))
-	r.Post("/admin/schematics/{id}/delete", Adapt(pages.AdminSchematicDeleteHandler(p.CacheService, p.AppStore)))
+	r.Post("/admin/schematics/{id}", Adapt(pages.AdminSchematicUpdateHandler(p.CacheService, p.AppStore, p.MailService, p.StorageService, enqueueSearchUpsert)))
+	r.Post("/admin/schematics/{id}/delete", Adapt(pages.AdminSchematicDeleteHandler(p.CacheService, p.AppStore, enqueueSearchDelete)))
 	r.Get("/admin/tags", Adapt(pages.AdminTagsHandler(registry, p.CacheService, p.AppStore)))
 	r.Post("/admin/tags/{id}/approve", Adapt(pages.AdminTagApproveHandler(p.CacheService, p.AppStore)))
 	r.Post("/admin/tags/{id}/reject", Adapt(pages.AdminTagRejectHandler(p.CacheService, p.AppStore)))

--- a/internal/search/meili_engine.go
+++ b/internal/search/meili_engine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"slices"
 	"strings"
 	"sync"
 
@@ -29,12 +28,6 @@ func NewMeiliEngine(client meilisearch.ServiceManager, indexUID string, svc *Ser
 }
 
 func (m *MeiliEngine) Search(ctx context.Context, q SearchQuery) ([]string, error) {
-	// Trending sort: query Meilisearch for filtered results, then re-sort
-	// by in-memory trending scores.
-	if q.Order == TrendingOrder {
-		return m.trendingSearch(ctx, q)
-	}
-
 	filter := m.buildFilter(q)
 	sort := m.buildSort(q.Order)
 
@@ -62,54 +55,6 @@ func (m *MeiliEngine) Search(ctx context.Context, q SearchQuery) ([]string, erro
 	}
 
 	m.triggerResyncIfEmpty(q, len(ids))
-	return ids, nil
-}
-
-// trendingSearch queries Meilisearch for filtered results, then re-sorts
-// them by in-memory trending scores.
-func (m *MeiliEngine) trendingSearch(ctx context.Context, q SearchQuery) ([]string, error) {
-	filter := m.buildFilter(q)
-
-	searchReq := &meilisearch.SearchRequest{
-		Limit:  5000,
-		Filter: filter,
-	}
-
-	index := m.client.Index(m.indexUID)
-	result, err := index.SearchWithContext(ctx, q.Term, searchReq)
-	if err != nil {
-		return nil, fmt.Errorf("meili trending search error: %w", err)
-	}
-
-	ids := make([]string, 0, len(result.Hits))
-	for _, hit := range result.Hits {
-		var doc struct {
-			ID string `json:"id"`
-		}
-		if err := hit.DecodeInto(&doc); err != nil || doc.ID == "" {
-			continue
-		}
-		ids = append(ids, doc.ID)
-	}
-
-	m.triggerResyncIfEmpty(q, len(ids))
-
-	// Re-sort by trending scores from the in-memory service.
-	scores := m.svc.trendingScores
-	if scores != nil && len(ids) > 1 {
-		slices.SortFunc(ids, func(a, b string) int {
-			sa := scores[a]
-			sb := scores[b]
-			if sa > sb {
-				return -1
-			}
-			if sa < sb {
-				return 1
-			}
-			return 0
-		})
-	}
-
 	return ids, nil
 }
 
@@ -246,6 +191,8 @@ func (m *MeiliEngine) buildSort(order int) []string {
 		return []string{"views:desc"}
 	case LeastViewedOrder:
 		return []string{"views:asc"}
+	case TrendingOrder:
+		return []string{"trending_score:desc"}
 	default:
 		// BestMatch: use Meilisearch relevancy (no sort).
 		return nil
@@ -267,7 +214,7 @@ func (m *MeiliEngine) triggerResyncIfEmpty(q SearchQuery, hitCount int) {
 	m.resync.Do(func() {
 		go func() {
 			slog.Info("meili: 0-result broad query detected, triggering background resync", "index", m.indexUID, "docs", len(idx))
-			docs := MapToMeiliDocuments(idx)
+			docs := MapToMeiliDocuments(idx, m.svc.trendingScores)
 			if err := SyncMeiliIndex(m.client, m.indexUID, docs); err != nil {
 				slog.Error("meili: background resync failed", "index", m.indexUID, "error", err)
 			} else {

--- a/internal/search/meili_engine_test.go
+++ b/internal/search/meili_engine_test.go
@@ -94,7 +94,7 @@ func TestMeiliEngine_BuildSort(t *testing.T) {
 		{LowestRatingOrder, "rating:asc"},
 		{MostViewedOrder, "views:desc"},
 		{LeastViewedOrder, "views:asc"},
-		{TrendingOrder, ""},
+		{TrendingOrder, "trending_score:desc"},
 	}
 
 	for _, tt := range tests {

--- a/internal/search/meili_setup.go
+++ b/internal/search/meili_setup.go
@@ -25,6 +25,7 @@ type MeiliDocument struct {
 	ModNames         []string `json:"mod_names,omitempty"`
 	Rating           float64  `json:"rating"`
 	Views            int64    `json:"views"`
+	Downloads        int64    `json:"downloads"`
 	Paid             bool     `json:"paid"`
 	MinecraftVersion string   `json:"minecraft_version"`
 	CreateVersion    string   `json:"create_version"`
@@ -33,22 +34,73 @@ type MeiliDocument struct {
 	DimX             int      `json:"dim_x"`
 	DimY             int      `json:"dim_y"`
 	DimZ             int      `json:"dim_z"`
+	TrendingScore    float64  `json:"trending_score"`
+	RatingCount      int      `json:"rating_count"`
 }
 
 // EnsureMeiliIndexes creates the Meilisearch index with proper settings.
 func EnsureMeiliIndexes(client meilisearch.ServiceManager) error {
-	searchable := []string{"title", "tags", "block_names", "mod_names", "description", "ai_description", "author"}
+	// Searchable attributes ordered by signal quality (highest first).
+	// The "attribute" ranking rule uses this order to boost matches in higher-priority fields.
+	searchable := []string{
+		"title",
+		"tags",
+		"ai_description",
+		"mod_names",
+		"author",
+		"block_names",
+		"description",
+	}
 
 	filterableStr := []string{
 		"id", "categories", "minecraft_version", "create_version",
-		"tags", "rating", "paid", "views", "created_timestamp",
+		"tags", "rating", "paid", "views", "downloads", "created_timestamp",
 		"block_count", "dim_x", "dim_y", "dim_z", "mod_names",
+		"trending_score", "rating_count",
 	}
 	filterable := make([]interface{}, len(filterableStr))
 	for i, s := range filterableStr {
 		filterable[i] = s
 	}
-	sortable := []string{"rating", "views", "created_timestamp"}
+
+	sortable := []string{"rating", "views", "downloads", "created_timestamp", "trending_score", "rating_count"}
+
+	rankingRules := []string{"words", "typo", "proximity", "attribute", "sort", "exactness"}
+
+	synonyms := map[string][]string{
+		"train":       {"locomotive", "railway", "rail"},
+		"locomotive":  {"train", "railway"},
+		"elevator":    {"lift"},
+		"lift":        {"elevator"},
+		"farm":        {"grinder", "harvester"},
+		"plane":       {"airplane", "aircraft", "biplane"},
+		"airplane":    {"plane", "aircraft"},
+		"ship":        {"boat", "vessel"},
+		"boat":        {"ship", "vessel"},
+		"car":         {"automobile", "vehicle"},
+		"vehicle":     {"car", "automobile"},
+		"factory":     {"processing", "production", "refinery"},
+		"door":        {"gate", "entrance"},
+		"gate":        {"door", "entrance"},
+		"house":       {"building", "home"},
+		"compact":     {"small", "mini", "tiny"},
+		"small":       {"compact", "mini", "tiny"},
+		"large":       {"big", "huge", "massive"},
+		"big":         {"large", "huge", "massive"},
+		"power":       {"energy", "generator"},
+		"storage":     {"silo", "warehouse"},
+		"contraption": {"machine", "mechanism", "device"},
+		"machine":     {"contraption", "mechanism", "device"},
+		"redstone":    {"logic", "circuitry"},
+		"decoration":  {"decor", "decorative"},
+		"bridge":      {"overpass", "viaduct"},
+		"tunnel":      {"underground", "subway"},
+		"crane":       {"hoist", "winch"},
+		"conveyor":    {"belt"},
+		"gear":        {"cog", "cogwheel"},
+	}
+
+	stopWords := []string{"the", "a", "an", "is", "it", "of", "for", "with", "and", "or", "in", "on", "to", "my", "this", "that"}
 
 	// Create index if it doesn't exist.
 	task, err := client.CreateIndex(&meilisearch.IndexConfig{
@@ -63,23 +115,64 @@ func EnsureMeiliIndexes(client meilisearch.ServiceManager) error {
 
 	index := client.Index(MeiliIndex)
 
-	// Set searchable attributes.
 	if task, err := index.UpdateSearchableAttributes(&searchable); err != nil {
-		slog.Error("meili: update searchable attributes", "uid", MeiliIndex, "error", err)
+		slog.Error("meili: update searchable attributes", "error", err)
 	} else {
 		waitForTask(client, task)
 	}
 
-	// Set filterable attributes.
 	if task, err := index.UpdateFilterableAttributes(&filterable); err != nil {
-		slog.Error("meili: update filterable attributes", "uid", MeiliIndex, "error", err)
+		slog.Error("meili: update filterable attributes", "error", err)
 	} else {
 		waitForTask(client, task)
 	}
 
-	// Set sortable attributes.
 	if task, err := index.UpdateSortableAttributes(&sortable); err != nil {
-		slog.Error("meili: update sortable attributes", "uid", MeiliIndex, "error", err)
+		slog.Error("meili: update sortable attributes", "error", err)
+	} else {
+		waitForTask(client, task)
+	}
+
+	if task, err := index.UpdateRankingRules(&rankingRules); err != nil {
+		slog.Error("meili: update ranking rules", "error", err)
+	} else {
+		waitForTask(client, task)
+	}
+
+	if task, err := index.UpdateSynonyms(&synonyms); err != nil {
+		slog.Error("meili: update synonyms", "error", err)
+	} else {
+		waitForTask(client, task)
+	}
+
+	if task, err := index.UpdateStopWords(&stopWords); err != nil {
+		slog.Error("meili: update stop words", "error", err)
+	} else {
+		waitForTask(client, task)
+	}
+
+	if task, err := index.UpdateTypoTolerance(&meilisearch.TypoTolerance{
+		Enabled: true,
+		MinWordSizeForTypos: meilisearch.MinWordSizeForTypos{
+			OneTypo:  4,
+			TwoTypos: 7,
+		},
+	}); err != nil {
+		slog.Error("meili: update typo tolerance", "error", err)
+	} else {
+		waitForTask(client, task)
+	}
+
+	if task, err := index.UpdateSeparatorTokens([]string{"_", "-"}); err != nil {
+		slog.Error("meili: update separator tokens", "error", err)
+	} else {
+		waitForTask(client, task)
+	}
+
+	if task, err := index.UpdatePagination(&meilisearch.Pagination{
+		MaxTotalHits: 5000,
+	}); err != nil {
+		slog.Error("meili: update pagination", "error", err)
 	} else {
 		waitForTask(client, task)
 	}
@@ -149,7 +242,8 @@ func SyncMeiliIndex(client meilisearch.ServiceManager, indexUID string, docs []M
 }
 
 // MapToMeiliDocuments converts schematic index entries to Meilisearch documents.
-func MapToMeiliDocuments(filterIndex []schematicIndex) []MeiliDocument {
+// trendingScores maps schematic IDs to their computed trending scores.
+func MapToMeiliDocuments(filterIndex []schematicIndex, trendingScores map[string]float64) []MeiliDocument {
 	docs := make([]MeiliDocument, len(filterIndex))
 	for i, si := range filterIndex {
 		docs[i] = MeiliDocument{
@@ -162,6 +256,7 @@ func MapToMeiliDocuments(filterIndex []schematicIndex) []MeiliDocument {
 			Author:           si.Author,
 			Rating:           si.Rating,
 			Views:            si.Views,
+			Downloads:        si.Downloads,
 			Paid:             si.Paid,
 			MinecraftVersion: si.MinecraftVersion,
 			CreateVersion:    si.CreateVersion,
@@ -172,6 +267,10 @@ func MapToMeiliDocuments(filterIndex []schematicIndex) []MeiliDocument {
 			DimX:             si.DimX,
 			DimY:             si.DimY,
 			DimZ:             si.DimZ,
+			RatingCount:      si.RatingCount,
+		}
+		if trendingScores != nil {
+			docs[i].TrendingScore = trendingScores[si.ID]
 		}
 	}
 	return docs

--- a/internal/search/meili_setup.go
+++ b/internal/search/meili_setup.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
+
+	"createmod/internal/models"
 
 	"github.com/meilisearch/meilisearch-go"
 )
@@ -274,4 +277,69 @@ func MapToMeiliDocuments(filterIndex []schematicIndex, trendingScores map[string
 		}
 	}
 	return docs
+}
+
+// BuildSingleDocument builds a MeiliDocument from a single models.Schematic.
+// Used for incremental index updates when a schematic is created or edited.
+func BuildSingleDocument(s models.Schematic, modDisplayNames map[string]string, trendingScores map[string]float64) MeiliDocument {
+	authorName := ""
+	if s.Author != nil {
+		authorName = s.Author.Username
+	}
+
+	var categories []string
+	for _, c := range s.Categories {
+		categories = append(categories, c.Name)
+	}
+
+	var tags []string
+	for _, t := range s.Tags {
+		tags = append(tags, t.Name)
+	}
+
+	blockNames := ExtractBlockNames(s.Materials)
+
+	var modNames []string
+	if modDisplayNames != nil {
+		for _, ns := range s.Mods {
+			if name, ok := modDisplayNames[ns]; ok && name != "" {
+				modNames = append(modNames, name)
+			}
+		}
+	}
+
+	var rating float64
+	if parsed, err := strconv.ParseFloat(s.Rating, 64); err == nil {
+		rating = parsed
+	}
+
+	doc := MeiliDocument{
+		ID:               s.ID,
+		Title:            stripHtmlRegex(s.Title),
+		Description:      stripHtmlRegex(s.Content),
+		AIDescription:    stripHtmlRegex(s.AIDescription),
+		Tags:             tags,
+		Categories:       categories,
+		Author:           authorName,
+		Rating:           rating,
+		Views:            int64(s.Views),
+		Downloads:        int64(s.Downloads),
+		Paid:             s.Paid,
+		MinecraftVersion: s.MinecraftVersion,
+		CreateVersion:    s.CreatemodVersion,
+		CreatedTimestamp:  s.Created.Unix(),
+		BlockNames:       blockNames,
+		ModNames:         modNames,
+		BlockCount:       s.BlockCount,
+		DimX:             s.DimX,
+		DimY:             s.DimY,
+		DimZ:             s.DimZ,
+		RatingCount:      s.RatingCount,
+	}
+
+	if trendingScores != nil {
+		doc.TrendingScore = trendingScores[s.ID]
+	}
+
+	return doc
 }

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -57,7 +57,9 @@ type schematicIndex struct {
 	Tags             []string
 	Categories       []string
 	Views            int64
+	Downloads        int64
 	Rating           float64
+	RatingCount      int
 	Author           string
 	MinecraftVersion string
 	CreateVersion    string
@@ -118,6 +120,8 @@ func (s *Service) BuildIndex(schematics []models.Schematic, modDisplayNames map[
 			Description: stripHtmlRegex(schematics[i].Content),
 			Created:     schematics[i].Created,
 			Views:       int64(schematics[i].Views),
+			Downloads:   int64(schematics[i].Downloads),
+			RatingCount: schematics[i].RatingCount,
 			Author:      authorName,
 		}
 		if parsedFloat, err := strconv.ParseFloat(schematics[i].Rating, 64); err == nil {

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -85,6 +85,29 @@ func (s *Service) SetTrendingScores(scores map[string]float64) {
 	s.trendingScores = scores
 }
 
+// GetTrendingScores returns the current trending scores map.
+func (s *Service) GetTrendingScores() map[string]float64 {
+	return s.trendingScores
+}
+
+// GetIndexForIDs returns index entries matching the given IDs.
+func (s *Service) GetIndexForIDs(ids []string) []schematicIndex {
+	if s.index == nil {
+		return nil
+	}
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+	var result []schematicIndex
+	for _, si := range s.index {
+		if _, ok := idSet[si.ID]; ok {
+			result = append(result, si)
+		}
+	}
+	return result
+}
+
 // NewEmpty creates a search service without loading the S3 cache, so the
 // caller is not blocked by network I/O. The index starts empty and is
 // populated by the River SearchIndexWorker which runs on start.


### PR DESCRIPTION
…and trending consistency

Meilisearch configuration:
- Add explicit ranking rules (words/typo/proximity/attribute/sort/exactness)
- Reorder searchable attributes by signal quality (title > tags > ai_description > mod_names > author > block_names > description)
- Add Create mod-specific synonyms (train↔locomotive, elevator↔lift, etc.)
- Enable typo tolerance for shorter words (4+ chars for 1 typo, 7+ for 2)
- Add separator tokens ("_", "-") so block names like brass_casing match "brass casing"
- Add stop words to reduce noise
- Set pagination max total hits

Trending score consistency:
- Store trending_score directly in Meilisearch documents
- Sort by trending_score in Meilisearch instead of in-memory re-sort
- Eliminates cold-start bug where trendingScores map was nil
- Search page trending now matches homepage trending (same scores, same order)

New indexed fields:
- trending_score (sortable) for consistent trending across pages
- downloads (filterable/sortable) for future "most downloaded" sort
- rating_count (filterable/sortable) for popularity sorting