### PR TITLE
Fix image placeholder fallback using CSS layering instead of sibling …

### DIFF
--- a/template/include/schematic_card.html
+++ b/template/include/schematic_card.html
@@ -2,19 +2,15 @@
 <a href="/schematics/{{ .Name }}" class="d-block text-decoration-none">
   <div class="card card-sm card-hover-lift overflow-hidden">
     <div class="card-body-borderless ratio ratio-16x9" style="position:relative;">
+      <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary" style="position:absolute;inset:0;z-index:0;">
+          <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-lg" width="48" height="48" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
+      </div>
       {{ if ne .FeaturedImage "" }}
       <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180"
            srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360 640w"
            sizes="(max-width: 767px) 100vw, (max-width: 991px) 50vw, (max-width: 1199px) 33vw, 25vw"
-           alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="640" height="360"
-           onerror="this.style.display='none';this.nextElementSibling.style.display=''">
-      <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary" style="display:none">
-          <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-lg" width="48" height="48" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
-      </div>
-      {{ else }}
-      <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary">
-          <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-lg" width="48" height="48" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
-      </div>
+           alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="640" height="360" style="position:relative;z-index:1;"
+           onerror="this.style.display='none'">
       {{ end }}
       {{ if .Paid }}<span class="badge bg-red" style="position:absolute;top:8px;left:8px;z-index:1;">Paid</span>{{ end }}
     </div>

--- a/template/include/schematic_card_featured.html
+++ b/template/include/schematic_card_featured.html
@@ -3,19 +3,15 @@
   <a href="/schematics/{{ .Name }}" class="d-block text-decoration-none">
     <div class="card card-featured card-hover-lift overflow-hidden">
       <div class="ratio ratio-16x9" style="position:relative;">
+        <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary" style="position:absolute;inset:0;z-index:0;">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-lg" width="48" height="48" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
+        </div>
         {{ if ne .FeaturedImage "" }}
         <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180"
              srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360 640w"
              sizes="(max-width: 767px) 100vw, 33vw"
-             alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="640" height="360"
-             onerror="this.style.display='none';this.nextElementSibling.style.display=''">
-        <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary" style="display:none">
-            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-lg" width="48" height="48" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
-        </div>
-        {{ else }}
-        <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary">
-            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-lg" width="48" height="48" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
-        </div>
+             alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="640" height="360" style="position:relative;z-index:1;"
+             onerror="this.style.display='none'">
         {{ end }}
         {{ if .Paid }}<span class="badge bg-red" style="position:absolute;top:8px;left:8px;z-index:2;">Paid</span>{{ end }}
       </div>

--- a/template/include/schematic_card_list.html
+++ b/template/include/schematic_card_list.html
@@ -1,17 +1,13 @@
 {{define "schematic_card_list.html"}}
 <a href="/schematics/{{ .Name }}" class="search-list-item d-flex text-decoration-none">
   <div class="flex-shrink-0" style="width: 120px; height: 68px; position:relative;">
+    <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary" style="position:absolute;inset:0;border-radius:.4rem;">
+        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
+    </div>
     {{ if ne .FeaturedImage "" }}
     <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=240x136"
-         alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="120" height="68" style="width: 120px; height: 68px; border-radius: .4rem;"
-         onerror="this.style.display='none';this.nextElementSibling.style.display=''">
-    <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary" style="display:none;width: 120px; height: 68px; border-radius: .4rem;">
-        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
-    </div>
-    {{ else }}
-    <div class="d-flex align-items-center justify-content-center bg-secondary-lt text-secondary" style="width: 120px; height: 68px; border-radius: .4rem;">
-        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8h.01"/><path d="M3 6a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3h-12a3 3 0 0 1 -3 -3v-12z"/><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l5 5"/><path d="M14 14l1 -1c.928 -.893 2.072 -.893 3 0l3 3"/></svg>
-    </div>
+         alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="120" height="68" style="position:relative;width:120px;height:68px;border-radius:.4rem;"
+         onerror="this.style.display='none'">
     {{ end }}
     {{ if .Paid }}<span class="badge bg-red" style="position:absolute;top:4px;left:4px;z-index:1;font-size:.6rem;">Paid</span>{{ end }}
   </div>


### PR DESCRIPTION
…swap

The previous nextElementSibling approach caused all images to show placeholders. Switch to always rendering the placeholder absolutely positioned behind the image (z-index:0). The image sits on top (z-index:1) and covers it when loaded. On error, only the broken img is hidden and the placeholder shows through naturally.