### PR TITLE
Remove inline display ad from desktop schematic pages

### DIFF
--- a/template/schematic.html
+++ b/template/schematic.html
@@ -226,9 +226,6 @@
                                     </div>
                                 </div>
 
-                                <!-- In-content display ad (tablet+) -->
-                                <div id="schematic-incontent" class="mt-3 d-none d-md-block" style="max-height:60px;overflow:hidden;"></div>
-
                                 <!-- Description -->
                                 <div class="mt-3">
                                     <div>{{ .Schematic.HTMLContent }}</div>
@@ -1408,31 +1405,6 @@ document.addEventListener('htmx:afterRequest', function(evt) {
       "position": "top-right"
     },
     "mediaQuery": "(min-width: 1200px)"
-  });
-  // In-content display ad (tablet+) — banner sizes that fit within 60px height
-  window['nitroAds'].createAd('schematic-incontent', {
-    "refreshTime": 60,
-    "refreshVisibleOnly": true,
-    "renderVisibleOnly": true,
-    "visibleMargin": 300,
-    "format": "display",
-    "sizes": [
-      ["728", "50"],
-      ["468", "60"],
-      ["468", "50"],
-      ["320", "50"],
-      ["234", "60"],
-      ["120", "60"]
-    ],
-    "keywords": kwString,
-    "targeting": targeting,
-    "report": {
-      "enabled": true,
-      "icon": true,
-      "wording": "Report Ad",
-      "position": "top-right"
-    },
-    "mediaQuery": "(min-width: 768px)"
   });
   // Mobile ad (in-content on smaller screens)
   window['nitroAds'].createAd('schematic-mobile', {


### PR DESCRIPTION
Remove the small in-content banner ad (schematic-incontent) that appeared between the rating section and description on tablet+ screens. The sidebar sticky-stack ads remain.