### PR TITLE
Fix comment translation toggle showing on all comments and causing pa…

### DIFF
--- a/internal/models/comment.go
+++ b/internal/models/comment.go
@@ -16,6 +16,7 @@ type Comment struct {
 	AuthorAvatar    string
 	Indent          int
 	Content         template.HTML
+	OriginalContent template.HTML
 	Approved        bool
 	ParentID        string
 	IsTranslated    bool

--- a/internal/pages/schematic.go
+++ b/internal/pages/schematic.go
@@ -75,10 +75,9 @@ type SchematicData struct {
 	// ScheduledFor is set when the schematic is scheduled for future publication and the viewer is the author.
 	ScheduledFor *time.Time
 	// Translation fields
-	IsTranslated            bool
-	OriginalLanguage        string
-	ShowingOriginal         bool
-	ShowingOriginalComments bool
+	IsTranslated     bool
+	OriginalLanguage string
+	ShowingOriginal  bool
 	// Moderation chat fields
 	ModerationChatEnabled bool
 	ModerationMessages    []models.ModerationChatMessage
@@ -151,9 +150,7 @@ func SchematicHandler(searchEngine search.SearchEngine, cacheService *cache.Serv
 		}
 		d.SubCategory = "Schematic"
 		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
-		commentShowOriginal := e.Request.URL.Query().Get("comments") == "original"
-		d.ShowingOriginalComments = commentShowOriginal
-		d.Comments = findSchematicCommentsFromStore(appStore, d.Schematic.ID, translationService, cacheService, d.Language, commentShowOriginal)
+		d.Comments = findSchematicCommentsFromStore(appStore, d.Schematic.ID, translationService, cacheService, d.Language)
 		authorID := ""
 		if d.Schematic.Author != nil {
 			authorID = d.Schematic.Author.ID
@@ -869,9 +866,10 @@ func findAuthorSchematicsFromStore(appStore *store.Store, cacheService *cache.Se
 
 // findSchematicCommentsFromStore returns approved comments for a schematic,
 // using the store which already joins user info.
-// When targetLang is non-empty and showOriginal is false, comment content is
-// replaced with the translated version (if available) and IsTranslated is set.
-func findSchematicCommentsFromStore(appStore *store.Store, schematicID string, translationSvc *translation.Service, cacheService *cache.Service, targetLang string, showOriginal bool) []models.Comment {
+// When targetLang is non-empty, comment content is replaced with the
+// translated version (if available and different from the original)
+// and IsTranslated is set. OriginalContent preserves the pre-translation text.
+func findSchematicCommentsFromStore(appStore *store.Store, schematicID string, translationSvc *translation.Service, cacheService *cache.Service, targetLang string) []models.Comment {
 	ctx := stdctx.Background()
 	storeComments, err := appStore.Comments.ListBySchematic(ctx, schematicID)
 	if err != nil {
@@ -951,16 +949,24 @@ func findSchematicCommentsFromStore(appStore *store.Store, schematicID string, t
 		}
 	}
 
-	// Apply translations if viewer's language differs from English and not showing original
-	if translationSvc != nil && cacheService != nil && targetLang != "" && !showOriginal {
+	// Apply translations when a translation exists and differs from the original.
+	if translationSvc != nil && cacheService != nil && targetLang != "" {
+		originalContent := make(map[string]string, len(storeComments))
+		for _, sc := range storeComments {
+			originalContent[sc.ID] = sc.Content
+		}
 		transSanitizer := htmlsanitizer.NewHTMLSanitizer()
 		for i := range comments {
 			ct := translationSvc.GetCommentTranslation(cacheService, comments[i].ID, targetLang)
 			if ct != nil && ct.Content != "" {
+				if ct.Content == originalContent[comments[i].ID] {
+					continue
+				}
 				sanitized, sErr := transSanitizer.SanitizeString(ct.Content)
 				if sErr != nil {
 					sanitized = template.HTMLEscapeString(ct.Content)
 				}
+				comments[i].OriginalContent = comments[i].Content
 				comments[i].Content = template.HTML(sanitized)
 				comments[i].IsTranslated = true
 			}

--- a/internal/pages/schematic_comments.go
+++ b/internal/pages/schematic_comments.go
@@ -37,8 +37,7 @@ func SchematicCommentsHandler(cacheService *cache.Service, registry *server.Regi
 			Schematic: MapStoreSchematicToModel(appStore, *storeSchematic, cacheService),
 		}
 		d.Populate(e)
-		commentShowOriginal := e.Request.URL.Query().Get("comments") == "original"
-		d.Comments = findSchematicCommentsFromStore(appStore, d.Schematic.ID, translationService, cacheService, d.Language, commentShowOriginal)
+		d.Comments = findSchematicCommentsFromStore(appStore, d.Schematic.ID, translationService, cacheService, d.Language)
 		d.Title = fmt.Sprintf("Comments for %s", d.Schematic.Title)
 
 		html, err := registry.LoadFiles(schematicCommentsTemplates...).Render(d)

--- a/template/include/comments.html
+++ b/template/include/comments.html
@@ -4,16 +4,22 @@
         <div class="card card-sm{{ if eq .Indent 1 }} ms-md-4{{end }}">
             <div class="card-body">
                 <div class="text-secondary">
-                    {{ .Content }}
                     {{ if .IsTranslated }}
-                    <div class="text-muted small mt-1">
-                        {{ T $.Language "Auto translated" }} &mdash;
-                        <a href="?comments=original#{{ .ID }}" class="link-muted">{{ T $.Language "show original" }}</a>
+                    <div class="comment-translated" data-comment-id="{{ .ID }}">
+                        <div class="comment-translated-content">{{ .Content }}</div>
+                        <div class="comment-original-content" style="display:none;">{{ .OriginalContent }}</div>
+                        <div class="text-muted small mt-1">
+                            <span class="comment-translated-label">
+                                {{ T $.Language "Auto translated" }} &mdash;
+                                <a href="#" class="link-muted" onclick="toggleCommentTranslation(this); return false;">{{ T $.Language "show original" }}</a>
+                            </span>
+                            <span class="comment-original-label" style="display:none;">
+                                <a href="#" class="link-muted" onclick="toggleCommentTranslation(this); return false;">{{ T $.Language "show translation" }}</a>
+                            </span>
+                        </div>
                     </div>
-                    {{ else if $.ShowingOriginalComments }}
-                    <div class="text-muted small mt-1">
-                        <a href="?#{{ .ID }}" class="link-muted">{{ T $.Language "show translation" }}</a>
-                    </div>
+                    {{ else }}
+                    {{ .Content }}
                     {{ end }}
                 </div>
                 <div class="mt-4">

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -396,16 +396,22 @@
                                     <div class="card card-sm{{ if eq .Indent 1 }} ms-md-4{{end }}">
                                         <div class="card-body">
                                             <div class="text-secondary">
-                                                {{ .Content }}
                                                 {{ if .IsTranslated }}
-                                                <div class="text-muted small mt-1">
-                                                    {{ T $.Language "Auto translated" }} &mdash;
-                                                    <a href="?comments=original#{{ .ID }}" class="link-muted">{{ T $.Language "show original" }}</a>
+                                                <div class="comment-translated" data-comment-id="{{ .ID }}">
+                                                    <div class="comment-translated-content">{{ .Content }}</div>
+                                                    <div class="comment-original-content" style="display:none;">{{ .OriginalContent }}</div>
+                                                    <div class="text-muted small mt-1">
+                                                        <span class="comment-translated-label">
+                                                            {{ T $.Language "Auto translated" }} &mdash;
+                                                            <a href="#" class="link-muted" onclick="toggleCommentTranslation(this); return false;">{{ T $.Language "show original" }}</a>
+                                                        </span>
+                                                        <span class="comment-original-label" style="display:none;">
+                                                            <a href="#" class="link-muted" onclick="toggleCommentTranslation(this); return false;">{{ T $.Language "show translation" }}</a>
+                                                        </span>
+                                                    </div>
                                                 </div>
-                                                {{ else if $.ShowingOriginalComments }}
-                                                <div class="text-muted small mt-1">
-                                                    <a href="?#{{ .ID }}" class="link-muted">{{ T $.Language "show translation" }}</a>
-                                                </div>
+                                                {{ else }}
+                                                {{ .Content }}
                                                 {{ end }}
                                             </div>
                                             <div class="mt-4">
@@ -1196,6 +1202,20 @@ function copyMaterialsAsMarkdown() {
             }
         });
     });
+
+    function toggleCommentTranslation(el) {
+        var c = el.closest('.comment-translated');
+        if (!c) return;
+        var t = c.querySelector('.comment-translated-content');
+        var o = c.querySelector('.comment-original-content');
+        var lt = c.querySelector('.comment-translated-label');
+        var lo = c.querySelector('.comment-original-label');
+        var showOriginal = o.style.display === 'none';
+        t.style.display = showOriginal ? 'none' : '';
+        o.style.display = showOriginal ? '' : 'none';
+        lt.style.display = showOriginal ? 'none' : '';
+        lo.style.display = showOriginal ? '' : 'none';
+    }
 </script>
 <script>
 document.addEventListener('htmx:afterRequest', function(evt) {


### PR DESCRIPTION
…ge reload

Three bugs fixed:
- "Auto translated / show original" appeared on every comment, even when the comment was originally in the viewer's language. The translation backfill saves original content as a "translation" for the detected language; the render loop now compares translation content against the original and skips identical matches.
- Clicking "show original" caused a full page reload via query parameter ?comments=original. Replaced with a per-comment client-side JS toggle that swaps translated/original content inline without navigation.
- Toggling one comment affected all comments because the query parameter was a page-level flag. Each comment now toggles independently.