### PR TITLE
Replace header search field with prominent search button

### DIFF
--- a/internal/pages/search_test.go
+++ b/internal/pages/search_test.go
@@ -45,31 +45,15 @@ func renderSearchPage(t *testing.T, data SearchData) string {
 }
 
 // Test that the header search form has the expected HTMX attributes
-func Test_Search_HTMX_HeaderFormAttributes(t *testing.T) {
+func Test_Search_Header_Has_Search_Button(t *testing.T) {
 	d := DefaultData{IsAuthenticated: false}
 	header := renderTemplate_search(t, "template/include/header.html", d)
 
-	// The header search forms must rely on the global hx-boost="true" on
-	// <body> instead of explicit hx-post/hx-target/hx-swap attributes.
-	// Explicit attributes caused a broken body-innerHTML swap that lost
-	// <head> scripts and body attributes, producing a blank screen.
-	forbidden := []string{
-		"hx-post=\"/search\"",
-		"hx-target=\"body\"",
-		"hx-swap=\"innerHTML\"",
-		"hx-select=\"body\"",
+	if !strings.Contains(header, "btn-search") {
+		t.Errorf("header should contain a search button with btn-search class")
 	}
-	for _, a := range forbidden {
-		if strings.Contains(header, a) {
-			t.Errorf("header search form must not contain %s — rely on hx-boost instead", a)
-		}
-	}
-
-	if !strings.Contains(header, "action=\"/search\"") {
-		t.Errorf("header search form should include action=\"/search\"")
-	}
-	if !strings.Contains(header, "method=\"post\"") {
-		t.Errorf("header search form should include method=\"post\"")
+	if !strings.Contains(header, "/search") {
+		t.Errorf("header should contain a link to /search")
 	}
 }
 

--- a/internal/pages/template_attrs_test.go
+++ b/internal/pages/template_attrs_test.go
@@ -16,32 +16,15 @@ func mustRead(t *testing.T, path string) string {
 	return string(b)
 }
 
-func Test_Header_Search_Uses_Boost(t *testing.T) {
-	// The header search forms must NOT have explicit hx-post/hx-target/hx-swap
-	// attributes.  They rely on the global hx-boost="true" on <body> to handle
-	// POST → redirect → full-page swap correctly.  Explicit attributes cause a
-	// broken body-innerHTML swap that loses <head> scripts and body attributes.
+func Test_Header_Has_Search_Button(t *testing.T) {
 	path := filepath.Join("..", "..", "template", "include", "header.html")
 	s := mustRead(t, path)
 
-	forbidden := []string{
-		`hx-post="/search"`,
-		`hx-target="body"`,
-		`hx-swap="innerHTML"`,
-		`hx-select="body"`,
+	if !strings.Contains(s, `btn-search`) {
+		t.Fatalf("header.html missing search button with btn-search class")
 	}
-	for _, a := range forbidden {
-		if strings.Contains(s, a) {
-			t.Fatalf("header.html must not contain %s — rely on hx-boost instead", a)
-		}
-	}
-
-	// The forms must still have action="/search" method="post" for boosting.
-	if !strings.Contains(s, `action="/search"`) {
-		t.Fatalf("header.html missing action=\"/search\"")
-	}
-	if !strings.Contains(s, `method="post"`) {
-		t.Fatalf("header.html missing method=\"post\"")
+	if !strings.Contains(s, `/search`) {
+		t.Fatalf("header.html missing link to /search")
 	}
 }
 

--- a/template/include/footer.html
+++ b/template/include/footer.html
@@ -195,25 +195,6 @@
                 });
             }
 
-            let searchForm = document.getElementById("search-form")
-            let searchField = document.getElementById("search-field")
-            if (searchForm != null && searchField != null && !searchForm._bound) {
-                searchForm._bound = true;
-                searchForm.addEventListener("submit", async (e) => {
-                    e.preventDefault();
-                    let slug = slugify(searchField.value)
-                    location.href = langPrefix + "/search/" + slug
-                })
-            }
-
-            function slugify(str) {
-                str = str.replace(/^\s+|\s+$/g, ''); // trim leading/trailing white space
-                str = str.toLowerCase(); // convert string to lowercase
-                str = str.replace(/[^a-z0-9 -]/g, '') // remove any non-alphanumeric characters
-                    .replace(/\s+/g, '-') // replace spaces with hyphens
-                    .replace(/-+/g, '-'); // remove consecutive hyphens
-                return str;
-            }
         }
 
         if (!window._footerRunInit) {

--- a/template/include/head.html
+++ b/template/include/head.html
@@ -205,21 +205,6 @@ window.setTheme=function(theme){
           document.body.classList.remove('sidebar-open');
         });
 
-        // Mobile search toggle
-        document.addEventListener('click', function(e){
-          var btn = e.target && e.target.closest && e.target.closest('.mobile-search-toggle');
-          if (btn) {
-            var bar = document.querySelector('.mobile-search-bar');
-            if (bar) {
-              bar.classList.toggle('active');
-              if (bar.classList.contains('active')) {
-                var input = bar.querySelector('input[name="q"]');
-                if (input) input.focus();
-              }
-            }
-          }
-        });
-
         // Desktop sidebar expand/collapse toggle
         document.addEventListener('click', function(e){
           var btn = e.target && e.target.closest && e.target.closest('#sidebar-toggle');

--- a/template/include/header.html
+++ b/template/include/header.html
@@ -6,29 +6,11 @@
         <a href="{{ LangURL .Language "/" }}" class="top-header-brand">
             <img alt="CreateMod.com logo" src="/assets/x/logo.png" width="60" height="60">
         </a>
-        <button class="mobile-search-toggle d-md-none" type="button" aria-label="Search">
-            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/><path d="M21 21l-6 -6"/></svg>
-        </button>
-        <form class="top-header-search d-none d-md-block" action="/search" method="post" autocomplete="off" id="search-form" novalidate>
-            <div class="input-group">
-                <input id="search-field" type="text" value="" name="q" class="form-control" placeholder="Search…" aria-label="Search CreateMod.com">
-                <button class="btn btn-primary" type="submit" aria-label="Search">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/><path d="M21 21l-6 -6"/></svg>
-                </button>
-            </div>
-        </form>
-        <form class="mobile-search-bar d-md-none" action="/search" method="post" autocomplete="off" novalidate>
-            <div class="input-group">
-                <input type="text" name="q" class="form-control" placeholder="Search…" aria-label="Search CreateMod.com" autofocus>
-                <button class="btn btn-primary" type="submit" aria-label="Search">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/><path d="M21 21l-6 -6"/></svg>
-                </button>
-                <button class="btn" type="button" onclick="document.querySelector('.mobile-search-bar').classList.remove('active')" aria-label="Close search">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6l-12 12"/><path d="M6 6l12 12"/></svg>
-                </button>
-            </div>
-        </form>
         <div class="top-header-actions">
+            <a href="{{ LangURL .Language "/search" }}" class="btn btn-search d-none d-md-inline-flex">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon me-1" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/><path d="M21 21l-6 -6"/></svg>
+                {{ T .Language "Search" }}
+            </a>
             <a href="{{ LangURL .Language "/upload" }}" class="btn btn-primary d-none d-md-inline-flex" id="header-upload-btn">
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/><path d="M7 9l5 -5l5 5"/><path d="M12 4l0 12"/></svg>
                 {{ T .Language "Upload" }}
@@ -44,6 +26,9 @@
                     <a class="dropdown-item" href="{{ LangURL .Language "/generators/hull" }}">{{ T .Language "Ship Hull" }}</a>
                 </div>
             </div>
+            <a href="{{ LangURL .Language "/search" }}" class="nav-link px-0 d-md-none" aria-label="{{ T .Language "Search" }}" title="{{ T .Language "Search" }}">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0"/><path d="M21 21l-6 -6"/></svg>
+            </a>
             <a href="{{ LangURL .Language "/upload" }}" class="nav-link px-0 d-md-none" aria-label="{{ T .Language "Upload" }}" title="{{ T .Language "Upload" }}">
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2"/><path d="M7 9l5 -5l5 5"/><path d="M12 4l0 12"/></svg>
             </a>
@@ -113,18 +98,3 @@
 </div>
 {{ .BreadcrumbJSONLD }}
 {{ end }}
-<script>
-(function(){
-  if (window._cmHeaderTrack) return;
-  window._cmHeaderTrack = true;
-  document.addEventListener('submit', function(e) {
-    var form = e.target && e.target.closest && e.target.closest('#search-form, .mobile-search-bar');
-    if (!form) return;
-    var input = form.querySelector('input[name="q"]');
-    var term = input ? input.value : '';
-    if (term) {
-      gtag('event', 'search', { 'search_term': term });
-    }
-  });
-})();
-</script>

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -611,20 +611,30 @@ body.sidebar-ready .sidebar-rail {
   height: 60px;
   width: auto;
 }
-.top-header-search {
-  flex: 1;
-  max-width: 520px;
-  margin: 0 auto;
-}
 .top-header-actions {
   display: flex;
   align-items: center;
   gap: 1.25rem;
   flex-shrink: 0;
 }
-.top-header-actions .lang-flag {
-  font-size: 1.5rem;
-  line-height: 1;
+.btn-search {
+  --tblr-btn-bg: #0ea5e9;
+  --tblr-btn-border-color: #0ea5e9;
+  --tblr-btn-color: #fff;
+  --tblr-btn-hover-bg: #0284c7;
+  --tblr-btn-hover-border-color: #0284c7;
+  --tblr-btn-hover-color: #fff;
+  --tblr-btn-active-bg: #0369a1;
+  --tblr-btn-active-border-color: #0369a1;
+  --tblr-btn-active-color: #fff;
+}
+[data-bs-theme=dark] .btn-search {
+  --tblr-btn-bg: #38bdf8;
+  --tblr-btn-border-color: #38bdf8;
+  --tblr-btn-color: #0c1425;
+  --tblr-btn-hover-bg: #7dd3fc;
+  --tblr-btn-hover-border-color: #7dd3fc;
+  --tblr-btn-hover-color: #0c1425;
 }
 .sidebar-mobile-toggle {
   background: none;
@@ -634,33 +644,6 @@ body.sidebar-ready .sidebar-rail {
   cursor: pointer;
 }
 
-/* Mobile search toggle (icon button visible only on small screens) */
-.mobile-search-toggle {
-  background: none;
-  border: none;
-  padding: 0.25rem;
-  color: var(--tblr-body-color);
-  cursor: pointer;
-  display: none;
-}
-/* Mobile search bar: full-width bar below the header, hidden by default.
-   Only shown on screens below md (< 768px) when toggled active. */
-.mobile-search-bar {
-  display: none !important;
-}
-@media (max-width: 767.98px) {
-  .mobile-search-bar.active {
-    display: block !important;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 100%;
-    background: var(--tblr-bg-surface);
-    padding: 0.5rem 1rem;
-    border-bottom: 1px solid rgba(128, 128, 128, 0.12);
-    z-index: 1049;
-  }
-}
 
 /***************
   Mobile header (< 768px)
@@ -678,14 +661,7 @@ body.sidebar-ready .sidebar-rail {
   }
   .top-header-actions {
     gap: 0.75rem;
-  }
-  .mobile-search-toggle {
-    display: block;
     margin-left: auto;
-  }
-  /* Push actions to the right, search icon fills gap */
-  .top-header-actions .lang-flag {
-    font-size: 1.25rem;
   }
 }
 
@@ -740,9 +716,6 @@ body.sidebar-pinned .page-wrapper {
   }
   body.sidebar-pinned .page-wrapper {
     margin-left: 0;
-  }
-  .top-header-search {
-    max-width: none;
   }
   /* Hide the expand/collapse toggle on mobile — mobile uses the hamburger */
   .sidebar-toggle {


### PR DESCRIPTION
Remove the inline search form from the header and replace it with a dedicated search button in a distinctive blue color that stands out next to the Upload and Generators buttons. On mobile, the search icon links directly to /search instead of toggling an overlay form.