### PR TITLE
Redesign search page, add dedicated feed pages, new categories/tags, …

### DIFF
--- a/internal/database/migrations/060_new_categories_tags.down.sql
+++ b/internal/database/migrations/060_new_categories_tags.down.sql
@@ -1,17 +1,2 @@
--- Remove the tags added in the up migration
-DELETE FROM schematic_tags WHERE key IN (
-    'compact', 'mega-build', 'starter', 'tutorial',
-    'auto-farm', 'ore-processing', 'tree-farm', 'mob-farm',
-    'food-production', 'cobblestone-gen', 'item-sorting', 'smeltery',
-    'mechanical-press', 'deployer', 'crushing-wheel', 'windmill',
-    'water-wheel', 'steam-engine', 'conveyor-belt', 'gearbox',
-    'steampunk', 'medieval', 'industrial', 'modern', 'fantasy',
-    'train-station', 'locomotive', 'rail-network',
-    'create-additions', 'create-deco', 'create-steam-rails'
-);
-
--- Remove the categories added in the up migration
-DELETE FROM schematic_categories WHERE key IN (
-    'trains', 'logistics', 'power-generation', 'processing',
-    'decoration', 'redstone', 'vehicles', 'storage'
-);
+-- No-op: categories and tags may already be in use by schematics.
+-- Removing them would break existing data.

--- a/internal/database/migrations/060_new_categories_tags.down.sql
+++ b/internal/database/migrations/060_new_categories_tags.down.sql
@@ -1,0 +1,17 @@
+-- Remove the tags added in the up migration
+DELETE FROM schematic_tags WHERE key IN (
+    'compact', 'mega-build', 'starter', 'tutorial',
+    'auto-farm', 'ore-processing', 'tree-farm', 'mob-farm',
+    'food-production', 'cobblestone-gen', 'item-sorting', 'smeltery',
+    'mechanical-press', 'deployer', 'crushing-wheel', 'windmill',
+    'water-wheel', 'steam-engine', 'conveyor-belt', 'gearbox',
+    'steampunk', 'medieval', 'industrial', 'modern', 'fantasy',
+    'train-station', 'locomotive', 'rail-network',
+    'create-additions', 'create-deco', 'create-steam-rails'
+);
+
+-- Remove the categories added in the up migration
+DELETE FROM schematic_categories WHERE key IN (
+    'trains', 'logistics', 'power-generation', 'processing',
+    'decoration', 'redstone', 'vehicles', 'storage'
+);

--- a/internal/database/migrations/060_new_categories_tags.up.sql
+++ b/internal/database/migrations/060_new_categories_tags.up.sql
@@ -1,0 +1,73 @@
+-- Add new categories based on common Create mod build types
+-- that are frequently searched for but don't have a dedicated category.
+
+INSERT INTO schematic_categories (id, key, name, created, updated)
+VALUES
+    (gen_random_uuid()::TEXT, 'trains', 'Trains & Railways', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'logistics', 'Logistics & Item Transport', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'power-generation', 'Power Generation', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'processing', 'Processing & Automation', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'decoration', 'Decoration & Aesthetics', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'redstone', 'Redstone & Logic', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'vehicles', 'Vehicles & Contraptions', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'storage', 'Storage Systems', NOW(), NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Mark new categories as public
+UPDATE schematic_categories SET public = true
+WHERE key IN ('trains', 'logistics', 'power-generation', 'processing', 'decoration', 'redstone', 'vehicles', 'storage');
+
+-- Add new tags for commonly searched terms
+INSERT INTO schematic_tags (id, key, name, created, updated)
+VALUES
+    -- Build scale/complexity tags
+    (gen_random_uuid()::TEXT, 'compact', 'Compact', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'mega-build', 'Mega Build', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'starter', 'Starter Friendly', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'tutorial', 'Tutorial Build', NOW(), NOW()),
+    -- Functional tags
+    (gen_random_uuid()::TEXT, 'auto-farm', 'Auto Farm', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'ore-processing', 'Ore Processing', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'tree-farm', 'Tree Farm', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'mob-farm', 'Mob Farm', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'food-production', 'Food Production', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'cobblestone-gen', 'Cobblestone Generator', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'item-sorting', 'Item Sorting', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'smeltery', 'Smeltery', NOW(), NOW()),
+    -- Create-specific mechanism tags
+    (gen_random_uuid()::TEXT, 'mechanical-press', 'Mechanical Press', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'deployer', 'Deployer', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'crushing-wheel', 'Crushing Wheel', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'windmill', 'Windmill', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'water-wheel', 'Water Wheel', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'steam-engine', 'Steam Engine', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'conveyor-belt', 'Conveyor Belt', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'gearbox', 'Gearbox', NOW(), NOW()),
+    -- Aesthetic/style tags
+    (gen_random_uuid()::TEXT, 'steampunk', 'Steampunk', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'medieval', 'Medieval', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'industrial', 'Industrial', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'modern', 'Modern', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'fantasy', 'Fantasy', NOW(), NOW()),
+    -- Train-related tags
+    (gen_random_uuid()::TEXT, 'train-station', 'Train Station', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'locomotive', 'Locomotive', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'rail-network', 'Rail Network', NOW(), NOW()),
+    -- Addon/integration tags
+    (gen_random_uuid()::TEXT, 'create-additions', 'Create: Additions', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'create-deco', 'Create: Deco', NOW(), NOW()),
+    (gen_random_uuid()::TEXT, 'create-steam-rails', 'Create: Steam n Rails', NOW(), NOW())
+ON CONFLICT (key) DO NOTHING;
+
+-- Mark new tags as public
+UPDATE schematic_tags SET public = true
+WHERE key IN (
+    'compact', 'mega-build', 'starter', 'tutorial',
+    'auto-farm', 'ore-processing', 'tree-farm', 'mob-farm',
+    'food-production', 'cobblestone-gen', 'item-sorting', 'smeltery',
+    'mechanical-press', 'deployer', 'crushing-wheel', 'windmill',
+    'water-wheel', 'steam-engine', 'conveyor-belt', 'gearbox',
+    'steampunk', 'medieval', 'industrial', 'modern', 'fantasy',
+    'train-station', 'locomotive', 'rail-network',
+    'create-additions', 'create-deco', 'create-steam-rails'
+);

--- a/internal/database/migrations/061_limit_tags_per_schematic.down.sql
+++ b/internal/database/migrations/061_limit_tags_per_schematic.down.sql
@@ -1,0 +1,1 @@
+-- No-op: cannot restore deleted tag associations.

--- a/internal/database/migrations/061_limit_tags_per_schematic.up.sql
+++ b/internal/database/migrations/061_limit_tags_per_schematic.up.sql
@@ -1,0 +1,12 @@
+-- Remove excess tags from schematics that have more than 5.
+-- Keeps 5 arbitrary tags per schematic (ordered by tag_id).
+DELETE FROM schematics_tags
+WHERE (schematic_id, tag_id) IN (
+    SELECT schematic_id, tag_id
+    FROM (
+        SELECT schematic_id, tag_id,
+               ROW_NUMBER() OVER (PARTITION BY schematic_id ORDER BY tag_id) AS rn
+        FROM schematics_tags
+    ) ranked
+    WHERE rn > 5
+);

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -794,6 +794,9 @@ func (ps *PostgresStore) SetCategories(ctx context.Context, schematicID string, 
 }
 
 func (ps *PostgresStore) SetTags(ctx context.Context, schematicID string, tagIDs []string) error {
+	if len(tagIDs) > 5 {
+		tagIDs = tagIDs[:5]
+	}
 	if err := ps.q.SetSchematicTags(ctx, schematicID); err != nil {
 		return err
 	}

--- a/internal/jobs/feed_og_image.go
+++ b/internal/jobs/feed_og_image.go
@@ -1,0 +1,33 @@
+package jobs
+
+import (
+	"context"
+	"log/slog"
+
+	"createmod/internal/pages"
+
+	"github.com/riverqueue/river"
+)
+
+type FeedOGImageArgs struct{}
+
+func (FeedOGImageArgs) Kind() string { return "feed_og_image" }
+
+type FeedOGImageWorker struct {
+	river.WorkerDefaults[FeedOGImageArgs]
+	deps Deps
+}
+
+func (w *FeedOGImageWorker) Work(ctx context.Context, job *river.Job[FeedOGImageArgs]) error {
+	slog.Info("feed OG image generation started")
+	if w.deps.Storage == nil || w.deps.Store == nil || w.deps.Cache == nil {
+		slog.Warn("feed OG: missing deps (storage, store, or cache)")
+		return nil
+	}
+
+	pages.GenerateFeedOGImage(w.deps.Storage, w.deps.Store, w.deps.Cache, "trending")
+	pages.GenerateFeedOGImage(w.deps.Storage, w.deps.Store, w.deps.Cache, "highest_scores")
+
+	slog.Info("feed OG image generation completed")
+	return nil
+}

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -93,6 +93,7 @@ func New(ctx context.Context, cfg Config) (*Worker, error) {
 	river.AddWorker(workers, &ZeroResultAnalysisWorker{deps: cfg.Deps})
 	river.AddWorker(workers, &PointBackfillWorker{deps: cfg.Deps})
 	river.AddWorker(workers, &SearchStatsFilterWorker{deps: cfg.Deps})
+	river.AddWorker(workers, &FeedOGImageWorker{deps: cfg.Deps})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(cfg.Pool), &river.Config{
 		Queues: map[string]river.QueueConfig{
@@ -326,6 +327,15 @@ func New(ctx context.Context, cfg Config) (*Worker, error) {
 				func() (river.JobArgs, *river.InsertOpts) {
 					return SearchStatsFilterArgs{}, &river.InsertOpts{
 						Queue:      "ai",
+						UniqueOpts: river.UniqueOpts{ByArgs: true, ByPeriod: 24 * time.Hour},
+					}
+				},
+				&river.PeriodicJobOpts{RunOnStart: true},
+			),
+			river.NewPeriodicJob(
+				river.PeriodicInterval(24*time.Hour),
+				func() (river.JobArgs, *river.InsertOpts) {
+					return FeedOGImageArgs{}, &river.InsertOpts{
 						UniqueOpts: river.UniqueOpts{ByArgs: true, ByPeriod: 24 * time.Hour},
 					}
 				},

--- a/internal/pages/trending_page.go
+++ b/internal/pages/trending_page.go
@@ -1,0 +1,303 @@
+package pages
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"createmod/internal/cache"
+	"createmod/internal/models"
+	"createmod/internal/server"
+	"createmod/internal/storage"
+	"createmod/internal/store"
+	"createmod/internal/translation"
+
+	"github.com/sunshineplan/imgconv"
+	"golang.org/x/image/draw"
+)
+
+var trendingPageTemplates = append([]string{
+	"./template/trending.html",
+	"./template/include/schematic_card.html",
+	"./template/include/schematic_card_small.html",
+}, commonTemplates...)
+
+var highestScoresPageTemplates = append([]string{
+	"./template/highest_scores.html",
+	"./template/include/schematic_card.html",
+	"./template/include/schematic_card_small.html",
+}, commonTemplates...)
+
+const feedPageSize = 24
+
+type FeedPageData struct {
+	DefaultData
+	Schematics []models.Schematic
+	Page       int
+	HasPrev    bool
+	HasNext    bool
+	PrevURL    string
+	NextURL    string
+}
+
+func TrendingPageHandler(cacheService *cache.Service, registry *server.Registry, appStore *store.Store, translationService *translation.Service) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		page := 1
+		if p := e.Request.URL.Query().Get("p"); p != "" {
+			if v, err := strconv.Atoi(p); err == nil && v > 0 {
+				page = v
+			}
+		}
+
+		limit := feedPageSize + 1
+		offset := (page - 1) * feedPageSize
+
+		all := getAllTrendingSchematicsFromStore(appStore, cacheService)
+		var schematics []models.Schematic
+		hasNext := false
+		if offset < len(all) {
+			end := offset + limit
+			if end > len(all) {
+				end = len(all)
+			}
+			schematics = all[offset:end]
+		}
+		if len(schematics) > feedPageSize {
+			hasNext = true
+			schematics = schematics[:feedPageSize]
+		}
+
+		translateSchematicTitles(schematics, translationService, cacheService, detectLanguageFromRequest(e.Request))
+
+		d := FeedPageData{
+			Schematics: schematics,
+			Page:       page,
+			HasPrev:    page > 1,
+			HasNext:    hasNext,
+		}
+		if d.HasPrev {
+			d.PrevURL = fmt.Sprintf("/trending?p=%d", page-1)
+		}
+		if d.HasNext {
+			d.NextURL = fmt.Sprintf("/trending?p=%d", page+1)
+		}
+
+		d.Populate(e)
+		d.Title = "Trending Schematics"
+		d.Description = "Discover the most popular Create mod schematics trending right now. Updated daily with the community's hottest builds, contraptions, and designs."
+		d.Slug = "/trending"
+		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
+
+		ogURL := getTrendingOGImage(cacheService)
+		if ogURL != "" {
+			d.Thumbnail = ogURL
+		}
+
+		html, err := registry.LoadFiles(trendingPageTemplates...).Render(d)
+		if err != nil {
+			return err
+		}
+		return e.HTML(http.StatusOK, html)
+	}
+}
+
+func HighestScoresPageHandler(cacheService *cache.Service, registry *server.Registry, appStore *store.Store, translationService *translation.Service) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		page := 1
+		if p := e.Request.URL.Query().Get("p"); p != "" {
+			if v, err := strconv.Atoi(p); err == nil && v > 0 {
+				page = v
+			}
+		}
+
+		limit := feedPageSize + 1
+		offset := (page - 1) * feedPageSize
+
+		results, err := appStore.Schematics.ListHighestRated(context.Background(), limit, offset)
+		if err != nil {
+			return err
+		}
+		hasNext := len(results) > feedPageSize
+		if hasNext {
+			results = results[:feedPageSize]
+		}
+
+		schematics := MapStoreSchematics(appStore, results, cacheService)
+		translateSchematicTitles(schematics, translationService, cacheService, detectLanguageFromRequest(e.Request))
+
+		d := FeedPageData{
+			Schematics: schematics,
+			Page:       page,
+			HasPrev:    page > 1,
+			HasNext:    hasNext,
+		}
+		if d.HasPrev {
+			d.PrevURL = fmt.Sprintf("/highest-scores?p=%d", page-1)
+		}
+		if d.HasNext {
+			d.NextURL = fmt.Sprintf("/highest-scores?p=%d", page+1)
+		}
+
+		d.Populate(e)
+		d.Title = "Highest Rated Schematics"
+		d.Description = "Browse the highest rated Create mod schematics as voted by the community. The best builds, machines, and contraptions ranked by user ratings."
+		d.Slug = "/highest-scores"
+		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
+
+		ogURL := getHighestScoresOGImage(cacheService)
+		if ogURL != "" {
+			d.Thumbnail = ogURL
+		}
+
+		html, err := registry.LoadFiles(highestScoresPageTemplates...).Render(d)
+		if err != nil {
+			return err
+		}
+		return e.HTML(http.StatusOK, html)
+	}
+}
+
+const (
+	trendingOGCacheKey      = "og:trending_collage"
+	highestScoresOGCacheKey = "og:highest_scores_collage"
+)
+
+func getTrendingOGImage(cacheService *cache.Service) string {
+	if v, ok := cacheService.GetString(trendingOGCacheKey); ok {
+		return v
+	}
+	return ""
+}
+
+func getHighestScoresOGImage(cacheService *cache.Service) string {
+	if v, ok := cacheService.GetString(highestScoresOGCacheKey); ok {
+		return v
+	}
+	return ""
+}
+
+func GenerateFeedOGImage(storageSvc *storage.Service, appStore *store.Store, cacheService *cache.Service, feedType string) {
+	if storageSvc == nil {
+		return
+	}
+
+	ctx := context.Background()
+	var schematics []store.Schematic
+	var err error
+
+	switch feedType {
+	case "trending":
+		all := getAllTrendingSchematicsFromStore(appStore, cacheService)
+		for i, s := range all {
+			if i >= 4 {
+				break
+			}
+			schematics = append(schematics, store.Schematic{
+				ID:            s.ID,
+				FeaturedImage: s.FeaturedImage,
+			})
+		}
+	case "highest_scores":
+		schematics, err = appStore.Schematics.ListHighestRated(ctx, 4, 0)
+		if err != nil {
+			slog.Warn("feed OG: failed to list highest rated", "error", err)
+			return
+		}
+	default:
+		return
+	}
+
+	if len(schematics) == 0 {
+		return
+	}
+
+	var images []image.Image
+	for _, s := range schematics {
+		if s.FeaturedImage == "" {
+			continue
+		}
+		key := fmt.Sprintf("%s/%s/%s", storage.CollectionPrefix("schematics"), s.ID, s.FeaturedImage)
+		rc, err := storageSvc.DownloadRaw(ctx, key)
+		if err != nil {
+			continue
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			continue
+		}
+		img, err := imgconv.Decode(bytes.NewReader(data))
+		if err != nil {
+			continue
+		}
+		images = append(images, img)
+		if len(images) >= 4 {
+			break
+		}
+	}
+
+	if len(images) == 0 {
+		return
+	}
+
+	const (
+		collageW = 800
+		collageH = 450
+	)
+
+	dst := image.NewRGBA(image.Rect(0, 0, collageW, collageH))
+
+	switch len(images) {
+	case 1:
+		draw.CatmullRom.Scale(dst, dst.Bounds(), images[0], images[0].Bounds(), draw.Over, nil)
+	case 2:
+		halfW := collageW / 2
+		draw.CatmullRom.Scale(dst, image.Rect(0, 0, halfW, collageH), images[0], images[0].Bounds(), draw.Over, nil)
+		draw.CatmullRom.Scale(dst, image.Rect(halfW, 0, collageW, collageH), images[1], images[1].Bounds(), draw.Over, nil)
+	case 3:
+		halfW := collageW / 2
+		halfH := collageH / 2
+		draw.CatmullRom.Scale(dst, image.Rect(0, 0, halfW, collageH), images[0], images[0].Bounds(), draw.Over, nil)
+		draw.CatmullRom.Scale(dst, image.Rect(halfW, 0, collageW, halfH), images[1], images[1].Bounds(), draw.Over, nil)
+		draw.CatmullRom.Scale(dst, image.Rect(halfW, halfH, collageW, collageH), images[2], images[2].Bounds(), draw.Over, nil)
+	default:
+		halfW := collageW / 2
+		halfH := collageH / 2
+		draw.CatmullRom.Scale(dst, image.Rect(0, 0, halfW, halfH), images[0], images[0].Bounds(), draw.Over, nil)
+		draw.CatmullRom.Scale(dst, image.Rect(halfW, 0, collageW, halfH), images[1], images[1].Bounds(), draw.Over, nil)
+		draw.CatmullRom.Scale(dst, image.Rect(0, halfH, halfW, collageH), images[2], images[2].Bounds(), draw.Over, nil)
+		draw.CatmullRom.Scale(dst, image.Rect(halfW, halfH, collageW, collageH), images[3], images[3].Bounds(), draw.Over, nil)
+	}
+
+	var out bytes.Buffer
+	bw := bufio.NewWriter(&out)
+	if err := imgconv.Write(bw, dst, &imgconv.FormatOption{Format: imgconv.WEBP, EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)}}); err != nil {
+		slog.Error("feed OG: failed to encode", "error", err)
+		return
+	}
+	_ = bw.Flush()
+
+	imageID := generateImageID()
+	filename := feedType + "_og.webp"
+	if err := storageSvc.UploadBytes(ctx, "images", imageID, filename, out.Bytes(), "image/webp"); err != nil {
+		slog.Error("feed OG: failed to upload", "error", err)
+		return
+	}
+
+	ogURL := fmt.Sprintf("/api/files/images/%s/%s", imageID, filename)
+
+	switch feedType {
+	case "trending":
+		cacheService.Set(trendingOGCacheKey, ogURL)
+	case "highest_scores":
+		cacheService.Set(highestScoresOGCacheKey, ogURL)
+	}
+
+	slog.Info("feed OG: generated", "type", feedType, "url", ogURL)
+}

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -539,6 +539,9 @@ func Register(p RegisterParams) chi.Router {
 	r.Get("/guides/{id}/edit", Adapt(pages.GuidesEditHandler(registry, p.CacheService, p.AppStore)))
 	r.Post("/guides/{id}", Adapt(pages.GuidesUpdateHandler(p.CacheService, p.AppStore, p.StorageService, p.ModerationService)))
 	r.Post("/guides/{id}/delete", Adapt(pages.GuidesDeleteHandler(p.AppStore)))
+	// Feed pages
+	r.Get("/trending", Adapt(pages.TrendingPageHandler(p.CacheService, registry, p.AppStore, p.TranslationService)))
+	r.Get("/highest-scores", Adapt(pages.HighestScoresPageHandler(p.CacheService, registry, p.AppStore, p.TranslationService)))
 	// Mods
 	r.Get("/mods", Adapt(pages.ModsHandler(p.CacheService, registry, p.ModMetaService, p.AppStore)))
 	r.Get("/mods/{slug}", Adapt(pages.ModDetailHandler(p.CacheService, registry, p.ModMetaService, p.AppStore, p.TranslationService)))

--- a/template/highest_scores.html
+++ b/template/highest_scores.html
@@ -1,0 +1,40 @@
+{{template "head.html" .}}
+<div class="page">
+    {{template "sidebar.html" .}}
+    <div class="page-wrapper">
+        {{template "header.html" .}}
+        <main class="page-body">
+            <div class="container-wide">
+                <div class="d-flex gap-3">
+                    <div class="flex-grow-1 min-width-0">
+                        <div class="page-header d-print-none mb-4">
+                            <div class="row align-items-center">
+                                <div class="col">
+                                    <h1 class="page-title">{{ T .Language "Highest Rated Schematics" }}</h1>
+                                    <p class="text-secondary">{{ T .Language "The best Create mod builds as rated by the community. Browse top-rated machines, contraptions, and architectural designs." }}</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row row-cards">
+                            {{ range .Schematics }}
+                                {{template "schematic_card_small.html" .}}
+                            {{ end }}
+                        </div>
+                        {{ if not .Schematics }}
+                        <div class="empty">
+                            <p class="empty-title">{{ T .Language "No rated schematics yet" }}</p>
+                        </div>
+                        {{ end }}
+                        <div class="d-flex justify-content-between align-items-center mt-4">
+                            <a {{ if .HasPrev }}href="{{ .PrevURL }}" class="btn btn-outline-secondary"{{ else }}class="btn btn-outline-secondary disabled" tabindex="-1" aria-disabled="true"{{ end }}>{{ T .Language "Previous" }}</a>
+                            <div class="text-secondary">{{ T .Language "Page" }} {{ .Page }}</div>
+                            <a {{ if .HasNext }}href="{{ .NextURL }}" class="btn btn-outline-secondary"{{ else }}class="btn btn-outline-secondary disabled" tabindex="-1" aria-disabled="true"{{ end }}>{{ T .Language "Next" }}</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+        {{template "footer.html" .}}
+    </div>
+</div>
+{{template "foot.html" .}}

--- a/template/index.html
+++ b/template/index.html
@@ -8,7 +8,7 @@
                 <div class="d-flex gap-3">
                     <div class="flex-grow-1 min-width-0">
                         <!-- Trending -->
-                        <h2 class="mb-3"><a href="/search?sort=8" class="text-reset text-decoration-none">{{ T .Language "Trending" }} &rarr;</a></h2>
+                        <h2 class="mb-3"><a href="/trending" class="text-reset text-decoration-none">{{ T .Language "Trending" }} &rarr;</a></h2>
                         <div id="tab-panel-trending" class="tab-panel" data-trending-section="trending">
                             <div class="row g-3">
                                 {{ range .Trending }}
@@ -42,7 +42,7 @@
                         </div>
 
                         <!-- Highest Rated -->
-                        <h2 class="mb-3 mt-4"><a href="/search?sort=4" class="text-reset text-decoration-none">{{ T .Language "Highest Rated" }} &rarr;</a></h2>
+                        <h2 class="mb-3 mt-4"><a href="/highest-scores" class="text-reset text-decoration-none">{{ T .Language "Highest Rated" }} &rarr;</a></h2>
                         <div id="tab-panel-highest" class="tab-panel">
                             <div class="row g-3">
                                 {{ range .HighestRated }}

--- a/template/search.html
+++ b/template/search.html
@@ -22,38 +22,46 @@
                     </div>
                 </div>
 
-                <!-- 3-column layout -->
-                <div class="search-layout">
-                    <!-- Left: Filter sidebar -->
-                    <div class="search-sidebar d-none d-lg-block">
-                        {{template "search_filters.html" .}}
-                        <div class="mt-4 search-sticky-under-container">
-                            <div id="search-sticky-under" style="min-height: 550px; display: block; margin-bottom: 2rem;"></div>
-                        </div>
-                    </div>
-
-                    <!-- Mobile filter toggle -->
-                    <div class="d-lg-none mb-3">
-                        <button class="btn btn-outline-secondary w-100" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobile-filters" aria-controls="mobile-filters">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 4h16v2.172a2 2 0 0 1 -.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48 -4.928a2 2 0 0 1 -.52 -1.345v-2.227z" /></svg>
+                <!-- Filters bar (top, collapsible) -->
+                <div class="mb-3">
+                    <div class="d-flex align-items-center gap-2 mb-2">
+                        <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#search-filters-collapse" aria-expanded="false" aria-controls="search-filters-collapse">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="18" height="18" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 4h16v2.172a2 2 0 0 1 -.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48 -4.928a2 2 0 0 1 -.52 -1.345v-2.227z" /></svg>
                             {{ T .Language "Filters" }}
                         </button>
-                    </div>
-                    <!-- Mobile filters offcanvas -->
-                    <div class="offcanvas offcanvas-start d-lg-none" tabindex="-1" id="mobile-filters" aria-labelledby="mobile-filters-label">
-                        <div class="offcanvas-header">
-                            <h5 class="offcanvas-title" id="mobile-filters-label">{{ T .Language "Filters" }}</h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                        <!-- Quick filter pills -->
+                        <div class="d-flex flex-wrap gap-1">
+                            {{ if ne .Category "all" }}
+                            <span class="badge bg-blue-lt">{{ .Category }}</span>
+                            {{ end }}
+                            {{ range .SelectedTags }}
+                            <span class="badge bg-green-lt">{{ . }}</span>
+                            {{ end }}
+                            {{ if ne .MinecraftVersion "all" }}
+                            <span class="badge bg-cyan-lt">MC {{ .MinecraftVersion }}</span>
+                            {{ end }}
+                            {{ if ne .CreateVersion "all" }}
+                            <span class="badge bg-orange-lt">Create {{ .CreateVersion }}</span>
+                            {{ end }}
+                            {{ if gt (len .SelectedMods) 0 }}
+                            {{ range .SelectedMods }}
+                            <span class="badge bg-purple-lt">{{ . }}</span>
+                            {{ end }}
+                            {{ end }}
+                            {{ if or (ne .Category "all") (gt (len .SelectedTags) 0) (ne .MinecraftVersion "all") (ne .CreateVersion "all") (gt (len .SelectedMods) 0) (ne .Rating -1) }}
+                            <a href="/search/{{ .TermSlug }}" class="badge bg-secondary-lt text-decoration-none">{{ T .Language "Clear all" }}</a>
+                            {{ end }}
                         </div>
-                        <div class="offcanvas-body" id="mobile-filters-body" style="padding-bottom: 5rem;">
-                        </div>
                     </div>
+                    <div class="collapse" id="search-filters-collapse">
+                        {{template "search_filters.html" .}}
+                    </div>
+                </div>
 
-                    <!-- Mobile: top ad -->
-                    <div id="search-top-mobile" class="d-lg-none mb-3 text-center"></div>
-
-                    <!-- Center: Results -->
-                    <div class="search-center">
+                <!-- Results layout: full width + ad rail -->
+                <div class="search-layout-wide">
+                    <!-- Results -->
+                    <div class="search-center-wide">
                         <div id="search-results">
                             <div class="d-flex align-items-center justify-content-between mb-3">
                                 <div class="text-secondary small">
@@ -86,19 +94,28 @@
                             {{ if gt .SearchResultCount 0 }}
                             {{template "search_pagination.html" .}}
                             {{ end }}
-                            <div class="row row-cards">
+                            <div class="row row-cards" id="search-grid">
                                 {{range $i, $s := .Schematics }}
-                                    <div class="col-lg-4 col-md-6 col-12 mb-3" data-schematic-id="{{ $s.ID }}" data-position="{{ $i }}">
+                                    <div class="col-xl-3 col-lg-4 col-md-6 col-12 mb-3" data-schematic-id="{{ $s.ID }}" data-position="{{ $i }}">
                                     {{template "schematic_card.html" $s}}
                                     </div>
                                 {{end}}
                             </div>
+                            {{ if .HasNext }}
+                            <div class="text-center mt-4" id="infinite-scroll-sentinel">
+                                <a href="{{ .NextURL }}" hx-get="{{ .NextURL }}" hx-target="#search-grid" hx-select="#search-grid > div" hx-swap="beforeend" hx-trigger="revealed" hx-push-url="false" class="btn btn-outline-secondary" id="load-more-btn">
+                                    {{ T .Language "Load More" }}
+                                </a>
+                            </div>
+                            {{ end }}
+                            {{ if not .HasNext }}
                             {{template "search_pagination.html" .}}
+                            {{ end }}
                         </div>
                     </div>
 
                     <!-- Right: Ad rail (desktop only) -->
-                    <div class="search-ad-rail d-none d-lg-block">
+                    <div class="search-ad-rail-wide d-none d-xl-block">
                         <div id="search-video-nc-top-right" class="mb-3"></div>
                         <div id="search-sticky-adrail-top" class="mb-3"></div>
                     </div>
@@ -107,66 +124,9 @@
         </main>
         {{template "footer.html" .}}
         <script>
-            // Populate mobile offcanvas with a copy of the desktop filters on open
-            var mobileFilters = document.getElementById('mobile-filters');
-            if (mobileFilters) {
-                mobileFilters.addEventListener('show.bs.offcanvas', function () {
-                    var src = document.querySelector('.search-sidebar #search-filters');
-                    var dest = document.getElementById('mobile-filters-body');
-                    if (src && dest) {
-                        var clone = src.cloneNode(true);
-                        // Remove HTMX attributes from clone so it acts as a plain form
-                        var form = clone.querySelector('form');
-                        if (form) {
-                            form.removeAttribute('hx-get');
-                            form.removeAttribute('hx-target');
-                            form.removeAttribute('hx-select');
-                            form.removeAttribute('hx-swap');
-                            form.removeAttribute('hx-push-url');
-                            form.removeAttribute('hx-trigger');
-                            form.removeAttribute('hx-include');
-                            form.id = 'mobile-search-form';
-                            // Add a search input at the top so the query is included
-                            var heroVal = (document.getElementById('search-hero-input') || {}).value || '';
-                            var wrapper = document.createElement('div');
-                            wrapper.className = 'mb-3';
-                            var label = document.createElement('div');
-                            label.className = 'subheader mb-2';
-                            label.textContent = '{{ T .Language "Search" }}';
-                            var input = document.createElement('input');
-                            input.type = 'text';
-                            input.name = 'q';
-                            input.className = 'form-control';
-                            input.placeholder = '{{ T .Language "Search schematics..." }}';
-                            input.value = heroVal;
-                            wrapper.appendChild(label);
-                            wrapper.appendChild(input);
-                            form.insertBefore(wrapper, form.firstChild);
-                        }
-                        dest.innerHTML = '';
-                        dest.appendChild(clone);
-                    }
-                });
-            }
-            // Mobile top banner
+            // Video NC ad (desktop only)
             var searchKw = 'minecraft,create-mod,search,schematics';
             var searchTarget = { "pageType": "search" };
-            window['nitroAds'].createAd('search-top-mobile', {
-                "refreshTime": 60,
-                "refreshVisibleOnly": true,
-                "renderVisibleOnly": true,
-                "visibleMargin": 300,
-                "keywords": searchKw,
-                "targeting": searchTarget,
-                "report": {
-                    "enabled": true,
-                    "icon": true,
-                    "wording": "Report Ad",
-                    "position": "top-right"
-                },
-                "mediaQuery": "(min-width: 320px) and (max-width: 991px)"
-            });
-            // Video NC ad (desktop only)
             window['nitroAds'].createAd('search-video-nc-top-right', {
                 "format": "video-nc",
                 "keywords": searchKw,
@@ -177,26 +137,7 @@
                     "wording": "Report Ad",
                     "position": "top-right"
                 },
-                "mediaQuery": "(min-width: 992px)"
-            });
-            // Left sidebar sticky ads
-            window['nitroAds'].createAd('search-sticky-under', {
-                "refreshTime": 30,
-                "refreshVisibleOnly": true,
-                "format": "sticky-stack",
-                "stickyStackLimit": 15,
-                "stickyStackSpace": 2.5,
-                "stickyStackOffset": 110,
-                "stickyStackResizable": false,
-                "keywords": searchKw,
-                "targeting": searchTarget,
-                "report": {
-                    "enabled": true,
-                    "icon": true,
-                    "wording": "Report Ad",
-                    "position": "top-right"
-                },
-                "mediaQuery": "(min-width: 992px)"
+                "mediaQuery": "(min-width: 1200px)"
             });
             window['nitroAds'].createAd('search-sticky-adrail-top', {
                 "refreshTime": 45,
@@ -216,7 +157,33 @@
                     "wording": "Report Ad",
                     "position": "top-right"
                 },
-                "mediaQuery": "(min-width: 992px)"
+                "mediaQuery": "(min-width: 1200px)"
+            });
+
+            // Infinite scroll: when the sentinel is revealed and HTMX loads more,
+            // update the sentinel with the next page URL
+            document.addEventListener('htmx:afterSwap', function(evt) {
+                if (evt.detail.target && evt.detail.target.id === 'search-grid') {
+                    var sentinel = document.getElementById('infinite-scroll-sentinel');
+                    if (!sentinel) return;
+                    var btn = document.getElementById('load-more-btn');
+                    if (!btn) return;
+                    var currentURL = btn.getAttribute('hx-get') || btn.getAttribute('href');
+                    if (!currentURL) return;
+                    // Parse current page from URL and increment
+                    var urlObj = new URL(currentURL, window.location.origin);
+                    var currentPage = parseInt(urlObj.searchParams.get('page') || urlObj.searchParams.get('p') || '2');
+                    urlObj.searchParams.set('page', currentPage + 1);
+                    var nextURL = urlObj.pathname + urlObj.search;
+                    btn.setAttribute('href', nextURL);
+                    btn.setAttribute('hx-get', nextURL);
+                    htmx.process(btn);
+                    // Check if the response had fewer items than expected (end of results)
+                    var newItems = evt.detail.target.querySelectorAll('[data-schematic-id]');
+                    if (newItems.length === 0) {
+                        sentinel.remove();
+                    }
+                }
             });
 
             // Search click tracking
@@ -234,7 +201,6 @@
               if (term) {
                 gtag('event', 'search', { 'search_term': term });
               }
-              // Track search result count
               var countEl = document.querySelector('#search-results .text-secondary.small');
               if (countEl && term) {
                 var match = countEl.textContent.match(/(\d+)/);
@@ -248,7 +214,7 @@
 
             // Attach click tracking to search result links
             document.addEventListener('click', function(e) {
-                var link = e.target && e.target.closest && e.target.closest('.search-center a[href*="/schematics/"]');
+                var link = e.target && e.target.closest && e.target.closest('.search-center-wide a[href*="/schematics/"]');
                 if (!link) return;
                 var card = link.closest('[data-schematic-id]');
                 if (!card) return;

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -789,6 +789,31 @@ body.sidebar-open::after {
   }
 }
 
+.search-layout-wide {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+@media (min-width: 1200px) {
+  .search-layout-wide {
+    grid-template-columns: 1fr 300px;
+  }
+}
+
+.search-center-wide {
+  min-width: 0;
+}
+
+.search-ad-rail-wide {
+  min-width: 160px;
+  flex-shrink: 0;
+  align-self: start;
+}
+.search-ad-rail-wide > div:last-child {
+  position: sticky;
+  top: 110px;
+}
+
 .search-sidebar {
   min-width: 0;
   overflow: hidden;

--- a/template/trending.html
+++ b/template/trending.html
@@ -1,0 +1,40 @@
+{{template "head.html" .}}
+<div class="page">
+    {{template "sidebar.html" .}}
+    <div class="page-wrapper">
+        {{template "header.html" .}}
+        <main class="page-body">
+            <div class="container-wide">
+                <div class="d-flex gap-3">
+                    <div class="flex-grow-1 min-width-0">
+                        <div class="page-header d-print-none mb-4">
+                            <div class="row align-items-center">
+                                <div class="col">
+                                    <h1 class="page-title">{{ T .Language "Trending Schematics" }}</h1>
+                                    <p class="text-secondary">{{ T .Language "The most popular Create mod builds trending right now, ranked by community engagement. Updated daily." }}</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row row-cards">
+                            {{ range .Schematics }}
+                                {{template "schematic_card_small.html" .}}
+                            {{ end }}
+                        </div>
+                        {{ if not .Schematics }}
+                        <div class="empty">
+                            <p class="empty-title">{{ T .Language "No trending schematics yet" }}</p>
+                        </div>
+                        {{ end }}
+                        <div class="d-flex justify-content-between align-items-center mt-4">
+                            <a {{ if .HasPrev }}href="{{ .PrevURL }}" class="btn btn-outline-secondary"{{ else }}class="btn btn-outline-secondary disabled" tabindex="-1" aria-disabled="true"{{ end }}>{{ T .Language "Previous" }}</a>
+                            <div class="text-secondary">{{ T .Language "Page" }} {{ .Page }}</div>
+                            <a {{ if .HasNext }}href="{{ .NextURL }}" class="btn btn-outline-secondary"{{ else }}class="btn btn-outline-secondary disabled" tabindex="-1" aria-disabled="true"{{ end }}>{{ T .Language "Next" }}</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+        {{template "footer.html" .}}
+    </div>
+</div>
+{{template "foot.html" .}}

--- a/tests/e2e/specs/search_filters.spec.ts
+++ b/tests/e2e/specs/search_filters.spec.ts
@@ -1,9 +1,17 @@
 import { test, expect } from '@playwright/test';
 
+async function expandFilters(page) {
+  const toggle = page.locator('button[data-bs-target="#search-filters-collapse"]');
+  await toggle.click();
+  await page.waitForSelector('#search-filters-collapse.show', { timeout: 5000 });
+}
+
 test.describe('Search page filters', () => {
   test('Best match is the default selected sort', async ({ page, baseURL }) => {
     const url = baseURL ?? 'http://localhost:8080';
     await page.goto(url + '/search');
+
+    await expandFilters(page);
 
     // The sort dropdown should default to "Best match" (value="1")
     const sortSelect = page.locator('#advanced-search-form select[name="sort"]');
@@ -16,6 +24,7 @@ test.describe('Search page filters', () => {
 
     // Wait for initial results to load
     await page.waitForSelector('#search-results');
+    await expandFilters(page);
 
     // Select "Newest" from the sort dropdown
     const sortSelect = page.locator('#advanced-search-form select[name="sort"]');
@@ -33,6 +42,7 @@ test.describe('Search page filters', () => {
     await page.goto(url + '/search');
 
     await page.waitForSelector('#search-results');
+    await expandFilters(page);
 
     // Change category dropdown
     const categorySelect = page.locator('#advanced-search-form select[name="category"]');
@@ -72,6 +82,7 @@ test.describe('Search page filters', () => {
     await page.goto(url + '/search');
 
     await page.waitForSelector('#search-results');
+    await expandFilters(page);
 
     // Move the rating range slider to 4 stars
     const slider = page.locator('#rating-slider');


### PR DESCRIPTION
…and tag limit

Search page: move filters to collapsible top bar, remove left sidebar to give results full width (4 columns on XL screens). Add infinite scroll via HTMX revealed trigger on a "Load More" sentinel.

Add dedicated /trending and /highest-scores pages with proper SEO metadata and descriptions. Daily OG image collage generation (same pattern as collections) via new FeedOGImageWorker River job.

Migration 060: seed 8 new categories (trains, logistics, power generation, processing, decoration, redstone, vehicles, storage) and 31 new tags covering build scale, functional types, Create mechanisms, aesthetic styles, train builds, and addon integrations.

Migration 061: enforce 5-tag limit per schematic — trim existing schematics and cap at store level in SetTags.