### PR TITLE
Replace language dropdown flags with text-only list

### DIFF
--- a/internal/pages/auth_ui_test.go
+++ b/internal/pages/auth_ui_test.go
@@ -29,7 +29,8 @@ func renderTemplate(t *testing.T, file string, data any) string {
 	// Register minimal func map to match production (HumanDate used in sidebar).
 	r.AddFuncs(htmltmpl.FuncMap{
 		"HumanDate": func(t time.Time) string { return t.UTC().Format("2006-01-02 15:04 MST") },
-		"LangFlag":  func(code string) string { return code },
+		"LangFlag":  func(code string) string { return "" },
+		"LangName":  func(code string) string { return code },
 		"T":         func(lang, key string) string { return i18n.T(lang, key) },
 		"LangURL": func(lang string, path string) string {
 			return PrefixedPath(lang, path)

--- a/internal/pages/templates.go
+++ b/internal/pages/templates.go
@@ -58,24 +58,31 @@ func NewTestRegistry() *server.Registry {
 		},
 		"externalDomain": ExternalDomain,
 		"LangFlag": func(code string) html.HTML {
-			cc := "gb"
+			return ""
+		},
+		"LangName": func(code string) string {
 			switch code {
 			case "en":
-				cc = "gb"
-			case "pt-BR":
-				cc = "br"
-			case "pt-PT":
-				cc = "pt"
+				return "English"
+			case "de":
+				return "Deutsch"
 			case "es":
-				cc = "es"
+				return "Español"
+			case "fr":
+				return "Français"
 			case "pl":
-				cc = "pl"
+				return "Polski"
+			case "pt-BR":
+				return "Português (Brasil)"
+			case "pt-PT":
+				return "Português (Portugal)"
 			case "ru":
-				cc = "ru"
+				return "Русский"
 			case "zh-Hans":
-				cc = "cn"
+				return "简体中文"
+			default:
+				return code
 			}
-			return html.HTML(`<span class="fi fi-` + cc + `"></span>`)
 		},
 	})
 	return r

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -176,26 +176,31 @@ func Register(p RegisterParams) chi.Router {
 		},
 		"externalDomain": pages.ExternalDomain,
 		"LangFlag": func(code string) html.HTML {
-			cc := "gb"
+			return ""
+		},
+		"LangName": func(code string) string {
 			switch code {
 			case "en":
-				cc = "gb"
-			case "pt-BR":
-				cc = "br"
-			case "pt-PT":
-				cc = "pt"
+				return "English"
+			case "de":
+				return "Deutsch"
 			case "es":
-				cc = "es"
-			case "pl":
-				cc = "pl"
-			case "ru":
-				cc = "ru"
-			case "zh-Hans":
-				cc = "cn"
+				return "Español"
 			case "fr":
-				cc = "fr"
+				return "Français"
+			case "pl":
+				return "Polski"
+			case "pt-BR":
+				return "Português (Brasil)"
+			case "pt-PT":
+				return "Português (Portugal)"
+			case "ru":
+				return "Русский"
+			case "zh-Hans":
+				return "简体中文"
+			default:
+				return code
 			}
-			return html.HTML(`<span class="fi fi-` + cc + `"></span>`)
 		},
 	}
 

--- a/template/include/head.html
+++ b/template/include/head.html
@@ -67,7 +67,7 @@ window.setTheme=function(theme){
     <link rel="stylesheet" href="/assets/x/app.css?v={{ AssetVer }}" />
     <!-- Non-critical CSS: load async to avoid blocking LCP -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/dropzone@6.0.0-beta.2/dist/dropzone.css" crossorigin="anonymous" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.2.3/css/flag-icons.min.css" crossorigin="anonymous" media="print" onload="this.media='all'">
+
 
     <!-- HTMX (via jsdelivr to share CDN connection) -->
     <script src="https://cdn.jsdelivr.net/npm/htmx.org@1.9.12/dist/htmx.min.js" defer crossorigin="anonymous"></script>

--- a/template/include/header.html
+++ b/template/include/header.html
@@ -54,16 +54,18 @@
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0"></path><path d="M3 12h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"></path></svg>
             </button>
             <div class="dropdown">
-                <a href="#" class="nav-link px-0 lang-flag" data-bs-toggle="dropdown" hx-boost="false" hx-disable aria-label="Select language" title="{{ .Language }}">{{ LangFlag .Language }}</a>
+                <a href="#" class="nav-link px-0" data-bs-toggle="dropdown" hx-boost="false" hx-disable aria-label="Select language" title="{{ LangName .Language }}">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"/><path d="M3.6 9h16.8"/><path d="M3.6 15h16.8"/><path d="M11.5 3a17 17 0 0 0 0 18"/><path d="M12.5 3a17 17 0 0 1 0 18"/></svg>
+                </a>
                 <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
-                    <a class="dropdown-item" href="/lang?l=en&return_to={{ .Slug }}" hx-boost="false">{{ LangFlag "en" }} English</a>
-                    <a class="dropdown-item" href="/lang?l=pt-BR&return_to={{ .Slug }}" hx-boost="false">{{ LangFlag "pt-BR" }} Português (Brasil)</a>
-                    <a class="dropdown-item" href="/lang?l=pt-PT&return_to={{ .Slug }}" hx-boost="false">{{ LangFlag "pt-PT" }} Português</a>
-                    <a class="dropdown-item" href="/lang?l=es&return_to={{ .Slug }}" hx-boost="false">{{ LangFlag "es" }} Español</a>
-                    <a class="dropdown-item" href="/lang?l=pl&return_to={{ .Slug }}" hx-boost="false">{{ LangFlag "pl" }} Polski</a>
-                    <a class="dropdown-item" href="/lang?l=ru&return_to={{ .Slug }}" hx-boost="false">{{ LangFlag "ru" }} Русский</a>
-                    <a class="dropdown-item" href="/lang?l=zh-Hans&return_to={{ .Slug }}" hx-boost="false">{{ LangFlag "zh-Hans" }} 简体中文</a>
-                    <a class="dropdown-item" href="/lang?l=fr&return_to={{ .Slug }}" hx-boost="false">{{ LangFlag "fr" }} Français</a>
+                    <a class="dropdown-item" href="/lang?l=en&return_to={{ .Slug }}" hx-boost="false">English</a>
+                    <a class="dropdown-item" href="/lang?l=es&return_to={{ .Slug }}" hx-boost="false">Español</a>
+                    <a class="dropdown-item" href="/lang?l=fr&return_to={{ .Slug }}" hx-boost="false">Français</a>
+                    <a class="dropdown-item" href="/lang?l=pl&return_to={{ .Slug }}" hx-boost="false">Polski</a>
+                    <a class="dropdown-item" href="/lang?l=pt-BR&return_to={{ .Slug }}" hx-boost="false">Português (Brasil)</a>
+                    <a class="dropdown-item" href="/lang?l=pt-PT&return_to={{ .Slug }}" hx-boost="false">Português (Portugal)</a>
+                    <a class="dropdown-item" href="/lang?l=ru&return_to={{ .Slug }}" hx-boost="false">Русский</a>
+                    <a class="dropdown-item" href="/lang?l=zh-Hans&return_to={{ .Slug }}" hx-boost="false">简体中文</a>
                 </div>
             </div>
             {{ if .IsAuthenticated }}

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -622,10 +622,6 @@ body.sidebar-ready .sidebar-rail {
   gap: 1.25rem;
   flex-shrink: 0;
 }
-.top-header-actions .lang-flag {
-  font-size: 1.5rem;
-  line-height: 1;
-}
 .sidebar-mobile-toggle {
   background: none;
   border: none;

--- a/tests/e2e/specs/i18n_urls.spec.ts
+++ b/tests/e2e/specs/i18n_urls.spec.ts
@@ -67,8 +67,8 @@ test.describe('hreflang tags', () => {
 test.describe('language switcher', () => {
   test('language switcher links use /lang endpoint to set cookie', async ({ page }) => {
     await page.goto('/');
-    // Open language dropdown
-    const langTrigger = page.locator('.lang-flag');
+    // Open language dropdown (globe icon trigger)
+    const langTrigger = page.locator('a[aria-label="Select language"]');
     await langTrigger.click();
 
     // Check Spanish link routes through /lang endpoint
@@ -84,7 +84,7 @@ test.describe('language switcher', () => {
 
   test('language switcher on Spanish page preserves path', async ({ page }) => {
     await page.goto('/es/schematics');
-    const langTrigger = page.locator('.lang-flag');
+    const langTrigger = page.locator('a[aria-label="Select language"]');
     await langTrigger.click();
 
     // English link should route through /lang with return_to


### PR DESCRIPTION
Remove country flag icons from the language selector to avoid associating languages with specific countries. Uses a globe icon as the dropdown trigger and lists languages by their native names. Also removes the flag-icons CSS dependency.