### PR TITLE
Unify follows and section subscriptions into a single system

### DIFF
--- a/internal/database/gen/follows.sql.go
+++ b/internal/database/gen/follows.sql.go
@@ -9,97 +9,137 @@ import (
 	"context"
 )
 
-const countFollowers = `-- name: CountFollowers :one
-SELECT COUNT(*)::INTEGER FROM user_follows WHERE followed_id = $1
+const countUserFollowers = `-- name: CountUserFollowers :one
+SELECT COUNT(*)::INTEGER FROM user_follows
+WHERE follow_type = 'user' AND target_id = $1
 `
 
-func (q *Queries) CountFollowers(ctx context.Context, followedID string) (int32, error) {
-	row := q.db.QueryRow(ctx, countFollowers, followedID)
+func (q *Queries) CountUserFollowers(ctx context.Context, targetID string) (int32, error) {
+	row := q.db.QueryRow(ctx, countUserFollowers, targetID)
 	var column_1 int32
 	err := row.Scan(&column_1)
 	return column_1, err
 }
 
-const countFollowing = `-- name: CountFollowing :one
-SELECT COUNT(*)::INTEGER FROM user_follows WHERE follower_id = $1
+const countUserFollowing = `-- name: CountUserFollowing :one
+SELECT COUNT(*)::INTEGER FROM user_follows
+WHERE follow_type = 'user' AND user_id = $1
 `
 
-func (q *Queries) CountFollowing(ctx context.Context, followerID string) (int32, error) {
-	row := q.db.QueryRow(ctx, countFollowing, followerID)
+func (q *Queries) CountUserFollowing(ctx context.Context, userID string) (int32, error) {
+	row := q.db.QueryRow(ctx, countUserFollowing, userID)
 	var column_1 int32
 	err := row.Scan(&column_1)
 	return column_1, err
 }
 
 const createFollow = `-- name: CreateFollow :exec
-WITH ins AS (
-    INSERT INTO user_follows (id, follower_id, followed_id)
-    VALUES (gen_random_uuid()::text, $1, $2)
-    ON CONFLICT (follower_id, followed_id) DO NOTHING
-    RETURNING follower_id, followed_id
-)
-SELECT follower_id, followed_id FROM ins
+INSERT INTO user_follows (user_id, follow_type, target_id, email_frequency, unsubscribe_token)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (user_id, follow_type, target_id) DO UPDATE SET
+    email_frequency = EXCLUDED.email_frequency,
+    unsubscribe_token = CASE WHEN EXCLUDED.unsubscribe_token != '' THEN EXCLUDED.unsubscribe_token ELSE user_follows.unsubscribe_token END
 `
 
 type CreateFollowParams struct {
-	FollowerID string `json:"follower_id"`
-	FollowedID string `json:"followed_id"`
+	UserID           string `json:"user_id"`
+	FollowType       string `json:"follow_type"`
+	TargetID         string `json:"target_id"`
+	EmailFrequency   string `json:"email_frequency"`
+	UnsubscribeToken string `json:"unsubscribe_token"`
 }
 
 func (q *Queries) CreateFollow(ctx context.Context, arg CreateFollowParams) error {
-	_, err := q.db.Exec(ctx, createFollow, arg.FollowerID, arg.FollowedID)
+	_, err := q.db.Exec(ctx, createFollow,
+		arg.UserID,
+		arg.FollowType,
+		arg.TargetID,
+		arg.EmailFrequency,
+		arg.UnsubscribeToken,
+	)
 	return err
 }
 
 const deleteFollow = `-- name: DeleteFollow :exec
-DELETE FROM user_follows WHERE follower_id = $1 AND followed_id = $2
+DELETE FROM user_follows WHERE user_id = $1 AND follow_type = $2 AND target_id = $3
 `
 
 type DeleteFollowParams struct {
-	FollowerID string `json:"follower_id"`
-	FollowedID string `json:"followed_id"`
+	UserID     string `json:"user_id"`
+	FollowType string `json:"follow_type"`
+	TargetID   string `json:"target_id"`
 }
 
 func (q *Queries) DeleteFollow(ctx context.Context, arg DeleteFollowParams) error {
-	_, err := q.db.Exec(ctx, deleteFollow, arg.FollowerID, arg.FollowedID)
+	_, err := q.db.Exec(ctx, deleteFollow, arg.UserID, arg.FollowType, arg.TargetID)
 	return err
+}
+
+const getFollow = `-- name: GetFollow :one
+SELECT id, user_id, follow_type, target_id, email_frequency, unsubscribe_token, last_notified, created FROM user_follows
+WHERE user_id = $1 AND follow_type = $2 AND target_id = $3
+LIMIT 1
+`
+
+type GetFollowParams struct {
+	UserID     string `json:"user_id"`
+	FollowType string `json:"follow_type"`
+	TargetID   string `json:"target_id"`
+}
+
+func (q *Queries) GetFollow(ctx context.Context, arg GetFollowParams) (UserFollow, error) {
+	row := q.db.QueryRow(ctx, getFollow, arg.UserID, arg.FollowType, arg.TargetID)
+	var i UserFollow
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.FollowType,
+		&i.TargetID,
+		&i.EmailFrequency,
+		&i.UnsubscribeToken,
+		&i.LastNotified,
+		&i.Created,
+	)
+	return i, err
 }
 
 const isFollowing = `-- name: IsFollowing :one
 SELECT EXISTS(
-    SELECT 1 FROM user_follows WHERE follower_id = $1 AND followed_id = $2
+    SELECT 1 FROM user_follows WHERE user_id = $1 AND follow_type = $2 AND target_id = $3
 ) AS is_following
 `
 
 type IsFollowingParams struct {
-	FollowerID string `json:"follower_id"`
-	FollowedID string `json:"followed_id"`
+	UserID     string `json:"user_id"`
+	FollowType string `json:"follow_type"`
+	TargetID   string `json:"target_id"`
 }
 
 func (q *Queries) IsFollowing(ctx context.Context, arg IsFollowingParams) (bool, error) {
-	row := q.db.QueryRow(ctx, isFollowing, arg.FollowerID, arg.FollowedID)
+	row := q.db.QueryRow(ctx, isFollowing, arg.UserID, arg.FollowType, arg.TargetID)
 	var is_following bool
 	err := row.Scan(&is_following)
 	return is_following, err
 }
 
-const listFollowedIDs = `-- name: ListFollowedIDs :many
-SELECT followed_id FROM user_follows WHERE follower_id = $1
+const listFollowedUserIDs = `-- name: ListFollowedUserIDs :many
+SELECT target_id FROM user_follows
+WHERE user_id = $1 AND follow_type = 'user'
 `
 
-func (q *Queries) ListFollowedIDs(ctx context.Context, followerID string) ([]string, error) {
-	rows, err := q.db.Query(ctx, listFollowedIDs, followerID)
+func (q *Queries) ListFollowedUserIDs(ctx context.Context, userID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listFollowedUserIDs, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 	items := []string{}
 	for rows.Next() {
-		var followed_id string
-		if err := rows.Scan(&followed_id); err != nil {
+		var target_id string
+		if err := rows.Scan(&target_id); err != nil {
 			return nil, err
 		}
-		items = append(items, followed_id)
+		items = append(items, target_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -107,22 +147,23 @@ func (q *Queries) ListFollowedIDs(ctx context.Context, followerID string) ([]str
 	return items, nil
 }
 
-const listFollowers = `-- name: ListFollowers :many
+const listFollowerUsers = `-- name: ListFollowerUsers :many
 SELECT u.id, u.email, u.username, u.password_hash, u.old_password, u.avatar, u.points, u.verified, u.is_admin, u.deleted, u.created, u.updated, u.follower_count, u.following_count FROM users u
-JOIN user_follows uf ON uf.follower_id = u.id
-WHERE uf.followed_id = $1
+JOIN user_follows uf ON uf.user_id = u.id
+WHERE uf.follow_type = 'user' AND uf.target_id = $1
 ORDER BY uf.created DESC
 LIMIT $2 OFFSET $3
 `
 
-type ListFollowersParams struct {
-	FollowedID string `json:"followed_id"`
-	Limit      int32  `json:"limit"`
-	Offset     int32  `json:"offset"`
+type ListFollowerUsersParams struct {
+	TargetID string `json:"target_id"`
+	Limit    int32  `json:"limit"`
+	Offset   int32  `json:"offset"`
 }
 
-func (q *Queries) ListFollowers(ctx context.Context, arg ListFollowersParams) ([]User, error) {
-	rows, err := q.db.Query(ctx, listFollowers, arg.FollowedID, arg.Limit, arg.Offset)
+// User-specific queries for profile follower counts
+func (q *Queries) ListFollowerUsers(ctx context.Context, arg ListFollowerUsersParams) ([]User, error) {
+	rows, err := q.db.Query(ctx, listFollowerUsers, arg.TargetID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -156,22 +197,22 @@ func (q *Queries) ListFollowers(ctx context.Context, arg ListFollowersParams) ([
 	return items, nil
 }
 
-const listFollowing = `-- name: ListFollowing :many
+const listFollowingUsers = `-- name: ListFollowingUsers :many
 SELECT u.id, u.email, u.username, u.password_hash, u.old_password, u.avatar, u.points, u.verified, u.is_admin, u.deleted, u.created, u.updated, u.follower_count, u.following_count FROM users u
-JOIN user_follows uf ON uf.followed_id = u.id
-WHERE uf.follower_id = $1
+JOIN user_follows uf ON uf.target_id = u.id
+WHERE uf.follow_type = 'user' AND uf.user_id = $1
 ORDER BY uf.created DESC
 LIMIT $2 OFFSET $3
 `
 
-type ListFollowingParams struct {
-	FollowerID string `json:"follower_id"`
-	Limit      int32  `json:"limit"`
-	Offset     int32  `json:"offset"`
+type ListFollowingUsersParams struct {
+	UserID string `json:"user_id"`
+	Limit  int32  `json:"limit"`
+	Offset int32  `json:"offset"`
 }
 
-func (q *Queries) ListFollowing(ctx context.Context, arg ListFollowingParams) ([]User, error) {
-	rows, err := q.db.Query(ctx, listFollowing, arg.FollowerID, arg.Limit, arg.Offset)
+func (q *Queries) ListFollowingUsers(ctx context.Context, arg ListFollowingUsersParams) ([]User, error) {
+	rows, err := q.db.Query(ctx, listFollowingUsers, arg.UserID, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -203,6 +244,198 @@ func (q *Queries) ListFollowing(ctx context.Context, arg ListFollowingParams) ([
 		return nil, err
 	}
 	return items, nil
+}
+
+const listFollowsByFrequency = `-- name: ListFollowsByFrequency :many
+SELECT id, user_id, follow_type, target_id, email_frequency, unsubscribe_token, last_notified, created FROM user_follows
+WHERE email_frequency = $1
+ORDER BY user_id, follow_type
+`
+
+func (q *Queries) ListFollowsByFrequency(ctx context.Context, emailFrequency string) ([]UserFollow, error) {
+	rows, err := q.db.Query(ctx, listFollowsByFrequency, emailFrequency)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserFollow{}
+	for rows.Next() {
+		var i UserFollow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.FollowType,
+			&i.TargetID,
+			&i.EmailFrequency,
+			&i.UnsubscribeToken,
+			&i.LastNotified,
+			&i.Created,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listFollowsByTarget = `-- name: ListFollowsByTarget :many
+SELECT id, user_id, follow_type, target_id, email_frequency, unsubscribe_token, last_notified, created FROM user_follows
+WHERE follow_type = $1 AND target_id = $2
+ORDER BY created ASC
+`
+
+type ListFollowsByTargetParams struct {
+	FollowType string `json:"follow_type"`
+	TargetID   string `json:"target_id"`
+}
+
+func (q *Queries) ListFollowsByTarget(ctx context.Context, arg ListFollowsByTargetParams) ([]UserFollow, error) {
+	rows, err := q.db.Query(ctx, listFollowsByTarget, arg.FollowType, arg.TargetID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserFollow{}
+	for rows.Next() {
+		var i UserFollow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.FollowType,
+			&i.TargetID,
+			&i.EmailFrequency,
+			&i.UnsubscribeToken,
+			&i.LastNotified,
+			&i.Created,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listFollowsByUser = `-- name: ListFollowsByUser :many
+SELECT id, user_id, follow_type, target_id, email_frequency, unsubscribe_token, last_notified, created FROM user_follows
+WHERE user_id = $1
+ORDER BY created DESC
+`
+
+func (q *Queries) ListFollowsByUser(ctx context.Context, userID string) ([]UserFollow, error) {
+	rows, err := q.db.Query(ctx, listFollowsByUser, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserFollow{}
+	for rows.Next() {
+		var i UserFollow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.FollowType,
+			&i.TargetID,
+			&i.EmailFrequency,
+			&i.UnsubscribeToken,
+			&i.LastNotified,
+			&i.Created,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listFollowsByUserAndType = `-- name: ListFollowsByUserAndType :many
+SELECT id, user_id, follow_type, target_id, email_frequency, unsubscribe_token, last_notified, created FROM user_follows
+WHERE user_id = $1 AND follow_type = $2
+ORDER BY created DESC
+`
+
+type ListFollowsByUserAndTypeParams struct {
+	UserID     string `json:"user_id"`
+	FollowType string `json:"follow_type"`
+}
+
+func (q *Queries) ListFollowsByUserAndType(ctx context.Context, arg ListFollowsByUserAndTypeParams) ([]UserFollow, error) {
+	rows, err := q.db.Query(ctx, listFollowsByUserAndType, arg.UserID, arg.FollowType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserFollow{}
+	for rows.Next() {
+		var i UserFollow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.FollowType,
+			&i.TargetID,
+			&i.EmailFrequency,
+			&i.UnsubscribeToken,
+			&i.LastNotified,
+			&i.Created,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const unsubscribeFollow = `-- name: UnsubscribeFollow :exec
+UPDATE user_follows SET email_frequency = 'off'
+WHERE unsubscribe_token = $1 AND unsubscribe_token != ''
+`
+
+func (q *Queries) UnsubscribeFollow(ctx context.Context, unsubscribeToken string) error {
+	_, err := q.db.Exec(ctx, unsubscribeFollow, unsubscribeToken)
+	return err
+}
+
+const updateFollowFrequency = `-- name: UpdateFollowFrequency :exec
+UPDATE user_follows SET email_frequency = $4
+WHERE user_id = $1 AND follow_type = $2 AND target_id = $3
+`
+
+type UpdateFollowFrequencyParams struct {
+	UserID         string `json:"user_id"`
+	FollowType     string `json:"follow_type"`
+	TargetID       string `json:"target_id"`
+	EmailFrequency string `json:"email_frequency"`
+}
+
+func (q *Queries) UpdateFollowFrequency(ctx context.Context, arg UpdateFollowFrequencyParams) error {
+	_, err := q.db.Exec(ctx, updateFollowFrequency,
+		arg.UserID,
+		arg.FollowType,
+		arg.TargetID,
+		arg.EmailFrequency,
+	)
+	return err
+}
+
+const updateFollowLastNotified = `-- name: UpdateFollowLastNotified :exec
+UPDATE user_follows SET last_notified = NOW()
+WHERE id = $1
+`
+
+func (q *Queries) UpdateFollowLastNotified(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, updateFollowLastNotified, id)
+	return err
 }
 
 const updateFollowerCountDecrement = `-- name: UpdateFollowerCountDecrement :exec

--- a/internal/database/gen/models.go
+++ b/internal/database/gen/models.go
@@ -648,17 +648,6 @@ type SearchTermModeration struct {
 	CheckedAt time.Time `json:"checked_at"`
 }
 
-type SectionSubscription struct {
-	ID               string    `json:"id"`
-	UserID           string    `json:"user_id"`
-	SubscriptionType string    `json:"subscription_type"`
-	TargetID         string    `json:"target_id"`
-	Frequency        string    `json:"frequency"`
-	UnsubscribeToken string    `json:"unsubscribe_token"`
-	Created          time.Time `json:"created"`
-	Updated          time.Time `json:"updated"`
-}
-
 type Session struct {
 	ID        string    `json:"id"`
 	UserID    string    `json:"user_id"`
@@ -761,10 +750,14 @@ type UserDisplayedBadge struct {
 }
 
 type UserFollow struct {
-	ID         string    `json:"id"`
-	FollowerID string    `json:"follower_id"`
-	FollowedID string    `json:"followed_id"`
-	Created    time.Time `json:"created"`
+	ID               string             `json:"id"`
+	UserID           string             `json:"user_id"`
+	FollowType       string             `json:"follow_type"`
+	TargetID         string             `json:"target_id"`
+	EmailFrequency   string             `json:"email_frequency"`
+	UnsubscribeToken string             `json:"unsubscribe_token"`
+	LastNotified     pgtype.Timestamptz `json:"last_notified"`
+	Created          time.Time          `json:"created"`
 }
 
 type UserKnownIp struct {

--- a/internal/database/gen/newsletters.sql.go
+++ b/internal/database/gen/newsletters.sql.go
@@ -139,45 +139,6 @@ func (q *Queries) CreateSearchAlert(ctx context.Context, arg CreateSearchAlertPa
 	return i, err
 }
 
-const createSectionSubscription = `-- name: CreateSectionSubscription :one
-INSERT INTO section_subscriptions (user_id, subscription_type, target_id, frequency, unsubscribe_token)
-VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (user_id, subscription_type, target_id) DO UPDATE SET
-    frequency = EXCLUDED.frequency,
-    updated = NOW()
-RETURNING id, user_id, subscription_type, target_id, frequency, unsubscribe_token, created, updated
-`
-
-type CreateSectionSubscriptionParams struct {
-	UserID           string `json:"user_id"`
-	SubscriptionType string `json:"subscription_type"`
-	TargetID         string `json:"target_id"`
-	Frequency        string `json:"frequency"`
-	UnsubscribeToken string `json:"unsubscribe_token"`
-}
-
-func (q *Queries) CreateSectionSubscription(ctx context.Context, arg CreateSectionSubscriptionParams) (SectionSubscription, error) {
-	row := q.db.QueryRow(ctx, createSectionSubscription,
-		arg.UserID,
-		arg.SubscriptionType,
-		arg.TargetID,
-		arg.Frequency,
-		arg.UnsubscribeToken,
-	)
-	var i SectionSubscription
-	err := row.Scan(
-		&i.ID,
-		&i.UserID,
-		&i.SubscriptionType,
-		&i.TargetID,
-		&i.Frequency,
-		&i.UnsubscribeToken,
-		&i.Created,
-		&i.Updated,
-	)
-	return i, err
-}
-
 const deleteSearchAlert = `-- name: DeleteSearchAlert :exec
 DELETE FROM search_alerts WHERE id = $1 AND user_id = $2
 `
@@ -189,20 +150,6 @@ type DeleteSearchAlertParams struct {
 
 func (q *Queries) DeleteSearchAlert(ctx context.Context, arg DeleteSearchAlertParams) error {
 	_, err := q.db.Exec(ctx, deleteSearchAlert, arg.ID, arg.UserID)
-	return err
-}
-
-const deleteSectionSubscription = `-- name: DeleteSectionSubscription :exec
-DELETE FROM section_subscriptions WHERE id = $1 AND user_id = $2
-`
-
-type DeleteSectionSubscriptionParams struct {
-	ID     string `json:"id"`
-	UserID string `json:"user_id"`
-}
-
-func (q *Queries) DeleteSectionSubscription(ctx context.Context, arg DeleteSectionSubscriptionParams) error {
-	_, err := q.db.Exec(ctx, deleteSectionSubscription, arg.ID, arg.UserID)
 	return err
 }
 
@@ -279,41 +226,6 @@ func (q *Queries) ListActiveSearchAlerts(ctx context.Context, limit int32) ([]Se
 			&i.LastChecked,
 			&i.LastNotified,
 			&i.Active,
-			&i.UnsubscribeToken,
-			&i.Created,
-			&i.Updated,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listAllSectionSubscriptions = `-- name: ListAllSectionSubscriptions :many
-SELECT id, user_id, subscription_type, target_id, frequency, unsubscribe_token, created, updated FROM section_subscriptions
-WHERE frequency != 'off'
-ORDER BY subscription_type, target_id
-`
-
-func (q *Queries) ListAllSectionSubscriptions(ctx context.Context) ([]SectionSubscription, error) {
-	rows, err := q.db.Query(ctx, listAllSectionSubscriptions)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []SectionSubscription{}
-	for rows.Next() {
-		var i SectionSubscription
-		if err := rows.Scan(
-			&i.ID,
-			&i.UserID,
-			&i.SubscriptionType,
-			&i.TargetID,
-			&i.Frequency,
 			&i.UnsubscribeToken,
 			&i.Created,
 			&i.Updated,
@@ -486,81 +398,6 @@ func (q *Queries) ListSearchAlertsByUser(ctx context.Context, userID string) ([]
 	return items, nil
 }
 
-const listSectionSubscriptionsByTarget = `-- name: ListSectionSubscriptionsByTarget :many
-SELECT id, user_id, subscription_type, target_id, frequency, unsubscribe_token, created, updated FROM section_subscriptions
-WHERE subscription_type = $1 AND target_id = $2
-ORDER BY created ASC
-`
-
-type ListSectionSubscriptionsByTargetParams struct {
-	SubscriptionType string `json:"subscription_type"`
-	TargetID         string `json:"target_id"`
-}
-
-func (q *Queries) ListSectionSubscriptionsByTarget(ctx context.Context, arg ListSectionSubscriptionsByTargetParams) ([]SectionSubscription, error) {
-	rows, err := q.db.Query(ctx, listSectionSubscriptionsByTarget, arg.SubscriptionType, arg.TargetID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []SectionSubscription{}
-	for rows.Next() {
-		var i SectionSubscription
-		if err := rows.Scan(
-			&i.ID,
-			&i.UserID,
-			&i.SubscriptionType,
-			&i.TargetID,
-			&i.Frequency,
-			&i.UnsubscribeToken,
-			&i.Created,
-			&i.Updated,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listSectionSubscriptionsByUser = `-- name: ListSectionSubscriptionsByUser :many
-SELECT id, user_id, subscription_type, target_id, frequency, unsubscribe_token, created, updated FROM section_subscriptions
-WHERE user_id = $1
-ORDER BY created DESC
-`
-
-func (q *Queries) ListSectionSubscriptionsByUser(ctx context.Context, userID string) ([]SectionSubscription, error) {
-	rows, err := q.db.Query(ctx, listSectionSubscriptionsByUser, userID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []SectionSubscription{}
-	for rows.Next() {
-		var i SectionSubscription
-		if err := rows.Scan(
-			&i.ID,
-			&i.UserID,
-			&i.SubscriptionType,
-			&i.TargetID,
-			&i.Frequency,
-			&i.UnsubscribeToken,
-			&i.Created,
-			&i.Updated,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const unsubscribeNewsletter = `-- name: UnsubscribeNewsletter :exec
 UPDATE newsletter_subscribers SET confirmed = false, updated = NOW()
 WHERE unsubscribe_token = $1
@@ -578,16 +415,6 @@ WHERE unsubscribe_token = $1
 
 func (q *Queries) UnsubscribeSearchAlert(ctx context.Context, unsubscribeToken string) error {
 	_, err := q.db.Exec(ctx, unsubscribeSearchAlert, unsubscribeToken)
-	return err
-}
-
-const unsubscribeSectionSubscription = `-- name: UnsubscribeSectionSubscription :exec
-UPDATE section_subscriptions SET frequency = 'off', updated = NOW()
-WHERE unsubscribe_token = $1
-`
-
-func (q *Queries) UnsubscribeSectionSubscription(ctx context.Context, unsubscribeToken string) error {
-	_, err := q.db.Exec(ctx, unsubscribeSectionSubscription, unsubscribeToken)
 	return err
 }
 

--- a/internal/database/gen/querier.go
+++ b/internal/database/gen/querier.go
@@ -42,8 +42,6 @@ type Querier interface {
 	CountCollectionsForAdmin(ctx context.Context, filter string) (int64, error)
 	CountCommentsBySchematic(ctx context.Context, schematicID *string) (int64, error)
 	CountCommentsForAdmin(ctx context.Context, arg CountCommentsForAdminParams) (int64, error)
-	CountFollowers(ctx context.Context, followedID string) (int32, error)
-	CountFollowing(ctx context.Context, followerID string) (int32, error)
 	CountGuidesForAdmin(ctx context.Context, filter string) (int64, error)
 	CountPointLogByReason(ctx context.Context, arg CountPointLogByReasonParams) (int32, error)
 	CountSchematicVariationsBySchematicAndUser(ctx context.Context, arg CountSchematicVariationsBySchematicAndUserParams) (int32, error)
@@ -57,6 +55,8 @@ type Querier interface {
 	CountUnresolvedCommentReportsByAuthor(ctx context.Context, authorID *string) (int64, error)
 	CountUserCollections(ctx context.Context, authorID *string) (int64, error)
 	CountUserComments(ctx context.Context, authorID *string) (int64, error)
+	CountUserFollowers(ctx context.Context, targetID string) (int32, error)
+	CountUserFollowing(ctx context.Context, userID string) (int32, error)
 	CountUserGuides(ctx context.Context, authorID *string) (int64, error)
 	CountUserMessagesSinceLastModerator(ctx context.Context, threadID string) (int64, error)
 	CountUserSchematics(ctx context.Context, authorID *string) (int32, error)
@@ -93,7 +93,6 @@ type Querier interface {
 	CreateSearchAlert(ctx context.Context, arg CreateSearchAlertParams) (SearchAlert, error)
 	CreateSearchClick(ctx context.Context, arg CreateSearchClickParams) error
 	CreateSearchConversion(ctx context.Context, arg CreateSearchConversionParams) error
-	CreateSectionSubscription(ctx context.Context, arg CreateSectionSubscriptionParams) (SectionSubscription, error)
 	CreateSession(ctx context.Context, arg CreateSessionParams) (Session, error)
 	CreateTOTPBackupCode(ctx context.Context, arg CreateTOTPBackupCodeParams) error
 	CreateTag(ctx context.Context, arg CreateTagParams) (SchematicTag, error)
@@ -128,7 +127,6 @@ type Querier interface {
 	DeleteSchematicVideo(ctx context.Context, arg DeleteSchematicVideoParams) error
 	DeleteSchematicVideosBySchematic(ctx context.Context, schematicID string) error
 	DeleteSearchAlert(ctx context.Context, arg DeleteSearchAlertParams) error
-	DeleteSectionSubscription(ctx context.Context, arg DeleteSectionSubscriptionParams) error
 	DeleteSession(ctx context.Context, id string) error
 	DeleteSocialLink(ctx context.Context, arg DeleteSocialLinkParams) error
 	DeleteTOTP(ctx context.Context, userID string) error
@@ -170,6 +168,7 @@ type Querier interface {
 	GetDownloadTokenByID(ctx context.Context, id string) (DownloadToken, error)
 	GetExternalAuth(ctx context.Context, arg GetExternalAuthParams) (ExternalAuth, error)
 	GetExternalAuthByUserAndProvider(ctx context.Context, arg GetExternalAuthByUserAndProviderParams) (ExternalAuth, error)
+	GetFollow(ctx context.Context, arg GetFollowParams) (UserFollow, error)
 	GetGuideByID(ctx context.Context, id string) (Guide, error)
 	GetGuideByIDAdmin(ctx context.Context, id string) (Guide, error)
 	GetGuideBySlug(ctx context.Context, slug string) (Guide, error)
@@ -259,7 +258,6 @@ type Querier interface {
 	ListAdminEmails(ctx context.Context) ([]string, error)
 	ListAllApprovedSchematicsForIndex(ctx context.Context) ([]Schematic, error)
 	ListAllCategories(ctx context.Context) ([]SchematicCategory, error)
-	ListAllSectionSubscriptions(ctx context.Context) ([]SectionSubscription, error)
 	ListAllTags(ctx context.Context) ([]SchematicTag, error)
 	ListAllTempUploads(ctx context.Context, arg ListAllTempUploadsParams) ([]ListAllTempUploadsRow, error)
 	ListApprovedSchematicIDsAndCreated(ctx context.Context) ([]ListApprovedSchematicIDsAndCreatedRow, error)
@@ -282,9 +280,14 @@ type Querier interface {
 	ListExternalAuthsByUser(ctx context.Context, userID string) ([]ExternalAuth, error)
 	ListFeaturedCollections(ctx context.Context, limit int32) ([]Collection, error)
 	ListFeaturedSchematics(ctx context.Context, limit int32) ([]Schematic, error)
-	ListFollowedIDs(ctx context.Context, followerID string) ([]string, error)
-	ListFollowers(ctx context.Context, arg ListFollowersParams) ([]User, error)
-	ListFollowing(ctx context.Context, arg ListFollowingParams) ([]User, error)
+	ListFollowedUserIDs(ctx context.Context, userID string) ([]string, error)
+	// User-specific queries for profile follower counts
+	ListFollowerUsers(ctx context.Context, arg ListFollowerUsersParams) ([]User, error)
+	ListFollowingUsers(ctx context.Context, arg ListFollowingUsersParams) ([]User, error)
+	ListFollowsByFrequency(ctx context.Context, emailFrequency string) ([]UserFollow, error)
+	ListFollowsByTarget(ctx context.Context, arg ListFollowsByTargetParams) ([]UserFollow, error)
+	ListFollowsByUser(ctx context.Context, userID string) ([]UserFollow, error)
+	ListFollowsByUserAndType(ctx context.Context, arg ListFollowsByUserAndTypeParams) ([]UserFollow, error)
 	ListGuideTranslations(ctx context.Context, guideID string) ([]GuideTranslation, error)
 	ListGuides(ctx context.Context, arg ListGuidesParams) ([]Guide, error)
 	ListGuidesForAdmin(ctx context.Context, arg ListGuidesForAdminParams) ([]Guide, error)
@@ -329,8 +332,6 @@ type Querier interface {
 	ListSchematicsForSitemap(ctx context.Context) ([]ListSchematicsForSitemapRow, error)
 	ListSchematicsWithoutTranslation(ctx context.Context, arg ListSchematicsWithoutTranslationParams) ([]ListSchematicsWithoutTranslationRow, error)
 	ListSearchAlertsByUser(ctx context.Context, userID string) ([]SearchAlert, error)
-	ListSectionSubscriptionsByTarget(ctx context.Context, arg ListSectionSubscriptionsByTargetParams) ([]SectionSubscription, error)
-	ListSectionSubscriptionsByUser(ctx context.Context, userID string) ([]SectionSubscription, error)
 	ListSocialLinksByPlatform(ctx context.Context, platform string) ([]UserSocialLink, error)
 	ListSocialLinksByUser(ctx context.Context, userID string) ([]UserSocialLink, error)
 	ListStaleRedditLinks(ctx context.Context, limit int32) ([]SchematicRedditLink, error)
@@ -405,11 +406,13 @@ type Querier interface {
 	SoftDeleteSchematicsByAuthor(ctx context.Context, authorID *string) error
 	SoftDeleteUser(ctx context.Context, id string) error
 	SumUserPoints(ctx context.Context, userID string) (int32, error)
+	UnsubscribeFollow(ctx context.Context, unsubscribeToken string) error
 	UnsubscribeNewsletter(ctx context.Context, unsubscribeToken string) error
 	UnsubscribeSearchAlert(ctx context.Context, unsubscribeToken string) error
-	UnsubscribeSectionSubscription(ctx context.Context, unsubscribeToken string) error
 	UpdateCollection(ctx context.Context, arg UpdateCollectionParams) (Collection, error)
 	UpdateCollectionCollageURL(ctx context.Context, arg UpdateCollectionCollageURLParams) error
+	UpdateFollowFrequency(ctx context.Context, arg UpdateFollowFrequencyParams) error
+	UpdateFollowLastNotified(ctx context.Context, id string) error
 	UpdateFollowerCountDecrement(ctx context.Context, id string) error
 	UpdateFollowerCountIncrement(ctx context.Context, id string) error
 	UpdateFollowingCountDecrement(ctx context.Context, id string) error

--- a/internal/database/migrations/059_unified_follows.down.sql
+++ b/internal/database/migrations/059_unified_follows.down.sql
@@ -1,0 +1,42 @@
+-- Recreate old user_follows table
+CREATE TABLE old_user_follows (
+    id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+    follower_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    followed_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX idx_old_user_follows_unique ON old_user_follows (follower_id, followed_id);
+CREATE INDEX idx_old_user_follows_followed ON old_user_follows (followed_id);
+CREATE INDEX idx_old_user_follows_follower ON old_user_follows (follower_id);
+
+INSERT INTO old_user_follows (id, follower_id, followed_id, created)
+SELECT id, user_id, target_id, created
+FROM user_follows
+WHERE follow_type = 'user'
+ON CONFLICT DO NOTHING;
+
+-- Recreate section_subscriptions
+CREATE TABLE section_subscriptions (
+    id                TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+    user_id           TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    subscription_type TEXT NOT NULL,
+    target_id         TEXT NOT NULL DEFAULT '',
+    frequency         TEXT NOT NULL DEFAULT 'weekly',
+    unsubscribe_token TEXT NOT NULL DEFAULT '',
+    created           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX idx_section_subs_unique ON section_subscriptions (user_id, subscription_type, target_id);
+
+INSERT INTO section_subscriptions (user_id, subscription_type, target_id, frequency, unsubscribe_token, created)
+SELECT user_id, follow_type, target_id, email_frequency, unsubscribe_token, created
+FROM user_follows
+WHERE follow_type IN ('category', 'tag') AND email_frequency != 'off'
+ON CONFLICT DO NOTHING;
+
+-- Drop unified and rename
+DROP TABLE user_follows;
+ALTER TABLE old_user_follows RENAME TO user_follows;
+ALTER INDEX idx_old_user_follows_unique RENAME TO idx_user_follows_unique;
+ALTER INDEX idx_old_user_follows_followed RENAME TO idx_user_follows_followed;
+ALTER INDEX idx_old_user_follows_follower RENAME TO idx_user_follows_follower;

--- a/internal/database/migrations/059_unified_follows.up.sql
+++ b/internal/database/migrations/059_unified_follows.up.sql
@@ -1,0 +1,44 @@
+-- Unify user_follows and section_subscriptions into a single follows table
+-- that supports following users, categories, feeds (latest/trending), searches, and mods.
+
+-- 1. Create the new unified table
+CREATE TABLE unified_follows (
+    id               TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+    user_id          TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    follow_type      TEXT NOT NULL,    -- 'user','category','latest','trending','highest_rated','search','mod'
+    target_id        TEXT NOT NULL DEFAULT '',
+    email_frequency  TEXT NOT NULL DEFAULT 'off', -- 'realtime','daily','weekly','off'
+    unsubscribe_token TEXT NOT NULL DEFAULT '',
+    last_notified    TIMESTAMPTZ,
+    created          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX idx_unified_follows_unique ON unified_follows (user_id, follow_type, target_id);
+CREATE INDEX idx_unified_follows_user ON unified_follows (user_id);
+CREATE INDEX idx_unified_follows_target ON unified_follows (follow_type, target_id);
+CREATE INDEX idx_unified_follows_email ON unified_follows (email_frequency) WHERE email_frequency != 'off';
+
+-- 2. Migrate existing user follows
+INSERT INTO unified_follows (id, user_id, follow_type, target_id, email_frequency, created)
+SELECT id, follower_id, 'user', followed_id, 'off', created
+FROM user_follows
+ON CONFLICT DO NOTHING;
+
+-- 3. Migrate section subscriptions (category/tag follows with email)
+INSERT INTO unified_follows (user_id, follow_type, target_id, email_frequency, unsubscribe_token, created)
+SELECT user_id, subscription_type, target_id, frequency, unsubscribe_token, created
+FROM section_subscriptions
+WHERE frequency != 'off'
+ON CONFLICT (user_id, follow_type, target_id) DO UPDATE SET
+    email_frequency = EXCLUDED.email_frequency,
+    unsubscribe_token = EXCLUDED.unsubscribe_token;
+
+-- 4. Drop old tables
+DROP TABLE user_follows;
+DROP TABLE section_subscriptions;
+
+-- 5. Rename to user_follows
+ALTER TABLE unified_follows RENAME TO user_follows;
+ALTER INDEX idx_unified_follows_unique RENAME TO idx_user_follows_unique;
+ALTER INDEX idx_unified_follows_user RENAME TO idx_user_follows_user;
+ALTER INDEX idx_unified_follows_target RENAME TO idx_user_follows_target;
+ALTER INDEX idx_unified_follows_email RENAME TO idx_user_follows_email;

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -2167,49 +2167,159 @@ func (sl *SocialLinkStoreImpl) ListByPlatform(ctx context.Context, platform stri
 }
 
 // --------------------------------------------------------------------------
-// FollowStoreImpl implements store.FollowStore.
+// FollowStoreImpl implements store.FollowStore (unified follows).
 // --------------------------------------------------------------------------
 
 type FollowStoreImpl struct{ q *db.Queries }
 
-func (fs *FollowStoreImpl) Follow(ctx context.Context, followerID, followedID string) error {
+func followFromDB(row db.UserFollow) store.UserFollow {
+	return store.UserFollow{
+		ID:               row.ID,
+		UserID:           row.UserID,
+		FollowType:       row.FollowType,
+		TargetID:         row.TargetID,
+		EmailFrequency:   row.EmailFrequency,
+		UnsubscribeToken: row.UnsubscribeToken,
+		LastNotified:     fromPgTimestamptz(row.LastNotified),
+		Created:          row.Created,
+	}
+}
+
+func (fs *FollowStoreImpl) Follow(ctx context.Context, userID, followType, targetID, emailFrequency string) error {
+	token := ""
+	if emailFrequency != "off" {
+		b := make([]byte, 16)
+		_, _ = rand.Read(b)
+		token = hex.EncodeToString(b)
+	}
 	if err := fs.q.CreateFollow(ctx, db.CreateFollowParams{
-		FollowerID: followerID,
-		FollowedID: followedID,
+		UserID:           userID,
+		FollowType:       followType,
+		TargetID:         targetID,
+		EmailFrequency:   emailFrequency,
+		UnsubscribeToken: token,
 	}); err != nil {
 		return err
 	}
-	if err := fs.q.UpdateFollowerCountIncrement(ctx, followedID); err != nil {
-		return err
+	if followType == "user" {
+		_ = fs.q.UpdateFollowerCountIncrement(ctx, targetID)
+		_ = fs.q.UpdateFollowingCountIncrement(ctx, userID)
 	}
-	return fs.q.UpdateFollowingCountIncrement(ctx, followerID)
+	return nil
 }
 
-func (fs *FollowStoreImpl) Unfollow(ctx context.Context, followerID, followedID string) error {
+func (fs *FollowStoreImpl) Unfollow(ctx context.Context, userID, followType, targetID string) error {
 	if err := fs.q.DeleteFollow(ctx, db.DeleteFollowParams{
-		FollowerID: followerID,
-		FollowedID: followedID,
+		UserID:     userID,
+		FollowType: followType,
+		TargetID:   targetID,
 	}); err != nil {
 		return err
 	}
-	if err := fs.q.UpdateFollowerCountDecrement(ctx, followedID); err != nil {
-		return err
+	if followType == "user" {
+		_ = fs.q.UpdateFollowerCountDecrement(ctx, targetID)
+		_ = fs.q.UpdateFollowingCountDecrement(ctx, userID)
 	}
-	return fs.q.UpdateFollowingCountDecrement(ctx, followerID)
+	return nil
 }
 
-func (fs *FollowStoreImpl) IsFollowing(ctx context.Context, followerID, followedID string) (bool, error) {
-	return fs.q.IsFollowing(ctx, db.IsFollowingParams{
-		FollowerID: followerID,
-		FollowedID: followedID,
+func (fs *FollowStoreImpl) UpdateFrequency(ctx context.Context, userID, followType, targetID, emailFrequency string) error {
+	return fs.q.UpdateFollowFrequency(ctx, db.UpdateFollowFrequencyParams{
+		UserID:         userID,
+		FollowType:     followType,
+		TargetID:       targetID,
+		EmailFrequency: emailFrequency,
 	})
 }
 
-func (fs *FollowStoreImpl) ListFollowers(ctx context.Context, userID string, limit, offset int) ([]store.User, error) {
-	rows, err := fs.q.ListFollowers(ctx, db.ListFollowersParams{
-		FollowedID: userID,
-		Limit:      int32(limit),
-		Offset:     int32(offset),
+func (fs *FollowStoreImpl) IsFollowing(ctx context.Context, userID, followType, targetID string) (bool, error) {
+	return fs.q.IsFollowing(ctx, db.IsFollowingParams{
+		UserID:     userID,
+		FollowType: followType,
+		TargetID:   targetID,
+	})
+}
+
+func (fs *FollowStoreImpl) GetFollow(ctx context.Context, userID, followType, targetID string) (*store.UserFollow, error) {
+	row, err := fs.q.GetFollow(ctx, db.GetFollowParams{
+		UserID:     userID,
+		FollowType: followType,
+		TargetID:   targetID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	f := followFromDB(row)
+	return &f, nil
+}
+
+func (fs *FollowStoreImpl) ListByUser(ctx context.Context, userID string) ([]store.UserFollow, error) {
+	rows, err := fs.q.ListFollowsByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.UserFollow, len(rows))
+	for i, r := range rows {
+		result[i] = followFromDB(r)
+	}
+	return result, nil
+}
+
+func (fs *FollowStoreImpl) ListByUserAndType(ctx context.Context, userID, followType string) ([]store.UserFollow, error) {
+	rows, err := fs.q.ListFollowsByUserAndType(ctx, db.ListFollowsByUserAndTypeParams{
+		UserID:     userID,
+		FollowType: followType,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.UserFollow, len(rows))
+	for i, r := range rows {
+		result[i] = followFromDB(r)
+	}
+	return result, nil
+}
+
+func (fs *FollowStoreImpl) ListByTarget(ctx context.Context, followType, targetID string) ([]store.UserFollow, error) {
+	rows, err := fs.q.ListFollowsByTarget(ctx, db.ListFollowsByTargetParams{
+		FollowType: followType,
+		TargetID:   targetID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.UserFollow, len(rows))
+	for i, r := range rows {
+		result[i] = followFromDB(r)
+	}
+	return result, nil
+}
+
+func (fs *FollowStoreImpl) ListByFrequency(ctx context.Context, emailFrequency string) ([]store.UserFollow, error) {
+	rows, err := fs.q.ListFollowsByFrequency(ctx, emailFrequency)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.UserFollow, len(rows))
+	for i, r := range rows {
+		result[i] = followFromDB(r)
+	}
+	return result, nil
+}
+
+func (fs *FollowStoreImpl) Unsubscribe(ctx context.Context, unsubscribeToken string) error {
+	return fs.q.UnsubscribeFollow(ctx, unsubscribeToken)
+}
+
+func (fs *FollowStoreImpl) UpdateLastNotified(ctx context.Context, id string) error {
+	return fs.q.UpdateFollowLastNotified(ctx, id)
+}
+
+func (fs *FollowStoreImpl) ListFollowerUsers(ctx context.Context, userID string, limit, offset int) ([]store.User, error) {
+	rows, err := fs.q.ListFollowerUsers(ctx, db.ListFollowerUsersParams{
+		TargetID: userID,
+		Limit:    int32(limit),
+		Offset:   int32(offset),
 	})
 	if err != nil {
 		return nil, err
@@ -2221,11 +2331,11 @@ func (fs *FollowStoreImpl) ListFollowers(ctx context.Context, userID string, lim
 	return result, nil
 }
 
-func (fs *FollowStoreImpl) ListFollowing(ctx context.Context, userID string, limit, offset int) ([]store.User, error) {
-	rows, err := fs.q.ListFollowing(ctx, db.ListFollowingParams{
-		FollowerID: userID,
-		Limit:      int32(limit),
-		Offset:     int32(offset),
+func (fs *FollowStoreImpl) ListFollowingUsers(ctx context.Context, userID string, limit, offset int) ([]store.User, error) {
+	rows, err := fs.q.ListFollowingUsers(ctx, db.ListFollowingUsersParams{
+		UserID: userID,
+		Limit:  int32(limit),
+		Offset: int32(offset),
 	})
 	if err != nil {
 		return nil, err
@@ -2238,17 +2348,12 @@ func (fs *FollowStoreImpl) ListFollowing(ctx context.Context, userID string, lim
 }
 
 func (fs *FollowStoreImpl) CountFollowers(ctx context.Context, userID string) (int, error) {
-	cnt, err := fs.q.CountFollowers(ctx, userID)
+	cnt, err := fs.q.CountUserFollowers(ctx, userID)
 	return int(cnt), err
 }
 
-func (fs *FollowStoreImpl) CountFollowing(ctx context.Context, userID string) (int, error) {
-	cnt, err := fs.q.CountFollowing(ctx, userID)
-	return int(cnt), err
-}
-
-func (fs *FollowStoreImpl) ListFollowedIDs(ctx context.Context, followerID string) ([]string, error) {
-	return fs.q.ListFollowedIDs(ctx, followerID)
+func (fs *FollowStoreImpl) ListFollowedUserIDs(ctx context.Context, userID string) ([]string, error) {
+	return fs.q.ListFollowedUserIDs(ctx, userID)
 }
 
 // TranslationStoreImpl implements store.TranslationStore.
@@ -3753,7 +3858,6 @@ func NewStoreFromPool(pool *pgxpool.Pool) *store.Store {
 		Notifications:        &NotificationStoreImpl{q: q},
 		Newsletters:          &NewsletterStoreImpl{q: q},
 		SearchAlerts:         &SearchAlertStoreImpl{q: q},
-		SectionSubscriptions: &SectionSubscriptionStoreImpl{q: q},
 		ZeroResults:          &ZeroResultStoreImpl{q: q},
 		Security:             &SecurityStoreImpl{q: q, pool: pool},
 	}
@@ -4321,8 +4425,7 @@ var (
 	_ store.NotificationStore        = (*NotificationStoreImpl)(nil)
 	_ store.NewsletterStore          = (*NewsletterStoreImpl)(nil)
 	_ store.SearchAlertStore         = (*SearchAlertStoreImpl)(nil)
-	_ store.SectionSubscriptionStore = (*SectionSubscriptionStoreImpl)(nil)
-	_ store.ZeroResultStore          = (*ZeroResultStoreImpl)(nil)
+	_ store.ZeroResultStore = (*ZeroResultStoreImpl)(nil)
 )
 
 // --------------------------------------------------------------------------
@@ -5104,92 +5207,6 @@ func (s *SearchAlertStoreImpl) UpdateLastChecked(ctx context.Context, id string)
 
 func (s *SearchAlertStoreImpl) UpdateLastNotified(ctx context.Context, id string) error {
 	return s.q.UpdateSearchAlertLastNotified(ctx, id)
-}
-
-// --------------------------------------------------------------------------
-// SectionSubscription Store Implementation
-// --------------------------------------------------------------------------
-
-type SectionSubscriptionStoreImpl struct{ q *db.Queries }
-
-func sectionSubscriptionFromDB(row db.SectionSubscription) store.SectionSubscription {
-	return store.SectionSubscription{
-		ID:               row.ID,
-		UserID:           row.UserID,
-		SubscriptionType: row.SubscriptionType,
-		TargetID:         row.TargetID,
-		Frequency:        row.Frequency,
-		UnsubscribeToken: row.UnsubscribeToken,
-		Created:          row.Created,
-		Updated:          row.Updated,
-	}
-}
-
-func (s *SectionSubscriptionStoreImpl) Create(ctx context.Context, sub *store.SectionSubscription) error {
-	row, err := s.q.CreateSectionSubscription(ctx, db.CreateSectionSubscriptionParams{
-		UserID:           sub.UserID,
-		SubscriptionType: sub.SubscriptionType,
-		TargetID:         sub.TargetID,
-		Frequency:        sub.Frequency,
-		UnsubscribeToken: sub.UnsubscribeToken,
-	})
-	if err != nil {
-		return err
-	}
-	sub.ID = row.ID
-	sub.Created = row.Created
-	sub.Updated = row.Updated
-	return nil
-}
-
-func (s *SectionSubscriptionStoreImpl) ListByUser(ctx context.Context, userID string) ([]store.SectionSubscription, error) {
-	rows, err := s.q.ListSectionSubscriptionsByUser(ctx, userID)
-	if err != nil {
-		return nil, err
-	}
-	result := make([]store.SectionSubscription, len(rows))
-	for i, r := range rows {
-		result[i] = sectionSubscriptionFromDB(r)
-	}
-	return result, nil
-}
-
-func (s *SectionSubscriptionStoreImpl) ListByTarget(ctx context.Context, subscriptionType, targetID string) ([]store.SectionSubscription, error) {
-	rows, err := s.q.ListSectionSubscriptionsByTarget(ctx, db.ListSectionSubscriptionsByTargetParams{
-		SubscriptionType: subscriptionType,
-		TargetID:         targetID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	result := make([]store.SectionSubscription, len(rows))
-	for i, r := range rows {
-		result[i] = sectionSubscriptionFromDB(r)
-	}
-	return result, nil
-}
-
-func (s *SectionSubscriptionStoreImpl) Delete(ctx context.Context, id, userID string) error {
-	return s.q.DeleteSectionSubscription(ctx, db.DeleteSectionSubscriptionParams{
-		ID:     id,
-		UserID: userID,
-	})
-}
-
-func (s *SectionSubscriptionStoreImpl) Unsubscribe(ctx context.Context, unsubscribeToken string) error {
-	return s.q.UnsubscribeSectionSubscription(ctx, unsubscribeToken)
-}
-
-func (s *SectionSubscriptionStoreImpl) ListAll(ctx context.Context) ([]store.SectionSubscription, error) {
-	rows, err := s.q.ListAllSectionSubscriptions(ctx)
-	if err != nil {
-		return nil, err
-	}
-	result := make([]store.SectionSubscription, len(rows))
-	for i, r := range rows {
-		result[i] = sectionSubscriptionFromDB(r)
-	}
-	return result, nil
 }
 
 // --------------------------------------------------------------------------

--- a/internal/database/queries/follows.sql
+++ b/internal/database/queries/follows.sql
@@ -1,11 +1,81 @@
 -- name: CreateFollow :exec
-WITH ins AS (
-    INSERT INTO user_follows (id, follower_id, followed_id)
-    VALUES (gen_random_uuid()::text, $1, $2)
-    ON CONFLICT (follower_id, followed_id) DO NOTHING
-    RETURNING follower_id, followed_id
-)
-SELECT * FROM ins;
+INSERT INTO user_follows (user_id, follow_type, target_id, email_frequency, unsubscribe_token)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (user_id, follow_type, target_id) DO UPDATE SET
+    email_frequency = EXCLUDED.email_frequency,
+    unsubscribe_token = CASE WHEN EXCLUDED.unsubscribe_token != '' THEN EXCLUDED.unsubscribe_token ELSE user_follows.unsubscribe_token END;
+
+-- name: DeleteFollow :exec
+DELETE FROM user_follows WHERE user_id = $1 AND follow_type = $2 AND target_id = $3;
+
+-- name: IsFollowing :one
+SELECT EXISTS(
+    SELECT 1 FROM user_follows WHERE user_id = $1 AND follow_type = $2 AND target_id = $3
+) AS is_following;
+
+-- name: GetFollow :one
+SELECT * FROM user_follows
+WHERE user_id = $1 AND follow_type = $2 AND target_id = $3
+LIMIT 1;
+
+-- name: UpdateFollowFrequency :exec
+UPDATE user_follows SET email_frequency = $4
+WHERE user_id = $1 AND follow_type = $2 AND target_id = $3;
+
+-- name: UpdateFollowLastNotified :exec
+UPDATE user_follows SET last_notified = NOW()
+WHERE id = $1;
+
+-- name: UnsubscribeFollow :exec
+UPDATE user_follows SET email_frequency = 'off'
+WHERE unsubscribe_token = $1 AND unsubscribe_token != '';
+
+-- name: ListFollowsByUser :many
+SELECT * FROM user_follows
+WHERE user_id = $1
+ORDER BY created DESC;
+
+-- name: ListFollowsByUserAndType :many
+SELECT * FROM user_follows
+WHERE user_id = $1 AND follow_type = $2
+ORDER BY created DESC;
+
+-- name: ListFollowsByTarget :many
+SELECT * FROM user_follows
+WHERE follow_type = $1 AND target_id = $2
+ORDER BY created ASC;
+
+-- name: ListFollowsByFrequency :many
+SELECT * FROM user_follows
+WHERE email_frequency = $1
+ORDER BY user_id, follow_type;
+
+-- name: ListFollowedUserIDs :many
+SELECT target_id FROM user_follows
+WHERE user_id = $1 AND follow_type = 'user';
+
+-- User-specific queries for profile follower counts
+-- name: ListFollowerUsers :many
+SELECT u.* FROM users u
+JOIN user_follows uf ON uf.user_id = u.id
+WHERE uf.follow_type = 'user' AND uf.target_id = $1
+ORDER BY uf.created DESC
+LIMIT $2 OFFSET $3;
+
+-- name: ListFollowingUsers :many
+SELECT u.* FROM users u
+JOIN user_follows uf ON uf.target_id = u.id
+WHERE uf.follow_type = 'user' AND uf.user_id = $1
+ORDER BY uf.created DESC
+LIMIT $2 OFFSET $3;
+
+-- name: CountUserFollowers :one
+SELECT COUNT(*)::INTEGER FROM user_follows
+WHERE follow_type = 'user' AND target_id = $1;
+
+-- name: CountUserFollowing :one
+SELECT COUNT(*)::INTEGER FROM user_follows
+WHERE follow_type = 'user' AND user_id = $1;
 
 -- name: UpdateFollowerCountIncrement :exec
 UPDATE users SET follower_count = follower_count + 1 WHERE id = $1;
@@ -13,39 +83,8 @@ UPDATE users SET follower_count = follower_count + 1 WHERE id = $1;
 -- name: UpdateFollowingCountIncrement :exec
 UPDATE users SET following_count = following_count + 1 WHERE id = $1;
 
--- name: DeleteFollow :exec
-DELETE FROM user_follows WHERE follower_id = $1 AND followed_id = $2;
-
 -- name: UpdateFollowerCountDecrement :exec
 UPDATE users SET follower_count = GREATEST(follower_count - 1, 0) WHERE id = $1;
 
 -- name: UpdateFollowingCountDecrement :exec
 UPDATE users SET following_count = GREATEST(following_count - 1, 0) WHERE id = $1;
-
--- name: IsFollowing :one
-SELECT EXISTS(
-    SELECT 1 FROM user_follows WHERE follower_id = $1 AND followed_id = $2
-) AS is_following;
-
--- name: ListFollowers :many
-SELECT u.* FROM users u
-JOIN user_follows uf ON uf.follower_id = u.id
-WHERE uf.followed_id = $1
-ORDER BY uf.created DESC
-LIMIT $2 OFFSET $3;
-
--- name: ListFollowing :many
-SELECT u.* FROM users u
-JOIN user_follows uf ON uf.followed_id = u.id
-WHERE uf.follower_id = $1
-ORDER BY uf.created DESC
-LIMIT $2 OFFSET $3;
-
--- name: CountFollowers :one
-SELECT COUNT(*)::INTEGER FROM user_follows WHERE followed_id = $1;
-
--- name: CountFollowing :one
-SELECT COUNT(*)::INTEGER FROM user_follows WHERE follower_id = $1;
-
--- name: ListFollowedIDs :many
-SELECT followed_id FROM user_follows WHERE follower_id = $1;

--- a/internal/database/queries/newsletters.sql
+++ b/internal/database/queries/newsletters.sql
@@ -74,35 +74,5 @@ WHERE id = $1;
 UPDATE search_alerts SET last_notified = NOW(), updated = NOW()
 WHERE id = $1;
 
--- name: CreateSectionSubscription :one
-INSERT INTO section_subscriptions (user_id, subscription_type, target_id, frequency, unsubscribe_token)
-VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (user_id, subscription_type, target_id) DO UPDATE SET
-    frequency = EXCLUDED.frequency,
-    updated = NOW()
-RETURNING *;
-
--- name: ListSectionSubscriptionsByUser :many
-SELECT * FROM section_subscriptions
-WHERE user_id = $1
-ORDER BY created DESC;
-
--- name: ListSectionSubscriptionsByTarget :many
-SELECT * FROM section_subscriptions
-WHERE subscription_type = $1 AND target_id = $2
-ORDER BY created ASC;
-
--- name: DeleteSectionSubscription :exec
-DELETE FROM section_subscriptions WHERE id = $1 AND user_id = $2;
-
--- name: UnsubscribeSectionSubscription :exec
-UPDATE section_subscriptions SET frequency = 'off', updated = NOW()
-WHERE unsubscribe_token = $1;
-
 -- name: UpdateNewsletterIssueSentAt :exec
 UPDATE newsletter_issues SET sent_at = NOW() WHERE id = $1;
-
--- name: ListAllSectionSubscriptions :many
-SELECT * FROM section_subscriptions
-WHERE frequency != 'off'
-ORDER BY subscription_type, target_id;

--- a/internal/jobs/section_update.go
+++ b/internal/jobs/section_update.go
@@ -30,15 +30,6 @@ func (w *SectionUpdateWorker) Work(ctx context.Context, job *river.Job[SectionUp
 		return nil
 	}
 
-	subs, err := w.deps.Store.SectionSubscriptions.ListAll(ctx)
-	if err != nil {
-		return fmt.Errorf("section update: list subscriptions: %w", err)
-	}
-	if len(subs) == 0 {
-		slog.Info("section update: no subscriptions")
-		return nil
-	}
-
 	now := time.Now().UTC()
 	isMonday := now.Weekday() == time.Monday
 
@@ -47,14 +38,29 @@ func (w *SectionUpdateWorker) Work(ctx context.Context, job *river.Job[SectionUp
 		baseURL = "https://createmod.com"
 	}
 
-	sent := 0
-	for _, sub := range subs {
-		if sub.Frequency == "weekly" && !isMonday {
-			continue
-		}
+	dailyFollows, err := w.deps.Store.Follows.ListByFrequency(ctx, "daily")
+	if err != nil {
+		return fmt.Errorf("section update: list daily follows: %w", err)
+	}
 
+	var weeklyFollows []store.UserFollow
+	if isMonday {
+		weeklyFollows, err = w.deps.Store.Follows.ListByFrequency(ctx, "weekly")
+		if err != nil {
+			return fmt.Errorf("section update: list weekly follows: %w", err)
+		}
+	}
+
+	allFollows := append(dailyFollows, weeklyFollows...)
+	if len(allFollows) == 0 {
+		slog.Info("section update: no follows with email frequency due")
+		return nil
+	}
+
+	sent := 0
+	for _, follow := range allFollows {
 		var since time.Time
-		switch sub.Frequency {
+		switch follow.EmailFrequency {
 		case "daily":
 			since = now.Add(-24 * time.Hour)
 		case "weekly":
@@ -63,17 +69,17 @@ func (w *SectionUpdateWorker) Work(ctx context.Context, job *river.Job[SectionUp
 			continue
 		}
 
-		schematics := w.findNewSchematics(ctx, sub, since)
+		schematics := w.findNewSchematics(ctx, follow, since)
 		if len(schematics) == 0 {
 			continue
 		}
 
-		user, err := w.deps.Store.Users.GetUserByID(ctx, sub.UserID)
+		user, err := w.deps.Store.Users.GetUserByID(ctx, follow.UserID)
 		if err != nil || user.Email == "" {
 			continue
 		}
 
-		sectionName := w.resolveSectionName(ctx, sub)
+		sectionName := w.resolveFollowName(ctx, follow)
 		subject := fmt.Sprintf("New schematics in %s", sectionName)
 
 		var lines []string
@@ -90,7 +96,7 @@ func (w *SectionUpdateWorker) Work(ctx context.Context, job *river.Job[SectionUp
 			lines = append(lines, fmt.Sprintf("- %s\n  %s/schematics/%s", title, baseURL, s.Name))
 		}
 
-		unsubLink := fmt.Sprintf("%s/unsubscribe-section?token=%s", baseURL, sub.UnsubscribeToken)
+		unsubLink := fmt.Sprintf("%s/unsubscribe?token=%s", baseURL, follow.UnsubscribeToken)
 		lines = append(lines, fmt.Sprintf("\nTo unsubscribe: %s", unsubLink))
 
 		bodyText := strings.Join(lines, "\n")
@@ -102,20 +108,45 @@ func (w *SectionUpdateWorker) Work(ctx context.Context, job *river.Job[SectionUp
 			HTML:    htmlBody,
 		}
 		if err := w.deps.Mail.Send(msg); err != nil {
-			slog.Warn("section update: send failed", "user", sub.UserID, "err", err)
+			slog.Warn("section update: send failed", "user", follow.UserID, "err", err)
 		} else {
+			_ = w.deps.Store.Follows.UpdateLastNotified(ctx, follow.ID)
 			sent++
 		}
 	}
 
-	slog.Info("section update digest completed", "subscriptions", len(subs), "sent", sent)
+	slog.Info("section update digest completed", "follows", len(allFollows), "sent", sent)
 	return nil
 }
 
-func (w *SectionUpdateWorker) findNewSchematics(ctx context.Context, sub store.SectionSubscription, since time.Time) []store.Schematic {
-	switch sub.SubscriptionType {
+func (w *SectionUpdateWorker) findNewSchematics(ctx context.Context, follow store.UserFollow, since time.Time) []store.Schematic {
+	switch follow.FollowType {
 	case "category":
-		schematics, err := w.deps.Store.Schematics.ListByCategoryIDs(ctx, []string{sub.TargetID}, nil, 10)
+		schematics, err := w.deps.Store.Schematics.ListByCategoryIDs(ctx, []string{follow.TargetID}, nil, 10)
+		if err != nil {
+			return nil
+		}
+		var recent []store.Schematic
+		for _, s := range schematics {
+			if s.Created.After(since) {
+				recent = append(recent, s)
+			}
+		}
+		return recent
+	case "user":
+		schematics, err := w.deps.Store.Schematics.ListByAuthor(ctx, follow.TargetID, 10, 0)
+		if err != nil {
+			return nil
+		}
+		var recent []store.Schematic
+		for _, s := range schematics {
+			if s.Created.After(since) {
+				recent = append(recent, s)
+			}
+		}
+		return recent
+	case "latest":
+		schematics, err := w.deps.Store.Schematics.ListApproved(ctx, 10, 0)
 		if err != nil {
 			return nil
 		}
@@ -127,7 +158,7 @@ func (w *SectionUpdateWorker) findNewSchematics(ctx context.Context, sub store.S
 		}
 		return recent
 	case "tag":
-		tag, err := w.deps.Store.Tags.GetByID(ctx, sub.TargetID)
+		tag, err := w.deps.Store.Tags.GetByID(ctx, follow.TargetID)
 		if err != nil || tag == nil {
 			return nil
 		}
@@ -145,7 +176,7 @@ func (w *SectionUpdateWorker) findNewSchematics(ctx context.Context, sub store.S
 				continue
 			}
 			for _, tid := range tagIDs {
-				if tid == sub.TargetID {
+				if tid == follow.TargetID {
 					recent = append(recent, s)
 					break
 				}
@@ -160,21 +191,37 @@ func (w *SectionUpdateWorker) findNewSchematics(ctx context.Context, sub store.S
 	}
 }
 
-func (w *SectionUpdateWorker) resolveSectionName(ctx context.Context, sub store.SectionSubscription) string {
-	switch sub.SubscriptionType {
+func (w *SectionUpdateWorker) resolveFollowName(ctx context.Context, follow store.UserFollow) string {
+	switch follow.FollowType {
 	case "category":
-		cat, err := w.deps.Store.Categories.GetByID(ctx, sub.TargetID)
+		cat, err := w.deps.Store.Categories.GetByID(ctx, follow.TargetID)
 		if err == nil && cat != nil {
 			return cat.Name
 		}
 		return "your subscribed category"
 	case "tag":
-		tag, err := w.deps.Store.Tags.GetByID(ctx, sub.TargetID)
+		tag, err := w.deps.Store.Tags.GetByID(ctx, follow.TargetID)
 		if err == nil && tag != nil {
 			return tag.Name
 		}
 		return "your subscribed tag"
+	case "user":
+		user, err := w.deps.Store.Users.GetUserByID(ctx, follow.TargetID)
+		if err == nil {
+			return user.Username
+		}
+		return "a creator you follow"
+	case "latest":
+		return "Latest Schematics"
+	case "trending":
+		return "Trending Schematics"
+	case "highest_rated":
+		return "Highest Rated Schematics"
+	case "mod":
+		return "a mod you follow"
+	case "search":
+		return "a saved search"
 	default:
-		return "your subscribed section"
+		return "your subscription"
 	}
 }

--- a/internal/pages/api_follows.go
+++ b/internal/pages/api_follows.go
@@ -26,7 +26,7 @@ func FollowHandler(appStore *store.Store) func(e *server.RequestEvent) error {
 			return &server.APIError{Status: http.StatusNotFound, Message: "User not found"}
 		}
 
-		if err := appStore.Follows.Follow(ctx, followerID, followedID); err != nil {
+		if err := appStore.Follows.Follow(ctx, followerID, "user", followedID, "off"); err != nil {
 			return err
 		}
 
@@ -47,7 +47,7 @@ func UnfollowHandler(appStore *store.Store) func(e *server.RequestEvent) error {
 		followerID := authenticatedUserID(e)
 
 		ctx := e.Request.Context()
-		if err := appStore.Follows.Unfollow(ctx, followerID, followedID); err != nil {
+		if err := appStore.Follows.Unfollow(ctx, followerID, "user", followedID); err != nil {
 			return err
 		}
 

--- a/internal/pages/following.go
+++ b/internal/pages/following.go
@@ -19,6 +19,7 @@ var followingTemplates = append([]string{
 type FollowingData struct {
 	Schematics    []models.Schematic
 	HasSchematics bool
+	Follows       []store.UserFollow
 	DefaultData
 }
 
@@ -35,8 +36,13 @@ func FollowingHandler(cacheService *cache.Service, registry *server.Registry, ap
 		ctx := e.Request.Context()
 		userID := authenticatedUserID(e)
 
-		followedIDs, err := appStore.Follows.ListFollowedIDs(ctx, userID)
-		if err != nil || len(followedIDs) == 0 {
+		follows, err := appStore.Follows.ListByUser(ctx, userID)
+		if err == nil {
+			d.Follows = follows
+		}
+
+		followedUserIDs, err := appStore.Follows.ListFollowedUserIDs(ctx, userID)
+		if err != nil || len(followedUserIDs) == 0 {
 			html, err := registry.LoadFiles(followingTemplates...).Render(d)
 			if err != nil {
 				return err
@@ -45,7 +51,7 @@ func FollowingHandler(cacheService *cache.Service, registry *server.Registry, ap
 		}
 
 		var allSchematics []models.Schematic
-		for _, fid := range followedIDs {
+		for _, fid := range followedUserIDs {
 			schematics := findAuthorSchematicsFromStore(appStore, cacheService, "", fid, 20)
 			allSchematics = append(allSchematics, schematics...)
 		}

--- a/internal/pages/newsletter.go
+++ b/internal/pages/newsletter.go
@@ -80,7 +80,7 @@ func UnsubscribeHandler(registry *server.Registry, cacheService *cache.Service, 
 			ctx := e.Request.Context()
 			_ = appStore.Newsletters.Unsubscribe(ctx, token)
 			_ = appStore.SearchAlerts.Unsubscribe(ctx, token)
-			_ = appStore.SectionSubscriptions.Unsubscribe(ctx, token)
+			_ = appStore.Follows.Unsubscribe(ctx, token)
 			d.Success = true
 		}
 

--- a/internal/pages/profile.go
+++ b/internal/pages/profile.go
@@ -150,7 +150,7 @@ func showProfile(e *server.RequestEvent, appStore *store.Store, cacheService *ca
 	if currentUser := session.UserFromContext(ctx); currentUser != nil {
 		d.IsOwnProfile = currentUser.ID == user.ID
 		if !d.IsOwnProfile {
-			d.IsFollowing, _ = appStore.Follows.IsFollowing(ctx, currentUser.ID, user.ID)
+			d.IsFollowing, _ = appStore.Follows.IsFollowing(ctx, currentUser.ID, "user", user.ID)
 		}
 	}
 

--- a/internal/pages/user_subscriptions.go
+++ b/internal/pages/user_subscriptions.go
@@ -16,8 +16,8 @@ var userSubscriptionsTemplates = append([]string{
 
 type UserSubscriptionsData struct {
 	DefaultData
-	SearchAlerts         []store.SearchAlert
-	SectionSubscriptions []store.SectionSubscription
+	SearchAlerts []store.SearchAlert
+	Follows      []store.UserFollow
 }
 
 func UserSubscriptionsHandler(registry *server.Registry, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
@@ -43,9 +43,9 @@ func UserSubscriptionsHandler(registry *server.Registry, cacheService *cache.Ser
 			d.SearchAlerts = alerts
 		}
 
-		subs, err := appStore.SectionSubscriptions.ListByUser(ctx, userID)
+		follows, err := appStore.Follows.ListByUser(ctx, userID)
 		if err == nil {
-			d.SectionSubscriptions = subs
+			d.Follows = follows
 		}
 
 		html, err := registry.LoadFiles(userSubscriptionsTemplates...).Render(d)
@@ -96,45 +96,6 @@ func CreateSearchAlertHandler(appStore *store.Store) func(e *server.RequestEvent
 	}
 }
 
-func CreateSectionSubscriptionHandler(appStore *store.Store) func(e *server.RequestEvent) error {
-	return func(e *server.RequestEvent) error {
-		if ok, err := requireAuth(e); !ok {
-			return err
-		}
-
-		ctx := e.Request.Context()
-		userID := authenticatedUserID(e)
-
-		var body struct {
-			SubscriptionType string `json:"subscription_type"`
-			TargetID         string `json:"target_id"`
-			Frequency        string `json:"frequency"`
-		}
-		if err := json.NewDecoder(e.Request.Body).Decode(&body); err != nil {
-			return &server.APIError{Status: http.StatusBadRequest, Message: "invalid request body"}
-		}
-		if body.SubscriptionType == "" || body.TargetID == "" {
-			return &server.APIError{Status: http.StatusBadRequest, Message: "subscription_type and target_id are required"}
-		}
-		if body.Frequency == "" {
-			body.Frequency = "daily"
-		}
-
-		sub := &store.SectionSubscription{
-			UserID:           userID,
-			SubscriptionType: body.SubscriptionType,
-			TargetID:         body.TargetID,
-			Frequency:        body.Frequency,
-			UnsubscribeToken: randomHex(16),
-		}
-		if err := appStore.SectionSubscriptions.Create(ctx, sub); err != nil {
-			return &server.APIError{Status: http.StatusInternalServerError, Message: "failed to create subscription"}
-		}
-
-		return e.JSON(http.StatusCreated, map[string]string{"id": sub.ID})
-	}
-}
-
 func DeleteSearchAlertHandler(appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if ok, err := requireAuth(e); !ok {
@@ -153,7 +114,7 @@ func DeleteSearchAlertHandler(appStore *store.Store) func(e *server.RequestEvent
 	}
 }
 
-func DeleteSectionSubscriptionHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+func GenericFollowHandler(appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if ok, err := requireAuth(e); !ok {
 			return err
@@ -161,12 +122,87 @@ func DeleteSectionSubscriptionHandler(appStore *store.Store) func(e *server.Requ
 
 		ctx := e.Request.Context()
 		userID := authenticatedUserID(e)
-		subID := e.Request.PathValue("id")
 
-		if err := appStore.SectionSubscriptions.Delete(ctx, subID, userID); err != nil {
-			return &server.APIError{Status: http.StatusInternalServerError, Message: "failed to delete subscription"}
+		var body struct {
+			FollowType     string `json:"follow_type"`
+			TargetID       string `json:"target_id"`
+			EmailFrequency string `json:"email_frequency"`
+		}
+		if err := json.NewDecoder(e.Request.Body).Decode(&body); err != nil {
+			return &server.APIError{Status: http.StatusBadRequest, Message: "invalid request body"}
+		}
+		if body.FollowType == "" || body.TargetID == "" {
+			return &server.APIError{Status: http.StatusBadRequest, Message: "follow_type and target_id are required"}
+		}
+		if body.EmailFrequency == "" {
+			body.EmailFrequency = "daily"
 		}
 
-		return e.String(http.StatusOK, "")
+		if body.FollowType == "user" && body.TargetID == userID {
+			return &server.APIError{Status: http.StatusBadRequest, Message: "cannot follow yourself"}
+		}
+
+		if err := appStore.Follows.Follow(ctx, userID, body.FollowType, body.TargetID, body.EmailFrequency); err != nil {
+			return &server.APIError{Status: http.StatusInternalServerError, Message: "failed to create follow"}
+		}
+
+		return e.JSON(http.StatusCreated, map[string]string{"status": "ok"})
+	}
+}
+
+func GenericUnfollowHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if ok, err := requireAuth(e); !ok {
+			return err
+		}
+
+		ctx := e.Request.Context()
+		userID := authenticatedUserID(e)
+
+		var body struct {
+			FollowType string `json:"follow_type"`
+			TargetID   string `json:"target_id"`
+		}
+		if err := json.NewDecoder(e.Request.Body).Decode(&body); err != nil {
+			return &server.APIError{Status: http.StatusBadRequest, Message: "invalid request body"}
+		}
+		if body.FollowType == "" || body.TargetID == "" {
+			return &server.APIError{Status: http.StatusBadRequest, Message: "follow_type and target_id are required"}
+		}
+
+		if err := appStore.Follows.Unfollow(ctx, userID, body.FollowType, body.TargetID); err != nil {
+			return &server.APIError{Status: http.StatusInternalServerError, Message: "failed to unfollow"}
+		}
+
+		return e.JSON(http.StatusOK, map[string]string{"status": "ok"})
+	}
+}
+
+func UpdateFollowFrequencyHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if ok, err := requireAuth(e); !ok {
+			return err
+		}
+
+		ctx := e.Request.Context()
+		userID := authenticatedUserID(e)
+
+		var body struct {
+			FollowType     string `json:"follow_type"`
+			TargetID       string `json:"target_id"`
+			EmailFrequency string `json:"email_frequency"`
+		}
+		if err := json.NewDecoder(e.Request.Body).Decode(&body); err != nil {
+			return &server.APIError{Status: http.StatusBadRequest, Message: "invalid request body"}
+		}
+		if body.FollowType == "" || body.TargetID == "" || body.EmailFrequency == "" {
+			return &server.APIError{Status: http.StatusBadRequest, Message: "follow_type, target_id, and email_frequency are required"}
+		}
+
+		if err := appStore.Follows.UpdateFrequency(ctx, userID, body.FollowType, body.TargetID, body.EmailFrequency); err != nil {
+			return &server.APIError{Status: http.StatusInternalServerError, Message: "failed to update frequency"}
+		}
+
+		return e.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	}
 }

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -646,8 +646,9 @@ func Register(p RegisterParams) chi.Router {
 	r.Get("/settings/subscriptions", Adapt(pages.UserSubscriptionsHandler(registry, p.CacheService, p.AppStore)))
 	r.Post("/api/search-alerts", Adapt(pages.CreateSearchAlertHandler(p.AppStore)))
 	r.Delete("/settings/subscriptions/alerts/{id}", Adapt(pages.DeleteSearchAlertHandler(p.AppStore)))
-	r.Post("/api/section-subscriptions", Adapt(pages.CreateSectionSubscriptionHandler(p.AppStore)))
-	r.Delete("/settings/subscriptions/sections/{id}", Adapt(pages.DeleteSectionSubscriptionHandler(p.AppStore)))
+	r.Post("/api/follows", Adapt(pages.GenericFollowHandler(p.AppStore)))
+	r.Delete("/api/follows", Adapt(pages.GenericUnfollowHandler(p.AppStore)))
+	r.Put("/api/follows/frequency", Adapt(pages.UpdateFollowFrequencyHandler(p.AppStore)))
 
 	// Phase 4: Newsletters
 	r.Post("/api/newsletter/subscribe", Adapt(pages.NewsletterSubscribeHandler(p.AppStore)))

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -317,12 +317,16 @@ type SocialLink struct {
 	Updated  time.Time
 }
 
-// UserFollow represents a follow relationship between users.
+// UserFollow represents a unified follow (user, category, feed, search, mod).
 type UserFollow struct {
-	ID         string
-	FollowerID string
-	FollowedID string
-	Created    time.Time
+	ID               string
+	UserID           string
+	FollowType       string // "user","category","latest","trending","highest_rated","search","mod"
+	TargetID         string
+	EmailFrequency   string // "realtime","daily","weekly","off"
+	UnsubscribeToken string
+	LastNotified     *time.Time
+	Created          time.Time
 }
 
 // SchematicVideo represents a video linked to a schematic.
@@ -445,17 +449,6 @@ type SearchAlert struct {
 	Updated          time.Time
 }
 
-// SectionSubscription represents a category/section subscription.
-type SectionSubscription struct {
-	ID               string
-	UserID           string
-	SubscriptionType string
-	TargetID         string
-	Frequency        string
-	UnsubscribeToken string
-	Created          time.Time
-	Updated          time.Time
-}
 
 // ZeroResultSuggestion represents a suggestion for zero-result queries.
 type ZeroResultSuggestion struct {
@@ -936,16 +929,24 @@ type SocialLinkStore interface {
 	ListByPlatform(ctx context.Context, platform string) ([]SocialLink, error)
 }
 
-// FollowStore handles user follow relationships.
+// FollowStore handles unified follow relationships (users, categories, feeds, searches, mods).
 type FollowStore interface {
-	Follow(ctx context.Context, followerID, followedID string) error
-	Unfollow(ctx context.Context, followerID, followedID string) error
-	IsFollowing(ctx context.Context, followerID, followedID string) (bool, error)
-	ListFollowers(ctx context.Context, userID string, limit, offset int) ([]User, error)
-	ListFollowing(ctx context.Context, userID string, limit, offset int) ([]User, error)
+	Follow(ctx context.Context, userID, followType, targetID, emailFrequency string) error
+	Unfollow(ctx context.Context, userID, followType, targetID string) error
+	UpdateFrequency(ctx context.Context, userID, followType, targetID, emailFrequency string) error
+	IsFollowing(ctx context.Context, userID, followType, targetID string) (bool, error)
+	GetFollow(ctx context.Context, userID, followType, targetID string) (*UserFollow, error)
+	ListByUser(ctx context.Context, userID string) ([]UserFollow, error)
+	ListByUserAndType(ctx context.Context, userID, followType string) ([]UserFollow, error)
+	ListByTarget(ctx context.Context, followType, targetID string) ([]UserFollow, error)
+	ListByFrequency(ctx context.Context, emailFrequency string) ([]UserFollow, error)
+	Unsubscribe(ctx context.Context, unsubscribeToken string) error
+	UpdateLastNotified(ctx context.Context, id string) error
+	// User-specific helpers for profile follower/following counts and lists.
+	ListFollowerUsers(ctx context.Context, userID string, limit, offset int) ([]User, error)
+	ListFollowingUsers(ctx context.Context, userID string, limit, offset int) ([]User, error)
 	CountFollowers(ctx context.Context, userID string) (int, error)
-	CountFollowing(ctx context.Context, userID string) (int, error)
-	ListFollowedIDs(ctx context.Context, followerID string) ([]string, error)
+	ListFollowedUserIDs(ctx context.Context, userID string) ([]string, error)
 }
 
 // TranslationStore handles translations for all content types.
@@ -1394,15 +1395,6 @@ type SearchAlertStore interface {
 	UpdateLastNotified(ctx context.Context, id string) error
 }
 
-// SectionSubscriptionStore handles category/section subscriptions.
-type SectionSubscriptionStore interface {
-	Create(ctx context.Context, sub *SectionSubscription) error
-	ListByUser(ctx context.Context, userID string) ([]SectionSubscription, error)
-	ListByTarget(ctx context.Context, subscriptionType, targetID string) ([]SectionSubscription, error)
-	Delete(ctx context.Context, id, userID string) error
-	Unsubscribe(ctx context.Context, unsubscribeToken string) error
-	ListAll(ctx context.Context) ([]SectionSubscription, error)
-}
 
 // ZeroResultStore handles zero-result search suggestions.
 type ZeroResultStore interface {
@@ -1483,7 +1475,6 @@ type Store struct {
 	Notifications        NotificationStore
 	Newsletters          NewsletterStore
 	SearchAlerts         SearchAlertStore
-	SectionSubscriptions SectionSubscriptionStore
 	ZeroResults          ZeroResultStore
 	Security             SecurityStore
 }

--- a/template/following.html
+++ b/template/following.html
@@ -8,6 +8,32 @@
                 <div class="d-flex gap-3">
                     <div class="flex-grow-1 min-width-0">
                         <h2 class="mb-3">{{ T .Language "Following Feed" }}</h2>
+
+                        {{ if .Follows }}
+                        <div class="mb-4">
+                            <div class="d-flex flex-wrap gap-2">
+                                {{ range .Follows }}
+                                <span class="badge bg-secondary-lt d-inline-flex align-items-center gap-1" id="follow-badge-{{ .ID }}">
+                                    {{ if eq .FollowType "user" }}
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-inline" width="14" height="14" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0"/><path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2"/></svg>
+                                    {{ else if eq .FollowType "category" }}
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-inline" width="14" height="14" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 4h6v6h-6z"/><path d="M14 4h6v6h-6z"/><path d="M4 14h6v6h-6z"/><path d="M17 17m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0"/></svg>
+                                    {{ else if eq .FollowType "search" }}
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-inline" width="14" height="14" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/><path d="M21 21l-6 -6"/></svg>
+                                    {{ else }}
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-inline" width="14" height="14" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6"/><path d="M9 17v1a3 3 0 0 0 6 0v-1"/></svg>
+                                    {{ end }}
+                                    {{ .FollowType }}: {{ .TargetID }}
+                                    <span class="text-muted">({{ .EmailFrequency }})</span>
+                                </span>
+                                {{ end }}
+                            </div>
+                            <a href="/settings/subscriptions" class="btn btn-sm btn-outline-secondary mt-2">
+                                {{ T .Language "Manage Follows" }}
+                            </a>
+                        </div>
+                        {{ end }}
+
                         {{ if .HasSchematics }}
                         <div class="row row-cards">
                             {{ range .Schematics }}
@@ -18,7 +44,7 @@
                         <div class="empty">
                             <p class="empty-title">{{ T .Language "No schematics yet" }}</p>
                             <p class="empty-subtitle text-secondary">
-                                {{ T .Language "Follow creators to see their schematics here." }}
+                                {{ T .Language "Follow creators, categories, or feeds to see content here." }}
                             </p>
                         </div>
                         {{ end }}

--- a/template/index.html
+++ b/template/index.html
@@ -8,7 +8,14 @@
                 <div class="d-flex gap-3">
                     <div class="flex-grow-1 min-width-0">
                         <!-- Trending -->
-                        <h2 class="mb-3"><a href="/search?sort=8" class="text-reset text-decoration-none">{{ T .Language "Trending" }} &rarr;</a></h2>
+                        <div class="d-flex align-items-center mb-3">
+                            <h2 class="mb-0"><a href="/search?sort=8" class="text-reset text-decoration-none">{{ T .Language "Trending" }} &rarr;</a></h2>
+                            {{ if .IsAuthenticated }}
+                            <button class="btn btn-sm btn-ghost-primary ms-2 follow-btn" data-follow-type="trending" data-target-id="trending" title="{{ T .Language "Follow" }}">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="18" height="18" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6"/><path d="M9 17v1a3 3 0 0 0 6 0v-1"/></svg>
+                            </button>
+                            {{ end }}
+                        </div>
                         <div id="tab-panel-trending" class="tab-panel" data-trending-section="trending">
                             <div class="row g-3">
                                 {{ range .Trending }}
@@ -25,7 +32,14 @@
                         </div>
 
                         <!-- Latest -->
-                        <h2 class="mb-3 mt-4"><a href="/search?sort=2" class="text-reset text-decoration-none">{{ T .Language "Latest" }} &rarr;</a></h2>
+                        <div class="d-flex align-items-center mb-3 mt-4">
+                            <h2 class="mb-0"><a href="/search?sort=2" class="text-reset text-decoration-none">{{ T .Language "Latest" }} &rarr;</a></h2>
+                            {{ if .IsAuthenticated }}
+                            <button class="btn btn-sm btn-ghost-primary ms-2 follow-btn" data-follow-type="latest" data-target-id="latest" title="{{ T .Language "Follow" }}">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="18" height="18" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6"/><path d="M9 17v1a3 3 0 0 0 6 0v-1"/></svg>
+                            </button>
+                            {{ end }}
+                        </div>
                         <div id="tab-panel-latest" class="tab-panel">
                             <div class="row g-3">
                                 {{ range .Schematics }}
@@ -42,7 +56,14 @@
                         </div>
 
                         <!-- Highest Rated -->
-                        <h2 class="mb-3 mt-4"><a href="/search?sort=4" class="text-reset text-decoration-none">{{ T .Language "Highest Rated" }} &rarr;</a></h2>
+                        <div class="d-flex align-items-center mb-3 mt-4">
+                            <h2 class="mb-0"><a href="/search?sort=4" class="text-reset text-decoration-none">{{ T .Language "Highest Rated" }} &rarr;</a></h2>
+                            {{ if .IsAuthenticated }}
+                            <button class="btn btn-sm btn-ghost-primary ms-2 follow-btn" data-follow-type="highest_rated" data-target-id="highest_rated" title="{{ T .Language "Follow" }}">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="18" height="18" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6"/><path d="M9 17v1a3 3 0 0 0 6 0v-1"/></svg>
+                            </button>
+                            {{ end }}
+                        </div>
                         <div id="tab-panel-highest" class="tab-panel">
                             <div class="row g-3">
                                 {{ range .HighestRated }}
@@ -61,7 +82,14 @@
                         <!-- Categories -->
                         <h2 class="mb-3 mt-5">{{ T .Language "Categories" }}</h2>
                         {{ range .CategorySections }}
-                        <h3 class="mb-3 mt-4"><a href="/search?category={{ .Category.Key }}" class="text-reset text-decoration-none">{{ T $.Language .Category.Name }} &rarr;</a></h3>
+                        <div class="d-flex align-items-center mb-3 mt-4">
+                            <h3 class="mb-0"><a href="/search?category={{ .Category.Key }}" class="text-reset text-decoration-none">{{ T $.Language .Category.Name }} &rarr;</a></h3>
+                            {{ if $.IsAuthenticated }}
+                            <button class="btn btn-sm btn-ghost-primary ms-2 follow-btn" data-follow-type="category" data-target-id="{{ .Category.ID }}" title="{{ T $.Language "Follow" }}">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="18" height="18" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6"/><path d="M9 17v1a3 3 0 0 0 6 0v-1"/></svg>
+                            </button>
+                            {{ end }}
+                        </div>
                         <div id="tab-panel-cat-{{ .Category.Key }}" class="tab-panel" data-trending-section="cat-{{ .Category.Key }}">
                             <div class="row g-3">
                                 {{ range .Items }}
@@ -86,6 +114,28 @@
     </div>
 </div>
 {{template "foot.html" .}}
+<script>
+(function() {
+  document.querySelectorAll('.follow-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var followType = btn.dataset.followType;
+      var targetId = btn.dataset.targetId;
+      fetch('/api/follows', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({follow_type: followType, target_id: targetId, email_frequency: 'daily'})
+      }).then(function(resp) {
+        if (resp.ok) {
+          btn.classList.remove('btn-ghost-primary');
+          btn.classList.add('btn-primary');
+          btn.disabled = true;
+          btn.title = 'Following';
+        }
+      });
+    });
+  });
+})();
+</script>
 <script>
 (function() {
   document.querySelectorAll('[data-trending-section] a[href*="/schematics/"]').forEach(function(link, i) {

--- a/template/mod_detail.html
+++ b/template/mod_detail.html
@@ -20,6 +20,13 @@
                   {{ if .Mod.Description }}<div class="text-secondary">{{ .Mod.Description }}</div>
                   {{ else }}<div class="text-secondary">{{ .Subtitle }}</div>{{ end }}
                   <div class="d-flex flex-wrap gap-2 mt-2">
+                    {{ if $.IsAuthenticated }}
+                    <button class="btn btn-sm btn-outline-primary follow-mod-btn" data-mod-slug="{{ .Mod.Slug }}"
+                            onclick="followMod(this, '{{ .Mod.Slug }}')">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="18" height="18" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6"/><path d="M9 17v1a3 3 0 0 0 6 0v-1"/></svg>
+                      {{ T .Language "Follow" }}
+                    </button>
+                    {{ end }}
                     {{ if .Mod.ModrinthURL }}
                     <a href="{{ .Mod.ModrinthURL }}" class="btn btn-sm btn-modrinth" target="_blank" rel="noopener">
                       <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/><path d="M7 11l5 5l5 -5"/><path d="M12 4l0 12"/></svg>
@@ -37,6 +44,15 @@
               </div>
             </div>
           </div>
+        </div>
+        <div class="mb-3">
+          <form action="/search" method="get" class="input-group">
+            <input type="text" name="q" class="form-control" placeholder="{{ T .Language "Search schematics in" }} {{ .Mod.Name }}..." aria-label="{{ T .Language "Search" }}">
+            <input type="hidden" name="mod" value="{{ .Mod.Slug }}">
+            <button class="btn btn-primary" type="submit">
+              <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/><path d="M21 21l-6 -6"/></svg>
+            </button>
+          </form>
         </div>
         <div id="mod-results">
           <h3 class="mb-3">{{ .Subtitle }}</h3>
@@ -77,6 +93,22 @@
   </div>
 </div>
 {{template "foot.html" .}}
+<script>
+function followMod(btn, slug) {
+  fetch('/api/follows', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({follow_type: 'mod', target_id: slug, email_frequency: 'daily'})
+  }).then(function(resp) {
+    if (resp.ok) {
+      btn.classList.remove('btn-outline-primary');
+      btn.classList.add('btn-primary');
+      btn.disabled = true;
+      btn.textContent = 'Following';
+    }
+  });
+}
+</script>
 <script>
 window['nitroAds'].createAd('moddetail-video-nc-top-right', {
   "format": "video-nc",

--- a/template/mods.html
+++ b/template/mods.html
@@ -13,7 +13,10 @@
             </div>
           </div>
         </div>
-        <div class="row row-cards">
+        <div class="mb-3">
+          <input type="text" class="form-control" id="mod-filter" placeholder="{{ T .Language "Filter mods..." }}" aria-label="{{ T .Language "Filter mods" }}">
+        </div>
+        <div class="row row-cards" id="mods-grid">
           {{range .Mods}}
           <div class="col-12 col-sm-6 col-md-4 col-lg-3">
             <a href="/mods/{{ .Slug }}" class="d-block text-decoration-none">
@@ -54,3 +57,17 @@
   </div>
 </div>
 {{template "foot.html" .}}
+<script>
+(function() {
+  var filter = document.getElementById('mod-filter');
+  var grid = document.getElementById('mods-grid');
+  if (!filter || !grid) return;
+  filter.addEventListener('input', function() {
+    var q = filter.value.toLowerCase();
+    grid.querySelectorAll('.col-12').forEach(function(card) {
+      var name = card.querySelector('.card-title');
+      card.style.display = (name && name.textContent.toLowerCase().indexOf(q) !== -1) ? '' : 'none';
+    });
+  });
+})();
+</script>

--- a/template/user-subscriptions.html
+++ b/template/user-subscriptions.html
@@ -14,6 +14,69 @@
                                     <div class="card-body">
                                         <h2 class="mb-4">{{ T .Language "Subscriptions" }}</h2>
 
+                                        <h3 class="card-title">{{ T .Language "Follows" }}</h3>
+                                        <p class="text-secondary mb-3">{{ T .Language "Manage what you follow and how often you receive email notifications." }}</p>
+                                        {{ if .Follows }}
+                                        <div class="table-responsive mb-4">
+                                            <table class="table table-vcenter">
+                                                <thead>
+                                                    <tr>
+                                                        <th>{{ T .Language "Type" }}</th>
+                                                        <th>{{ T .Language "Target" }}</th>
+                                                        <th>{{ T .Language "Email Frequency" }}</th>
+                                                        <th class="w-1"></th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    {{ range .Follows }}
+                                                    <tr id="follow-{{ .ID }}">
+                                                        <td>
+                                                            {{ if eq .FollowType "user" }}
+                                                                <span class="badge bg-blue-lt">{{ T $.Language "Creator" }}</span>
+                                                            {{ else if eq .FollowType "category" }}
+                                                                <span class="badge bg-green-lt">{{ T $.Language "Category" }}</span>
+                                                            {{ else if eq .FollowType "latest" }}
+                                                                <span class="badge bg-cyan-lt">{{ T $.Language "Latest" }}</span>
+                                                            {{ else if eq .FollowType "trending" }}
+                                                                <span class="badge bg-orange-lt">{{ T $.Language "Trending" }}</span>
+                                                            {{ else if eq .FollowType "highest_rated" }}
+                                                                <span class="badge bg-yellow-lt">{{ T $.Language "Highest Rated" }}</span>
+                                                            {{ else if eq .FollowType "search" }}
+                                                                <span class="badge bg-purple-lt">{{ T $.Language "Search" }}</span>
+                                                            {{ else if eq .FollowType "mod" }}
+                                                                <span class="badge bg-red-lt">{{ T $.Language "Mod" }}</span>
+                                                            {{ else }}
+                                                                <span class="badge bg-secondary-lt">{{ .FollowType }}</span>
+                                                            {{ end }}
+                                                        </td>
+                                                        <td>{{ .TargetID }}</td>
+                                                        <td>
+                                                            <select class="form-select form-select-sm" style="width: auto;"
+                                                                    onchange="updateFollowFrequency('{{ .FollowType }}', '{{ .TargetID }}', this.value)">
+                                                                <option value="realtime" {{ if eq .EmailFrequency "realtime" }}selected{{ end }}>{{ T $.Language "Realtime" }}</option>
+                                                                <option value="daily" {{ if eq .EmailFrequency "daily" }}selected{{ end }}>{{ T $.Language "Daily" }}</option>
+                                                                <option value="weekly" {{ if eq .EmailFrequency "weekly" }}selected{{ end }}>{{ T $.Language "Weekly" }}</option>
+                                                                <option value="off" {{ if eq .EmailFrequency "off" }}selected{{ end }}>{{ T $.Language "Off" }}</option>
+                                                            </select>
+                                                        </td>
+                                                        <td>
+                                                            <button class="btn btn-sm btn-ghost-danger"
+                                                                    onclick="unfollowItem('{{ .FollowType }}', '{{ .TargetID }}', 'follow-{{ .ID }}')"
+                                                                    title="{{ T $.Language "Unfollow" }}">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M18 6l-12 12"/><path d="M6 6l12 12"/></svg>
+                                                            </button>
+                                                        </td>
+                                                    </tr>
+                                                    {{ end }}
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                        {{ else }}
+                                        <p class="text-secondary mb-4">{{ T .Language "You are not following anything yet. Follow creators, categories, or feeds to get notified about new content." }}</p>
+                                        {{ end }}
+
+                                        <hr class="my-4">
+
                                         <h3 class="card-title">{{ T .Language "Search Alerts" }}</h3>
                                         {{ if .SearchAlerts }}
                                         <div class="list-group list-group-flush mb-3">
@@ -40,36 +103,6 @@
                                         {{ else }}
                                         <p class="text-secondary">{{ T .Language "No search alerts. Save a search from the search page to get notified about new results." }}</p>
                                         {{ end }}
-
-                                        <hr class="my-4">
-
-                                        <h3 class="card-title">{{ T .Language "Section Subscriptions" }}</h3>
-                                        {{ if .SectionSubscriptions }}
-                                        <div class="list-group list-group-flush">
-                                            {{ range .SectionSubscriptions }}
-                                            <div class="list-group-item" id="sub-{{ .ID }}">
-                                                <div class="row align-items-center">
-                                                    <div class="col">
-                                                        <strong>{{ .SubscriptionType }}</strong>
-                                                        {{ if .TargetID }}<span class="text-secondary ms-2">{{ .TargetID }}</span>{{ end }}
-                                                        <span class="badge bg-secondary ms-2">{{ .Frequency }}</span>
-                                                    </div>
-                                                    <div class="col-auto">
-                                                        <button class="btn btn-sm btn-ghost-danger"
-                                                                hx-delete="/settings/subscriptions/sections/{{ .ID }}"
-                                                                hx-target="#sub-{{ .ID }}"
-                                                                hx-swap="outerHTML"
-                                                                hx-confirm="{{ T $.Language "Are you sure?" }}">
-                                                            {{ T $.Language "Remove" }}
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            {{ end }}
-                                        </div>
-                                        {{ else }}
-                                        <p class="text-secondary">{{ T .Language "No section subscriptions." }}</p>
-                                        {{ end }}
                                     </div>
                                 </div>
                             </div>
@@ -81,4 +114,26 @@
         {{template "footer.html" .}}
     </div>
 </div>
+<script>
+function updateFollowFrequency(followType, targetId, frequency) {
+    fetch('/api/follows/frequency', {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({follow_type: followType, target_id: targetId, email_frequency: frequency})
+    });
+}
+function unfollowItem(followType, targetId, elementId) {
+    if (!confirm('Are you sure?')) return;
+    fetch('/api/follows', {
+        method: 'DELETE',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({follow_type: followType, target_id: targetId})
+    }).then(function(resp) {
+        if (resp.ok) {
+            var el = document.getElementById(elementId);
+            if (el) el.remove();
+        }
+    });
+}
+</script>
 {{template "foot.html" .}}


### PR DESCRIPTION
Merge user_follows and section_subscriptions tables into one unified user_follows table supporting follow types: user, category, latest, trending, highest_rated, search, and mod. Each follow has an email_frequency (realtime, daily, weekly, off).

Add follow buttons to index page sections, mod detail pages, and category headers. Add search bar to mod detail and filter to mods listing. Replace section subscription settings UI with unified follow management table. Update background digest worker to use unified follows.