### PR TITLE
Combine Width and Length search filters into single Horizontal Size s…

### DIFF
--- a/internal/pages/search.go
+++ b/internal/pages/search.go
@@ -73,12 +73,14 @@ type SearchData struct {
 	MaxDimY           int
 	MinDimZ           int
 	MaxDimZ           int
+	MinHorizontal     int
 	SelectedMods      []string
 	AllMods           []ModOption
 	MaxBlockCountAll  int // global max for slider upper bound
 	MaxDimXAll        int
 	MaxDimYAll        int
 	MaxDimZAll        int
+	MaxHorizontalAll  int
 }
 
 func SearchHandler(searchEngine search.SearchEngine, searchService *search.Service, cacheService *cache.Service, registry *server.Registry, appStore *store.Store, translationService *translation.Service) func(e *server.RequestEvent) error {
@@ -169,6 +171,7 @@ func SearchHandler(searchEngine search.SearchEngine, searchService *search.Servi
 		maxDimY := parseIntParam("maxy")
 		minDimZ := parseIntParam("minz")
 		maxDimZ := parseIntParam("maxz")
+		minHorizontal := parseIntParam("minhz")
 
 		// Parse mod filter (comma-separated "mods" param or multiple "mod" checkbox params)
 		var selectedMods []string
@@ -225,6 +228,7 @@ func SearchHandler(searchEngine search.SearchEngine, searchService *search.Servi
 			MaxDimY:          maxDimY,
 			MinDimZ:          minDimZ,
 			MaxDimZ:          maxDimZ,
+			MinHorizontal:    minHorizontal,
 			Mods:             meiliModNames,
 		}
 
@@ -332,6 +336,9 @@ func SearchHandler(searchEngine search.SearchEngine, searchService *search.Servi
 		if maxBlockCount > 0 {
 			queryParts = append(queryParts, fmt.Sprintf("maxbc=%d", maxBlockCount))
 		}
+		if minHorizontal > 0 {
+			queryParts = append(queryParts, fmt.Sprintf("minhz=%d", minHorizontal))
+		}
 		if minDimX > 0 {
 			queryParts = append(queryParts, fmt.Sprintf("minx=%d", minDimX))
 		}
@@ -425,12 +432,14 @@ func SearchHandler(searchEngine search.SearchEngine, searchService *search.Servi
 			MaxDimY:           maxDimY,
 			MinDimZ:           minDimZ,
 			MaxDimZ:           maxDimZ,
+			MinHorizontal:     minHorizontal,
 			SelectedMods:      selectedMods,
 			AllMods:           allMods,
 			MaxBlockCountAll:  maxStats.BlockCount,
 			MaxDimXAll:        maxStats.DimX,
 			MaxDimYAll:        maxStats.DimY,
 			MaxDimZAll:        maxStats.DimZ,
+			MaxHorizontalAll:  max(maxStats.DimX, maxStats.DimZ),
 		}
 		d.Populate(e)
 		translateSchematicTitles(d.Schematics, translationService, cacheService, d.Language)
@@ -523,12 +532,9 @@ func SearchPostHandler(service *cache.Service, registry *server.Registry, appSto
 			CreateVersion    string `json:"cv" form:"cv"`
 			MinBlockCount    string `json:"minbc" form:"minbc"`
 			MaxBlockCount    string `json:"maxbc" form:"maxbc"`
-			MinDimX          string `json:"minx" form:"minx"`
-			MaxDimX          string `json:"maxx" form:"maxx"`
+			MinHorizontal    string `json:"minhz" form:"minhz"`
 			MinDimY          string `json:"miny" form:"miny"`
 			MaxDimY          string `json:"maxy" form:"maxy"`
-			MinDimZ          string `json:"minz" form:"minz"`
-			MaxDimZ          string `json:"maxz" form:"maxz"`
 		}{}
 		if err := e.BindBody(&data); err != nil {
 			return &server.APIError{Status: 400, Message: "Failed to read request data"}
@@ -561,23 +567,14 @@ func SearchPostHandler(service *cache.Service, registry *server.Registry, appSto
 		if data.MaxBlockCount != "" && data.MaxBlockCount != "0" {
 			redirectURL += "&maxbc=" + data.MaxBlockCount
 		}
-		if data.MinDimX != "" && data.MinDimX != "0" {
-			redirectURL += "&minx=" + data.MinDimX
-		}
-		if data.MaxDimX != "" && data.MaxDimX != "0" {
-			redirectURL += "&maxx=" + data.MaxDimX
+		if data.MinHorizontal != "" && data.MinHorizontal != "0" {
+			redirectURL += "&minhz=" + data.MinHorizontal
 		}
 		if data.MinDimY != "" && data.MinDimY != "0" {
 			redirectURL += "&miny=" + data.MinDimY
 		}
 		if data.MaxDimY != "" && data.MaxDimY != "0" {
 			redirectURL += "&maxy=" + data.MaxDimY
-		}
-		if data.MinDimZ != "" && data.MinDimZ != "0" {
-			redirectURL += "&minz=" + data.MinDimZ
-		}
-		if data.MaxDimZ != "" && data.MaxDimZ != "0" {
-			redirectURL += "&maxz=" + data.MaxDimZ
 		}
 		if modsParam != "" {
 			redirectURL += "&mods=" + modsParam

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -33,5 +33,6 @@ type SearchQuery struct {
 	MaxDimY          int
 	MinDimZ          int
 	MaxDimZ          int
+	MinHorizontal    int // combined X/Z minimum: matches dim_x >= N OR dim_z >= N
 	Mods             []string // mod display names to filter by (AND semantics)
 }

--- a/internal/search/meili_engine.go
+++ b/internal/search/meili_engine.go
@@ -149,6 +149,9 @@ func (m *MeiliEngine) buildFilter(q SearchQuery) string {
 	if q.MaxBlockCount > 0 {
 		parts = append(parts, fmt.Sprintf("block_count <= %d", q.MaxBlockCount))
 	}
+	if q.MinHorizontal > 0 {
+		parts = append(parts, fmt.Sprintf("(dim_x >= %d OR dim_z >= %d)", q.MinHorizontal, q.MinHorizontal))
+	}
 	if q.MinDimX > 0 {
 		parts = append(parts, fmt.Sprintf("dim_x >= %d", q.MinDimX))
 	}

--- a/template/include/search_filters.html
+++ b/template/include/search_filters.html
@@ -88,25 +88,19 @@
         {{ if gt .MaxDimYAll 0 }}
         <div class="subheader mb-2">{{ T .Language "Dimensions" }}</div>
         <div class="mb-3">
+            {{ if gt .MaxHorizontalAll 0 }}
+            <div class="mb-2">
+                <label class="form-label small text-secondary mb-1">{{ T .Language "Horizontal Size" }} (X/Z): <span id="hz-label">{{ if gt .MinHorizontal 0 }}{{ .MinHorizontal }}+{{ else }}{{ T .Language "Any" }}{{ end }}</span></label>
+                <div class="d-flex gap-2 align-items-center">
+                    <input type="range" class="form-range flex-grow-1" name="minhz" min="0" max="{{ .MaxHorizontalAll }}" step="1" value="{{ .MinHorizontal }}" oninput="var v=parseInt(this.value)||0;document.getElementById('hz-label').textContent=v>0?v+'+':'{{ T .Language "Any" }}';">
+                </div>
+            </div>
+            {{ end }}
             <div class="mb-2">
                 <label class="form-label small text-secondary mb-1">{{ T .Language "Height" }} (Y): <span id="dimy-label">{{ if and (gt .MinDimY 0) (gt .MaxDimY 0) }}{{ .MinDimY }}–{{ .MaxDimY }}{{ else if gt .MinDimY 0 }}{{ .MinDimY }}+{{ else if gt .MaxDimY 0 }}0–{{ .MaxDimY }}{{ else }}{{ T .Language "Any" }}{{ end }}</span></label>
                 <div class="d-flex gap-2 align-items-center">
                     <input type="range" class="form-range flex-grow-1" name="miny" min="0" max="{{ .MaxDimYAll }}" step="1" value="{{ .MinDimY }}" oninput="updateRangeLabel('dimy',this.value,document.querySelector('[name=maxy]').value,{{ .MaxDimYAll }})">
                     <input type="range" class="form-range flex-grow-1" name="maxy" min="0" max="{{ .MaxDimYAll }}" step="1" value="{{ if gt .MaxDimY 0 }}{{ .MaxDimY }}{{ else }}{{ .MaxDimYAll }}{{ end }}" oninput="updateRangeLabel('dimy',document.querySelector('[name=miny]').value,this.value,{{ .MaxDimYAll }})">
-                </div>
-            </div>
-            <div class="mb-2">
-                <label class="form-label small text-secondary mb-1">{{ T .Language "Width" }} (X): <span id="dimx-label">{{ if and (gt .MinDimX 0) (gt .MaxDimX 0) }}{{ .MinDimX }}–{{ .MaxDimX }}{{ else if gt .MinDimX 0 }}{{ .MinDimX }}+{{ else if gt .MaxDimX 0 }}0–{{ .MaxDimX }}{{ else }}{{ T .Language "Any" }}{{ end }}</span></label>
-                <div class="d-flex gap-2 align-items-center">
-                    <input type="range" class="form-range flex-grow-1" name="minx" min="0" max="{{ .MaxDimXAll }}" step="1" value="{{ .MinDimX }}" oninput="updateRangeLabel('dimx',this.value,document.querySelector('[name=maxx]').value,{{ .MaxDimXAll }})">
-                    <input type="range" class="form-range flex-grow-1" name="maxx" min="0" max="{{ .MaxDimXAll }}" step="1" value="{{ if gt .MaxDimX 0 }}{{ .MaxDimX }}{{ else }}{{ .MaxDimXAll }}{{ end }}" oninput="updateRangeLabel('dimx',document.querySelector('[name=minx]').value,this.value,{{ .MaxDimXAll }})">
-                </div>
-            </div>
-            <div class="mb-2">
-                <label class="form-label small text-secondary mb-1">{{ T .Language "Length" }} (Z): <span id="dimz-label">{{ if and (gt .MinDimZ 0) (gt .MaxDimZ 0) }}{{ .MinDimZ }}–{{ .MaxDimZ }}{{ else if gt .MinDimZ 0 }}{{ .MinDimZ }}+{{ else if gt .MaxDimZ 0 }}0–{{ .MaxDimZ }}{{ else }}{{ T .Language "Any" }}{{ end }}</span></label>
-                <div class="d-flex gap-2 align-items-center">
-                    <input type="range" class="form-range flex-grow-1" name="minz" min="0" max="{{ .MaxDimZAll }}" step="1" value="{{ .MinDimZ }}" oninput="updateRangeLabel('dimz',this.value,document.querySelector('[name=maxz]').value,{{ .MaxDimZAll }})">
-                    <input type="range" class="form-range flex-grow-1" name="maxz" min="0" max="{{ .MaxDimZAll }}" step="1" value="{{ if gt .MaxDimZ 0 }}{{ .MaxDimZ }}{{ else }}{{ .MaxDimZAll }}{{ end }}" oninput="updateRangeLabel('dimz',document.querySelector('[name=minz]').value,this.value,{{ .MaxDimZAll }})">
                 </div>
             </div>
         </div>
@@ -132,7 +126,7 @@
             {{ end }}
         </div>
         {{ end }}
-        {{ if or (ne .Category "all") (gt (len .SelectedTags) 0) (ne .MinecraftVersion "all") (ne .CreateVersion "all") (ne .Rating -1) (gt .MinBlockCount 0) (gt .MaxBlockCount 0) (gt .MinDimX 0) (gt .MaxDimX 0) (gt .MinDimY 0) (gt .MaxDimY 0) (gt .MinDimZ 0) (gt .MaxDimZ 0) (gt (len .SelectedMods) 0) }}
+        {{ if or (ne .Category "all") (gt (len .SelectedTags) 0) (ne .MinecraftVersion "all") (ne .CreateVersion "all") (ne .Rating -1) (gt .MinBlockCount 0) (gt .MaxBlockCount 0) (gt .MinHorizontal 0) (gt .MinDimY 0) (gt .MaxDimY 0) (gt (len .SelectedMods) 0) }}
         <div class="mb-3">
             <a href="/search/{{ .TermSlug }}" class="text-secondary small">{{ T .Language "Clear all filters" }}</a>
         </div>
@@ -179,7 +173,7 @@
         if (el.type === 'range') {
           var max = parseInt(el.max) || 0;
           var val = parseInt(el.value) || 0;
-          if (el.name.indexOf('max') === 0 || el.name === 'maxbc' || el.name === 'maxy' || el.name === 'maxx' || el.name === 'maxz') {
+          if (el.name.indexOf('max') === 0 || el.name === 'maxbc' || el.name === 'maxy') {
             if (val >= max) el.value = '0';
           }
         }


### PR DESCRIPTION
…lider

Replaces the separate Width(X) and Length(Z) min/max range pairs with a single "Horizontal Size (X/Z)" minimum slider. When set to e.g. 150, the Meilisearch filter uses OR semantics: (dim_x >= 150 OR dim_z >= 150), showing schematics where either horizontal dimension meets the threshold.