### PR TITLE
Update latest news article with follow feature, generator improvements

### DIFF
--- a/content/news/2026-05-security-and-features.md
+++ b/content/news/2026-05-security-and-features.md
@@ -1,12 +1,16 @@
 ---
-title: "360 Viewer, Short Codes & Security Update"
+title: "Follow Creators, 360 Viewer, Short Codes & More"
 date: 2026-05-17
 slug: security-update-rotation-images
-excerpt: "360 viewer for schematics, short codes for easy sharing, improved search filters, performance optimizations, and a major security hardening pass."
+excerpt: "Follow your favorite creators and categories, 360 viewer for schematics, short codes for easy sharing, improved generators, and performance optimizations."
 image: "/assets/x/news/security-and-features.webp"
 ---
 
-We have been busy the past few weeks with a large update focused on new features, performance, and security.
+We have been busy the past few weeks with a large update focused on new features, generators, and performance.
+
+## Follow Creators and Categories
+
+You can now follow your favorite creators and categories. When you follow a creator or category you will see their latest uploads on your personalized feed, making it easier to stay up to date with the builds you care about.
 
 ## 360 Viewer
 
@@ -30,17 +34,15 @@ The leaderboard page now shows 100 creators per page in a two-column layout with
 - User stats page loads faster with parallelized queries and better caching
 - Fixed a bug where hourly view counts were inflated
 
+## Generators
+
+- Balloon generator now places envelopes on the inside of ribs and ribs can be offset
+- Ship hull generator has been improved with better hull shaping
+
 ## Other Improvements
 
 - Passkey registration UX fix
 - Dark mode styling fixes
-- Hull generator now supports ship presets
 - New placeholder images for schematics without thumbnails
-- Added Meilisearch to local development setup
-- Dockerfile now runs as a non-root user
-
-## Security
-
-A comprehensive security review has been completed and all findings have been addressed. This includes improvements to authentication, access control, rate limiting, and input validation across the site.
 
 If you have feedback or run into issues, reach out on the [contact page](/contact).

--- a/content/news/2026-05-security-and-features.md
+++ b/content/news/2026-05-security-and-features.md
@@ -6,7 +6,11 @@ excerpt: "Follow your favorite creators and categories, 360 viewer for schematic
 image: "/assets/x/news/security-and-features.webp"
 ---
 
-We have been busy the past few weeks with a large update focused on new features, generators, and performance.
+We have been busy the past few weeks with a large update focused on new features, a UI overhaul, generators, and performance.
+
+## UI Overhaul
+
+The site has received a visual refresh with a focus on making better use of screen space. Most pages are now full width, giving schematics and content more room to breathe. Creator profile pages now prominently display social links so you can connect with builders across platforms.
 
 ## Follow Creators and Categories
 
@@ -22,7 +26,7 @@ Every schematic now gets a unique short code for easy sharing. These are short a
 
 ## Search and Mods
 
-The search page has been updated with improved filter controls including tag and mod dropdowns, a per-page selector, and better pagination. The mods section has been expanded with detailed mod pages showing compatible schematics.
+The search page has been updated with improved filter controls including tag and mod dropdowns, a per-page selector, and better pagination. Mod pages are now searchable and the mods section has been expanded with detailed mod pages showing compatible schematics.
 
 ## Top Creators
 


### PR DESCRIPTION
Add follow creators/categories as top feature, add balloon envelope and rib offset fixes, improve ship hull mention, remove Dockerfile and security sections from public-facing news.