### PR TITLE
Add uploads chart, total schematics and drafts count to site stats

### DIFF
--- a/internal/database/gen/analytics.sql.go
+++ b/internal/database/gen/analytics.sql.go
@@ -23,6 +23,39 @@ func (q *Queries) CountUserSchematics(ctx context.Context, authorID *string) (in
 	return total, err
 }
 
+const dailySchematicUploads = `-- name: DailySchematicUploads :many
+SELECT to_char(created, 'YYYY-MM-DD') AS day, COUNT(*)::BIGINT AS count
+FROM schematics
+WHERE created >= $1 AND deleted IS NULL
+GROUP BY day
+ORDER BY day
+`
+
+type DailySchematicUploadsRow struct {
+	Day   string `json:"day"`
+	Count int64  `json:"count"`
+}
+
+func (q *Queries) DailySchematicUploads(ctx context.Context, created time.Time) ([]DailySchematicUploadsRow, error) {
+	rows, err := q.db.Query(ctx, dailySchematicUploads, created)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []DailySchematicUploadsRow{}
+	for rows.Next() {
+		var i DailySchematicUploadsRow
+		if err := rows.Scan(&i.Day, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const deleteOldSchematicEvents = `-- name: DeleteOldSchematicEvents :execrows
 DELETE FROM schematic_events WHERE created < $1
 `

--- a/internal/database/gen/querier.go
+++ b/internal/database/gen/querier.go
@@ -102,6 +102,7 @@ type Querier interface {
 	CreateUser(ctx context.Context, arg CreateUserParams) (User, error)
 	CreateUserMeta(ctx context.Context, arg CreateUserMetaParams) error
 	CreateUserWebhook(ctx context.Context, arg CreateUserWebhookParams) (UserWebhook, error)
+	DailySchematicUploads(ctx context.Context, created time.Time) ([]DailySchematicUploadsRow, error)
 	DailySearchTermVolume(ctx context.Context, arg DailySearchTermVolumeParams) ([]DailySearchTermVolumeRow, error)
 	DailySearchVolume(ctx context.Context, created time.Time) ([]DailySearchVolumeRow, error)
 	DeleteAPIKey(ctx context.Context, arg DeleteAPIKeyParams) error

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -3765,6 +3765,18 @@ func (ss *StatsStoreImpl) DeleteOldEvents(ctx context.Context, before time.Time)
 	return ss.q.DeleteOldSchematicEvents(ctx, before)
 }
 
+func (ss *StatsStoreImpl) DailySchematicUploads(ctx context.Context, since time.Time) ([]store.DailyCount, error) {
+	rows, err := ss.q.DailySchematicUploads(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.DailyCount, len(rows))
+	for i, r := range rows {
+		result[i] = store.DailyCount{Day: r.Day, Count: r.Count}
+	}
+	return result, nil
+}
+
 // --------------------------------------------------------------------------
 // NBTHashStoreImpl
 // --------------------------------------------------------------------------

--- a/internal/database/queries/analytics.sql
+++ b/internal/database/queries/analytics.sql
@@ -132,5 +132,12 @@ GROUP BY s.id, s.name, s.title, s.featured_image
 ORDER BY total_views DESC
 LIMIT $2;
 
+-- name: DailySchematicUploads :many
+SELECT to_char(created, 'YYYY-MM-DD') AS day, COUNT(*)::BIGINT AS count
+FROM schematics
+WHERE created >= $1 AND deleted IS NULL
+GROUP BY day
+ORDER BY day;
+
 -- name: DeleteOldSchematicEvents :execrows
 DELETE FROM schematic_events WHERE created < $1;

--- a/internal/pages/sitestats.go
+++ b/internal/pages/sitestats.go
@@ -39,9 +39,13 @@ type SiteStatsData struct {
 	HourlyViewsJSON     html.JS
 	HourlyDownloadsJSON html.JS
 
-	TotalViews30d    int
+	TotalViews30d     int
 	TotalDownloads30d int
-	GlobalVDRatio    string
+	GlobalVDRatio     string
+
+	TotalSchematics int64
+	TotalDrafts     int64
+	DailyUploadsJSON html.JS
 
 	ShowYourStatsLink bool
 
@@ -132,6 +136,29 @@ func SiteStatsHandler(registry *server.Registry, cacheService *cache.Service, ap
 		d.TotalViews30d = global.TotalViews
 		d.TotalDownloads30d = global.TotalDL
 		d.GlobalVDRatio = global.VDRatio
+
+		type cachedCounts struct {
+			TotalSchematics int64
+			TotalDrafts     int64
+			DailyUploads    string
+		}
+		countsCacheKey := "site_stats_counts"
+		var counts cachedCounts
+		if cached, found := cacheService.Get(countsCacheKey); found {
+			if c, ok := cached.(cachedCounts); ok {
+				counts = c
+			}
+		}
+		if counts.DailyUploads == "" {
+			counts.TotalSchematics, _ = appStore.Schematics.CountApproved(ctx)
+			counts.TotalDrafts, _ = appStore.TempUploads.CountAll(ctx)
+			daily, _ := appStore.Stats.DailySchematicUploads(ctx, since30d)
+			counts.DailyUploads = dailyCountsJSON(daily)
+			cacheService.SetWithTTL(countsCacheKey, counts, 15*time.Minute)
+		}
+		d.TotalSchematics = counts.TotalSchematics
+		d.TotalDrafts = counts.TotalDrafts
+		d.DailyUploadsJSON = html.JS(counts.DailyUploads)
 
 		userID := authenticatedUserID(e)
 		d.ShowYourStatsLink = userID != ""

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1086,6 +1086,7 @@ type StatsStore interface {
 	GetSchematicVDRatioSinceCutoff(ctx context.Context, schematicID string, since time.Time) (views int64, downloads int64, err error)
 	GetUserVDRatioSinceCutoff(ctx context.Context, userID string, since time.Time) (views int64, downloads int64, err error)
 	DeleteOldEvents(ctx context.Context, before time.Time) (int64, error)
+	DailySchematicUploads(ctx context.Context, since time.Time) ([]DailyCount, error)
 }
 
 // NBTHash represents a stored NBT file hash for duplicate/blacklist detection.

--- a/template/site-stats.html
+++ b/template/site-stats.html
@@ -18,7 +18,23 @@
                 </div>
 
                 <div class="row row-deck row-cards mb-3">
-                    <div class="col-sm-6 col-lg-4">
+                    <div class="col-6 col-lg-3">
+                        <div class="card card-sm">
+                            <div class="card-body">
+                                <div class="subheader">{{ T .Language "Total Schematics" }}</div>
+                                <div class="h1 mb-0">{{ .TotalSchematics }}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-6 col-lg-3">
+                        <div class="card card-sm">
+                            <div class="card-body">
+                                <div class="subheader">{{ T .Language "Drafts" }}</div>
+                                <div class="h1 mb-0">{{ .TotalDrafts }}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-6 col-lg-3">
                         <div class="card card-sm">
                             <div class="card-body">
                                 <div class="subheader">{{ T .Language "Views (30d)" }}</div>
@@ -26,7 +42,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-6 col-lg-4">
+                    <div class="col-6 col-lg-3">
                         <div class="card card-sm">
                             <div class="card-body">
                                 <div class="subheader">{{ T .Language "Downloads (30d)" }}</div>
@@ -34,12 +50,13 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-6 col-lg-4">
-                        <div class="card card-sm">
-                            <div class="card-body">
-                                <div class="subheader">{{ T .Language "Download/View Ratio" }}</div>
-                                <div class="h1 mb-0">{{ .GlobalVDRatio }}</div>
-                            </div>
+                </div>
+
+                <div class="row row-deck row-cards mb-3">
+                    <div class="col-12">
+                        <div class="card">
+                            <div class="card-header"><h3 class="card-title">{{ T .Language "Uploads per Day (30d)" }}</h3></div>
+                            <div class="card-body" style="overflow:hidden;min-width:0;"><div id="chart-uploads" style="min-height:250px;width:100%;"></div></div>
                         </div>
                     </div>
                 </div>
@@ -212,7 +229,7 @@
 (function() {
     function initSiteCharts() {
         if (typeof ApexCharts === 'undefined') return;
-        ['chart-views', 'chart-downloads'].forEach(function(id) {
+        ['chart-uploads', 'chart-views', 'chart-downloads'].forEach(function(id) {
             var el = document.getElementById(id);
             if (el && el._apexChart) { el._apexChart.destroy(); el._apexChart = null; }
         });
@@ -229,6 +246,15 @@
             tooltip: { theme: isDark ? 'dark' : 'light' }
         };
         function renderChart(el, opts) { var c = new ApexCharts(el, opts); el._apexChart = c; c.render(); }
+        var uploadsEl = document.getElementById('chart-uploads');
+        if (uploadsEl) {
+            renderChart(uploadsEl, Object.assign({}, commonOpts, {
+                chart: { type: 'bar', height: 250, toolbar: { show: false }, zoom: { enabled: false }, foreColor: fg },
+                series: [{ name: 'Uploads', data: {{ .DailyUploadsJSON }} }],
+                colors: ['#bf9045'],
+                plotOptions: { bar: { borderRadius: 3, columnWidth: '60%' } }
+            }));
+        }
         var viewsEl = document.getElementById('chart-views');
         if (viewsEl) {
             renderChart(viewsEl, Object.assign({}, commonOpts, {


### PR DESCRIPTION
Show total published schematics, total drafts (temp uploads), and a 30-day uploads-per-day bar chart on the public stats page alongside the existing views and downloads metrics.