### PR TITLE
Fix YouTube watch URL for youtu.be share links

### DIFF
--- a/internal/pages/templates.go
+++ b/internal/pages/templates.go
@@ -50,7 +50,7 @@ func NewTestRegistry() *server.Registry {
 		},
 		"urlPathEscape": url.PathEscape,
 		"YouTubeWatchURL": func(video string) string {
-			return "https://www.youtube.com/watch?v=" + video
+			return YoutubeWatchURL(video)
 		},
 		"externalDomain": ExternalDomain,
 		"LangFlag": func(code string) html.HTML {
@@ -102,4 +102,46 @@ func ExternalDomain(rawURL string) string {
 	default:
 		return host
 	}
+}
+
+func ExtractYouTubeID(video string) string {
+	video = strings.TrimSpace(video)
+	if video == "" {
+		return ""
+	}
+	if u, err := url.Parse(video); err == nil && u.Host != "" {
+		host := strings.ToLower(u.Host)
+		switch {
+		case host == "youtu.be" || host == "www.youtu.be":
+			id := strings.TrimPrefix(u.Path, "/")
+			if id != "" {
+				return id
+			}
+		case strings.Contains(host, "youtube.com"):
+			if strings.HasPrefix(u.Path, "/embed/") {
+				id := strings.TrimPrefix(u.Path, "/embed/")
+				if id != "" {
+					return id
+				}
+			}
+			if strings.HasPrefix(u.Path, "/shorts/") {
+				id := strings.TrimPrefix(u.Path, "/shorts/")
+				if id != "" {
+					return id
+				}
+			}
+			if v := u.Query().Get("v"); v != "" {
+				return v
+			}
+		}
+	}
+	return video
+}
+
+func YoutubeWatchURL(video string) string {
+	id := ExtractYouTubeID(video)
+	if id == "" {
+		return video
+	}
+	return "https://www.youtube.com/watch?v=" + id
 }

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -156,17 +156,7 @@ func Register(p RegisterParams) chi.Router {
 			return pages.AllHreflangs()
 		},
 		"YouTubeWatchURL": func(video string) string {
-			if strings.Contains(video, "/embed/") {
-				parts := strings.Split(video, "/embed/")
-				if len(parts) == 2 && parts[1] != "" {
-					id := strings.SplitN(parts[1], "?", 2)[0]
-					return "https://www.youtube.com/watch?v=" + id
-				}
-			}
-			if strings.Contains(video, "watch?v=") {
-				return video
-			}
-			return "https://www.youtube.com/watch?v=" + video
+			return pages.YoutubeWatchURL(video)
 		},
 		"externalDomain": pages.ExternalDomain,
 		"LangFlag": func(code string) html.HTML {


### PR DESCRIPTION
YouTubeWatchURL was prepending watch?v= to the full youtu.be URL, producing broken links like youtube.com/watch?v=https://youtu.be/... Now properly extracts the video ID from youtu.be, embed, shorts, and standard watch URLs.