### PR TITLE
Fix image placeholder z-index layering in card templates

### DIFF
--- a/template/include/schematic_card.html
+++ b/template/include/schematic_card.html
@@ -9,7 +9,7 @@
       <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180"
            srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360 640w"
            sizes="(max-width: 767px) 100vw, (max-width: 991px) 50vw, (max-width: 1199px) 33vw, 25vw"
-           alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="640" height="360" style="position:relative;z-index:1;"
+           alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="640" height="360" style="z-index:1;"
            onerror="this.style.display='none'">
       {{ end }}
       {{ if .Paid }}<span class="badge bg-red" style="position:absolute;top:8px;left:8px;z-index:1;">Paid</span>{{ end }}

--- a/template/include/schematic_card_featured.html
+++ b/template/include/schematic_card_featured.html
@@ -10,7 +10,7 @@
         <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180"
              srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360 640w"
              sizes="(max-width: 767px) 100vw, 33vw"
-             alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="640" height="360" style="position:relative;z-index:1;"
+             alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="640" height="360" style="z-index:1;"
              onerror="this.style.display='none'">
         {{ end }}
         {{ if .Paid }}<span class="badge bg-red" style="position:absolute;top:8px;left:8px;z-index:2;">Paid</span>{{ end }}

--- a/template/include/schematic_card_list.html
+++ b/template/include/schematic_card_list.html
@@ -6,7 +6,7 @@
     </div>
     {{ if ne .FeaturedImage "" }}
     <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=240x136"
-         alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="120" height="68" style="position:relative;width:120px;height:68px;border-radius:.4rem;"
+         alt="Featured image of {{ .Title }}" class="img-fluid object-fit-cover" width="120" height="68" style="position:absolute;inset:0;width:120px;height:68px;border-radius:.4rem;z-index:1;"
          onerror="this.style.display='none'">
     {{ end }}
     {{ if .Paid }}<span class="badge bg-red" style="position:absolute;top:4px;left:4px;z-index:1;font-size:.6rem;">Paid</span>{{ end }}


### PR DESCRIPTION
position:relative on images was overriding Bootstrap's .ratio > * absolute positioning, causing images to flow below the placeholder instead of covering it.