### PR TITLE
Fix login error display and SMTP STARTTLS for email delivery

### DIFF
--- a/internal/i18n/en.go
+++ b/internal/i18n/en.go
@@ -755,6 +755,7 @@ var LangEN = map[string]string{
 	"Invalid email":    "Invalid email",
 	"Invalid password": "Invalid password",
 	"Invalid username": "Invalid username",
+	"Invalid username or password.": "Invalid username or password.",
 	"You must agree to the Terms Of Service": "You must agree to the Terms Of Service",
 
 	// ── Admin: Schematic Edit ──

--- a/internal/i18n/es.go
+++ b/internal/i18n/es.go
@@ -818,4 +818,58 @@ var LangES = map[string]string{
 	// ── Upload / Publish ──
 	"Select a category":   "Selecciona una categoría",
 	"delete_draft.confirm": "¿Estás seguro de que quieres eliminar este borrador? Esta acción no se puede deshacer.",
+
+	// ── News ──
+	"CHANGELOG":            "REGISTRO DE CAMBIOS",
+	"RSS feed":             "Canal RSS",
+	"Read the changelog":   "Leer el registro de cambios",
+	"posts":                "publicaciones",
+	"Updates from the workshop - release notes, site changes, and shoutouts to the community.": "Actualizaciones del taller - notas de versión, cambios en el sitio y menciones a la comunidad.",
+	"There are no news posts available at the moment. Please check back later.": "No hay publicaciones disponibles en este momento. Por favor, vuelve más tarde.",
+
+	// ── Login ──
+	"Invalid username or password.": "Nombre de usuario o contraseña incorrectos.",
+
+	// ── Following ──
+	"following.email.tooltip": "Frecuencia de notificación por correo. Cambia en los ajustes de suscripción.",
+
+	// ── Top Creators ──
+	"page.topcreators.description": "Descubre los mejores creadores de la comunidad del mod Create, clasificados por puntos de contribución obtenidos a través de subidas, interacciones y logros.",
+
+	// ── API Documentation ──
+	"Getting Started":      "Primeros pasos",
+	"Request":              "Solicitud",
+	"Response Headers":     "Cabeceras de respuesta",
+	"User":                 "Usuario",
+	"Your API key":         "Tu clave de API",
+	"Save Key (this session)": "Guardar clave (esta sesión)",
+	"Page number":          "Número de página",
+	"Page number for the schematic list": "Número de página para la lista de esquemas",
+	"Display title. 2-80 characters.": "Título visible. 2-80 caracteres.",
+	"Markdown supported. Max 4000 characters.": "Se admite Markdown. Máximo 4000 caracteres.",
+	"Up to 10 lowercase tags.": "Hasta 10 etiquetas en minúsculas.",
+	"Up to 3 from the category list.": "Hasta 3 de la lista de categorías.",
+	"The .nbt schematic file. Max 5 MB.": "El archivo de esquema .nbt. Máximo 5 MB.",
+	"Used to populate requests below. Stored only in this tab.": "Se usa para completar las solicitudes a continuación. Solo se almacena en esta pestaña.",
+	"Keys are shown once at creation, store them securely. Never embed keys in client-side code.": "Las claves se muestran una vez al crearlas, guárdalas de forma segura. Nunca incluyas claves en código del lado del cliente.",
+	"Integrate with CreateMod.com to search, retrieve, and upload schematics programmatically. The API is REST-style, returns JSON, and is rate-limited per key.": "Integra con CreateMod.com para buscar, obtener y subir esquemas de forma programática. La API es estilo REST, devuelve JSON y tiene límite de peticiones por clave.",
+	"Search or list schematics. Returns newest schematics when no query is provided. Results are paginated with 24 items per page.": "Busca o lista esquemas. Devuelve los esquemas más recientes cuando no se proporciona consulta. Los resultados están paginados con 24 elementos por página.",
+	"Get detailed information about a single schematic by its URL name (slug).": "Obtén información detallada de un esquema por su nombre de URL (slug).",
+	"Get aggregate hourly analytics across all your schematics, plus a paginated list of schematics with per-schematic totals.": "Obtén analíticas horarias agregadas de todos tus esquemas, más una lista paginada con totales por esquema.",
+	"Get hourly analytics for a single schematic over the last 30 days. Useful for charting views, downloads, and engagement on a schematic detail page.": "Obtén analíticas horarias de un esquema durante los últimos 30 días. Útil para graficar vistas, descargas e interacción en la página de detalle.",
+	"Upload a new schematic. Send a": "Sube un nuevo esquema. Envía una",
+	"URL slug of the schematic (path parameter).": "Slug de URL del esquema (parámetro de ruta).",
+	"The API uses conventional HTTP status codes.": "La API usa códigos de estado HTTP convencionales.",
+	"All error responses return JSON with a single": "Todas las respuestas de error devuelven JSON con un solo",
+	"field describing the problem:": "campo que describe el problema:",
+	"indicates success,": "indica éxito,",
+	"a client-side problem, and": "un problema del lado del cliente, y",
+	"a server-side problem.": "un problema del lado del servidor.",
+	"The": "El",
+	"header. Keys are scoped to your account and inherit your user-level rate limits.": "cabecera. Las claves están vinculadas a tu cuenta y heredan tus límites de velocidad.",
+	"header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle.": "cabecera que indica los segundos de espera. Cada respuesta incluye cabeceras de límite de velocidad para que puedas autorregularte.",
+	"request with the": "solicitud con el",
+	"file plus metadata. Duplicate file hashes return": "archivo más metadatos. Los hashes de archivo duplicados devuelven",
+	"Each array contains one entry per hour for 30 days (720 entries). Hours with no data have": "Cada array contiene una entrada por hora durante 30 días (720 entradas). Las horas sin datos tienen",
+	"values are averages in seconds.": "los valores son promedios en segundos.",
 }

--- a/internal/i18n/fr.go
+++ b/internal/i18n/fr.go
@@ -818,4 +818,58 @@ var LangFR = map[string]string{
 	// ── Upload / Publish ──
 	"Select a category":   "Sélectionner une catégorie",
 	"delete_draft.confirm": "Êtes-vous sûr de vouloir supprimer ce brouillon ? Cette action est irréversible.",
+
+	// ── News ──
+	"CHANGELOG":            "JOURNAL DES MODIFICATIONS",
+	"RSS feed":             "Flux RSS",
+	"Read the changelog":   "Lire le journal des modifications",
+	"posts":                "articles",
+	"Updates from the workshop - release notes, site changes, and shoutouts to the community.": "Nouvelles de l'atelier - notes de version, changements du site et mentions de la communauté.",
+	"There are no news posts available at the moment. Please check back later.": "Aucun article disponible pour le moment. Veuillez revenir plus tard.",
+
+	// ── Login ──
+	"Invalid username or password.": "Nom d'utilisateur ou mot de passe incorrect.",
+
+	// ── Following ──
+	"following.email.tooltip": "Fréquence des notifications par e-mail. Modifiable dans les paramètres d'abonnement.",
+
+	// ── Top Creators ──
+	"page.topcreators.description": "Découvrez les meilleurs créateurs de la communauté du mod Create, classés par points de contribution obtenus grâce aux mises en ligne, à l'engagement et aux accomplissements.",
+
+	// ── API Documentation ──
+	"Getting Started":      "Pour commencer",
+	"Request":              "Requête",
+	"Response Headers":     "En-têtes de réponse",
+	"User":                 "Utilisateur",
+	"Your API key":         "Votre clé API",
+	"Save Key (this session)": "Enregistrer la clé (cette session)",
+	"Page number":          "Numéro de page",
+	"Page number for the schematic list": "Numéro de page pour la liste des schémas",
+	"Display title. 2-80 characters.": "Titre affiché. 2-80 caractères.",
+	"Markdown supported. Max 4000 characters.": "Markdown pris en charge. Maximum 4000 caractères.",
+	"Up to 10 lowercase tags.": "Jusqu'à 10 tags en minuscules.",
+	"Up to 3 from the category list.": "Jusqu'à 3 de la liste des catégories.",
+	"The .nbt schematic file. Max 5 MB.": "Le fichier schéma .nbt. Maximum 5 Mo.",
+	"Used to populate requests below. Stored only in this tab.": "Utilisé pour remplir les requêtes ci-dessous. Stocké uniquement dans cet onglet.",
+	"Keys are shown once at creation, store them securely. Never embed keys in client-side code.": "Les clés sont affichées une seule fois à la création, conservez-les en sécurité. N'intégrez jamais de clés dans du code côté client.",
+	"Integrate with CreateMod.com to search, retrieve, and upload schematics programmatically. The API is REST-style, returns JSON, and is rate-limited per key.": "Intégrez CreateMod.com pour rechercher, récupérer et téléverser des schémas par programmation. L'API est de style REST, renvoie du JSON et est limitée en débit par clé.",
+	"Search or list schematics. Returns newest schematics when no query is provided. Results are paginated with 24 items per page.": "Rechercher ou lister des schémas. Renvoie les schémas les plus récents sans requête. Les résultats sont paginés avec 24 éléments par page.",
+	"Get detailed information about a single schematic by its URL name (slug).": "Obtenir des informations détaillées sur un schéma par son nom d'URL (slug).",
+	"Get aggregate hourly analytics across all your schematics, plus a paginated list of schematics with per-schematic totals.": "Obtenez des analyses horaires agrégées de tous vos schémas, plus une liste paginée avec des totaux par schéma.",
+	"Get hourly analytics for a single schematic over the last 30 days. Useful for charting views, downloads, and engagement on a schematic detail page.": "Obtenez des analyses horaires d'un schéma sur les 30 derniers jours. Utile pour visualiser les vues, téléchargements et l'engagement.",
+	"Upload a new schematic. Send a": "Téléverser un nouveau schéma. Envoyez une",
+	"URL slug of the schematic (path parameter).": "Slug d'URL du schéma (paramètre de chemin).",
+	"The API uses conventional HTTP status codes.": "L'API utilise les codes de statut HTTP conventionnels.",
+	"All error responses return JSON with a single": "Toutes les réponses d'erreur renvoient du JSON avec un seul",
+	"field describing the problem:": "champ décrivant le problème :",
+	"indicates success,": "indique le succès,",
+	"a client-side problem, and": "un problème côté client, et",
+	"a server-side problem.": "un problème côté serveur.",
+	"The": "Le",
+	"header. Keys are scoped to your account and inherit your user-level rate limits.": "en-tête. Les clés sont liées à votre compte et héritent de vos limites de débit.",
+	"header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle.": "en-tête indiquant les secondes d'attente. Chaque réponse inclut des en-têtes de limite de débit pour l'auto-régulation.",
+	"request with the": "requête avec le",
+	"file plus metadata. Duplicate file hashes return": "fichier plus métadonnées. Les hashes de fichiers dupliqués renvoient",
+	"Each array contains one entry per hour for 30 days (720 entries). Hours with no data have": "Chaque tableau contient une entrée par heure pendant 30 jours (720 entrées). Les heures sans données ont",
+	"values are averages in seconds.": "les valeurs sont des moyennes en secondes.",
 }

--- a/internal/i18n/pl.go
+++ b/internal/i18n/pl.go
@@ -819,4 +819,58 @@ var LangPL = map[string]string{
 	// ── Upload / Publish ──
 	"Select a category":   "Wybierz kategorię",
 	"delete_draft.confirm": "Czy na pewno chcesz usunąć ten szkic? Tej operacji nie można cofnąć.",
+
+	// ── News ──
+	"CHANGELOG":            "DZIENNIK ZMIAN",
+	"RSS feed":             "Kanał RSS",
+	"Read the changelog":   "Przeczytaj dziennik zmian",
+	"posts":                "wpisy",
+	"Updates from the workshop - release notes, site changes, and shoutouts to the community.": "Aktualności z warsztatu - informacje o wydaniach, zmiany na stronie i podziękowania dla społeczności.",
+	"There are no news posts available at the moment. Please check back later.": "W tej chwili nie ma dostępnych wpisów. Sprawdź ponownie później.",
+
+	// ── Login ──
+	"Invalid username or password.": "Nieprawidłowa nazwa użytkownika lub hasło.",
+
+	// ── Following ──
+	"following.email.tooltip": "Częstotliwość powiadomień e-mail. Zmień w ustawieniach subskrypcji.",
+
+	// ── Top Creators ──
+	"page.topcreators.description": "Odkryj najlepszych twórców społeczności moda Create, uszeregowanych według punktów kontrybucji zdobytych za przesyłanie, zaangażowanie i osiągnięcia.",
+
+	// ── API Documentation ──
+	"Getting Started":      "Rozpoczęcie",
+	"Request":              "Żądanie",
+	"Response Headers":     "Nagłówki odpowiedzi",
+	"User":                 "Użytkownik",
+	"Your API key":         "Twój klucz API",
+	"Save Key (this session)": "Zapisz klucz (ta sesja)",
+	"Page number":          "Numer strony",
+	"Page number for the schematic list": "Numer strony listy schematów",
+	"Display title. 2-80 characters.": "Tytuł wyświetlany. 2-80 znaków.",
+	"Markdown supported. Max 4000 characters.": "Obsługiwany Markdown. Maksymalnie 4000 znaków.",
+	"Up to 10 lowercase tags.": "Do 10 tagów małymi literami.",
+	"Up to 3 from the category list.": "Do 3 z listy kategorii.",
+	"The .nbt schematic file. Max 5 MB.": "Plik schematu .nbt. Maksymalnie 5 MB.",
+	"Used to populate requests below. Stored only in this tab.": "Używany do wypełniania żądań poniżej. Przechowywany tylko w tej karcie.",
+	"Keys are shown once at creation, store them securely. Never embed keys in client-side code.": "Klucze są wyświetlane tylko raz przy tworzeniu, przechowuj je bezpiecznie. Nigdy nie umieszczaj kluczy w kodzie po stronie klienta.",
+	"Integrate with CreateMod.com to search, retrieve, and upload schematics programmatically. The API is REST-style, returns JSON, and is rate-limited per key.": "Integruj się z CreateMod.com, aby programowo wyszukiwać, pobierać i przesyłać schematy. API jest w stylu REST, zwraca JSON i ma limit zapytań na klucz.",
+	"Search or list schematics. Returns newest schematics when no query is provided. Results are paginated with 24 items per page.": "Wyszukuj lub wyświetlaj schematy. Zwraca najnowsze schematy gdy nie podano zapytania. Wyniki są paginowane po 24 elementy na stronę.",
+	"Get detailed information about a single schematic by its URL name (slug).": "Pobierz szczegółowe informacje o schemacie po jego nazwie URL (slug).",
+	"Get aggregate hourly analytics across all your schematics, plus a paginated list of schematics with per-schematic totals.": "Pobierz zagregowane godzinowe analizy ze wszystkich schematów oraz paginowaną listę z sumami dla każdego schematu.",
+	"Get hourly analytics for a single schematic over the last 30 days. Useful for charting views, downloads, and engagement on a schematic detail page.": "Pobierz godzinowe analizy pojedynczego schematu z ostatnich 30 dni. Przydatne do wykresów wyświetleń, pobrań i zaangażowania.",
+	"Upload a new schematic. Send a": "Prześlij nowy schemat. Wyślij",
+	"URL slug of the schematic (path parameter).": "Slug URL schematu (parametr ścieżki).",
+	"The API uses conventional HTTP status codes.": "API używa konwencjonalnych kodów statusu HTTP.",
+	"All error responses return JSON with a single": "Wszystkie odpowiedzi błędów zwracają JSON z pojedynczym",
+	"field describing the problem:": "polem opisującym problem:",
+	"indicates success,": "oznacza sukces,",
+	"a client-side problem, and": "problem po stronie klienta, a",
+	"a server-side problem.": "problem po stronie serwera.",
+	"The": "Nagłówek",
+	"header. Keys are scoped to your account and inherit your user-level rate limits.": "Klucze są powiązane z kontem i dziedziczą limity zapytań użytkownika.",
+	"header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle.": "nagłówek wskazujący sekundy oczekiwania. Każda odpowiedź zawiera nagłówki limitu zapytań.",
+	"request with the": "żądanie z",
+	"file plus metadata. Duplicate file hashes return": "plik plus metadane. Zduplikowane hashe plików zwracają",
+	"Each array contains one entry per hour for 30 days (720 entries). Hours with no data have": "Każda tablica zawiera jeden wpis na godzinę przez 30 dni (720 wpisów). Godziny bez danych mają",
+	"values are averages in seconds.": "wartości są średnimi w sekundach.",
 }

--- a/internal/i18n/pt_br.go
+++ b/internal/i18n/pt_br.go
@@ -843,4 +843,58 @@ var LangPtBR = map[string]string{
 	// ── Upload / Publish ──
 	"Select a category":   "Selecione uma categoria",
 	"delete_draft.confirm": "Tem certeza de que deseja excluir este rascunho? Esta ação não pode ser desfeita.",
+
+	// ── News ──
+	"CHANGELOG":            "REGISTRO DE ALTERAÇÕES",
+	"RSS feed":             "Feed RSS",
+	"Read the changelog":   "Ler o registro de alterações",
+	"posts":                "publicações",
+	"Updates from the workshop - release notes, site changes, and shoutouts to the community.": "Novidades da oficina - notas de versão, mudanças no site e menções à comunidade.",
+	"There are no news posts available at the moment. Please check back later.": "Não há publicações disponíveis no momento. Por favor, volte mais tarde.",
+
+	// ── Login ──
+	"Invalid username or password.": "Nome de usuário ou senha incorretos.",
+
+	// ── Following ──
+	"following.email.tooltip": "Frequência de notificação por e-mail. Altere nas configurações de assinatura.",
+
+	// ── Top Creators ──
+	"page.topcreators.description": "Descubra os melhores criadores da comunidade do mod Create, classificados por pontos de contribuição obtidos através de uploads, engajamento e conquistas.",
+
+	// ── API Documentation ──
+	"Getting Started":      "Primeiros passos",
+	"Request":              "Requisição",
+	"Response Headers":     "Cabeçalhos de resposta",
+	"User":                 "Usuário",
+	"Your API key":         "Sua chave de API",
+	"Save Key (this session)": "Salvar chave (esta sessão)",
+	"Page number":          "Número da página",
+	"Page number for the schematic list": "Número da página para a lista de schematics",
+	"Display title. 2-80 characters.": "Título de exibição. 2-80 caracteres.",
+	"Markdown supported. Max 4000 characters.": "Markdown suportado. Máximo 4000 caracteres.",
+	"Up to 10 lowercase tags.": "Até 10 tags em minúsculas.",
+	"Up to 3 from the category list.": "Até 3 da lista de categorias.",
+	"The .nbt schematic file. Max 5 MB.": "O arquivo schematic .nbt. Máximo 5 MB.",
+	"Used to populate requests below. Stored only in this tab.": "Usado para preencher as requisições abaixo. Armazenado apenas nesta aba.",
+	"Keys are shown once at creation, store them securely. Never embed keys in client-side code.": "As chaves são exibidas apenas uma vez na criação, armazene-as com segurança. Nunca inclua chaves em código do lado do cliente.",
+	"Integrate with CreateMod.com to search, retrieve, and upload schematics programmatically. The API is REST-style, returns JSON, and is rate-limited per key.": "Integre com CreateMod.com para buscar, obter e enviar schematics programaticamente. A API é estilo REST, retorna JSON e tem limite de requisições por chave.",
+	"Search or list schematics. Returns newest schematics when no query is provided. Results are paginated with 24 items per page.": "Buscar ou listar schematics. Retorna os schematics mais recentes quando nenhuma consulta é fornecida. Resultados paginados com 24 itens por página.",
+	"Get detailed information about a single schematic by its URL name (slug).": "Obtenha informações detalhadas de um schematic pelo nome da URL (slug).",
+	"Get aggregate hourly analytics across all your schematics, plus a paginated list of schematics with per-schematic totals.": "Obtenha análises horárias agregadas de todos os seus schematics, mais uma lista paginada com totais por schematic.",
+	"Get hourly analytics for a single schematic over the last 30 days. Useful for charting views, downloads, and engagement on a schematic detail page.": "Obtenha análises horárias de um schematic nos últimos 30 dias. Útil para gráficos de visualizações, downloads e engajamento.",
+	"Upload a new schematic. Send a": "Enviar um novo schematic. Envie uma",
+	"URL slug of the schematic (path parameter).": "Slug da URL do schematic (parâmetro de caminho).",
+	"The API uses conventional HTTP status codes.": "A API usa códigos de status HTTP convencionais.",
+	"All error responses return JSON with a single": "Todas as respostas de erro retornam JSON com um único",
+	"field describing the problem:": "campo descrevendo o problema:",
+	"indicates success,": "indica sucesso,",
+	"a client-side problem, and": "um problema do lado do cliente, e",
+	"a server-side problem.": "um problema do lado do servidor.",
+	"The": "O",
+	"header. Keys are scoped to your account and inherit your user-level rate limits.": "cabeçalho. As chaves são vinculadas à sua conta e herdam seus limites de requisições.",
+	"header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle.": "cabeçalho indicando segundos de espera. Cada resposta inclui cabeçalhos de limite de requisições para autorregulação.",
+	"request with the": "requisição com o",
+	"file plus metadata. Duplicate file hashes return": "arquivo mais metadados. Hashes de arquivos duplicados retornam",
+	"Each array contains one entry per hour for 30 days (720 entries). Hours with no data have": "Cada array contém uma entrada por hora durante 30 dias (720 entradas). Horas sem dados têm",
+	"values are averages in seconds.": "os valores são médias em segundos.",
 }

--- a/internal/i18n/pt_pt.go
+++ b/internal/i18n/pt_pt.go
@@ -843,4 +843,58 @@ var LangPtPT = map[string]string{
 	// ── Upload / Publish ──
 	"Select a category":   "Seleciona uma categoria",
 	"delete_draft.confirm": "Tens a certeza de que queres eliminar este rascunho? Esta ação não pode ser revertida.",
+
+	// ── News ──
+	"CHANGELOG":            "REGISTO DE ALTERAÇÕES",
+	"RSS feed":             "Feed RSS",
+	"Read the changelog":   "Ler o registo de alterações",
+	"posts":                "publicações",
+	"Updates from the workshop - release notes, site changes, and shoutouts to the community.": "Novidades da oficina - notas de lançamento, alterações ao site e menções à comunidade.",
+	"There are no news posts available at the moment. Please check back later.": "Não há publicações disponíveis de momento. Por favor, volte mais tarde.",
+
+	// ── Login ──
+	"Invalid username or password.": "Nome de utilizador ou palavra-passe incorretos.",
+
+	// ── Following ──
+	"following.email.tooltip": "Frequência de notificação por e-mail. Altere nas definições de subscrição.",
+
+	// ── Top Creators ──
+	"page.topcreators.description": "Descubra os melhores criadores da comunidade do mod Create, classificados por pontos de contribuição obtidos através de carregamentos, envolvimento e conquistas.",
+
+	// ── API Documentation ──
+	"Getting Started":      "Começar",
+	"Request":              "Pedido",
+	"Response Headers":     "Cabeçalhos de resposta",
+	"User":                 "Utilizador",
+	"Your API key":         "A sua chave de API",
+	"Save Key (this session)": "Guardar chave (esta sessão)",
+	"Page number":          "Número da página",
+	"Page number for the schematic list": "Número da página para a lista de schematics",
+	"Display title. 2-80 characters.": "Título de apresentação. 2-80 caracteres.",
+	"Markdown supported. Max 4000 characters.": "Markdown suportado. Máximo 4000 caracteres.",
+	"Up to 10 lowercase tags.": "Até 10 etiquetas em minúsculas.",
+	"Up to 3 from the category list.": "Até 3 da lista de categorias.",
+	"The .nbt schematic file. Max 5 MB.": "O ficheiro schematic .nbt. Máximo 5 MB.",
+	"Used to populate requests below. Stored only in this tab.": "Usado para preencher os pedidos abaixo. Armazenado apenas neste separador.",
+	"Keys are shown once at creation, store them securely. Never embed keys in client-side code.": "As chaves são mostradas apenas uma vez na criação, guarde-as em segurança. Nunca inclua chaves em código do lado do cliente.",
+	"Integrate with CreateMod.com to search, retrieve, and upload schematics programmatically. The API is REST-style, returns JSON, and is rate-limited per key.": "Integre com CreateMod.com para pesquisar, obter e carregar schematics programaticamente. A API é estilo REST, devolve JSON e tem limite de pedidos por chave.",
+	"Search or list schematics. Returns newest schematics when no query is provided. Results are paginated with 24 items per page.": "Pesquisar ou listar schematics. Devolve os schematics mais recentes sem consulta. Os resultados são paginados com 24 itens por página.",
+	"Get detailed information about a single schematic by its URL name (slug).": "Obtenha informações detalhadas de um schematic pelo nome de URL (slug).",
+	"Get aggregate hourly analytics across all your schematics, plus a paginated list of schematics with per-schematic totals.": "Obtenha análises horárias agregadas de todos os seus schematics, mais uma lista paginada com totais por schematic.",
+	"Get hourly analytics for a single schematic over the last 30 days. Useful for charting views, downloads, and engagement on a schematic detail page.": "Obtenha análises horárias de um schematic nos últimos 30 dias. Útil para gráficos de visualizações, transferências e envolvimento.",
+	"Upload a new schematic. Send a": "Carregar um novo schematic. Envie um",
+	"URL slug of the schematic (path parameter).": "Slug do URL do schematic (parâmetro de caminho).",
+	"The API uses conventional HTTP status codes.": "A API usa códigos de estado HTTP convencionais.",
+	"All error responses return JSON with a single": "Todas as respostas de erro devolvem JSON com um único",
+	"field describing the problem:": "campo a descrever o problema:",
+	"indicates success,": "indica sucesso,",
+	"a client-side problem, and": "um problema do lado do cliente, e",
+	"a server-side problem.": "um problema do lado do servidor.",
+	"The": "O",
+	"header. Keys are scoped to your account and inherit your user-level rate limits.": "cabeçalho. As chaves estão vinculadas à sua conta e herdam os seus limites de pedidos.",
+	"header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle.": "cabeçalho a indicar segundos de espera. Cada resposta inclui cabeçalhos de limite de pedidos para autorregulação.",
+	"request with the": "pedido com o",
+	"file plus metadata. Duplicate file hashes return": "ficheiro mais metadados. Hashes de ficheiros duplicados devolvem",
+	"Each array contains one entry per hour for 30 days (720 entries). Hours with no data have": "Cada array contém uma entrada por hora durante 30 dias (720 entradas). As horas sem dados têm",
+	"values are averages in seconds.": "os valores são médias em segundos.",
 }

--- a/internal/i18n/ru.go
+++ b/internal/i18n/ru.go
@@ -820,4 +820,58 @@ var LangRU = map[string]string{
 	// ── Upload / Publish ──
 	"Select a category":   "Выберите категорию",
 	"delete_draft.confirm": "Вы уверены, что хотите удалить этот черновик? Это действие нельзя отменить.",
+
+	// ── News ──
+	"CHANGELOG":            "ЖУРНАЛ ИЗМЕНЕНИЙ",
+	"RSS feed":             "RSS-канал",
+	"Read the changelog":   "Читать журнал изменений",
+	"posts":                "записей",
+	"Updates from the workshop - release notes, site changes, and shoutouts to the community.": "Новости из мастерской - заметки о выпусках, изменения на сайте и благодарности сообществу.",
+	"There are no news posts available at the moment. Please check back later.": "На данный момент нет доступных записей. Пожалуйста, загляните позже.",
+
+	// ── Login ──
+	"Invalid username or password.": "Неверное имя пользователя или пароль.",
+
+	// ── Following ──
+	"following.email.tooltip": "Частота уведомлений по электронной почте. Измените в настройках подписки.",
+
+	// ── Top Creators ──
+	"page.topcreators.description": "Откройте для себя лучших создателей сообщества мода Create, ранжированных по очкам вклада за загрузки, активность и достижения.",
+
+	// ── API Documentation ──
+	"Getting Started":      "Начало работы",
+	"Request":              "Запрос",
+	"Response Headers":     "Заголовки ответа",
+	"User":                 "Пользователь",
+	"Your API key":         "Ваш ключ API",
+	"Save Key (this session)": "Сохранить ключ (эта сессия)",
+	"Page number":          "Номер страницы",
+	"Page number for the schematic list": "Номер страницы для списка схем",
+	"Display title. 2-80 characters.": "Отображаемое название. 2-80 символов.",
+	"Markdown supported. Max 4000 characters.": "Поддерживается Markdown. Максимум 4000 символов.",
+	"Up to 10 lowercase tags.": "До 10 тегов в нижнем регистре.",
+	"Up to 3 from the category list.": "До 3 из списка категорий.",
+	"The .nbt schematic file. Max 5 MB.": "Файл схемы .nbt. Максимум 5 МБ.",
+	"Used to populate requests below. Stored only in this tab.": "Используется для заполнения запросов ниже. Хранится только в этой вкладке.",
+	"Keys are shown once at creation, store them securely. Never embed keys in client-side code.": "Ключи показываются один раз при создании, храните их надёжно. Никогда не встраивайте ключи в клиентский код.",
+	"Integrate with CreateMod.com to search, retrieve, and upload schematics programmatically. The API is REST-style, returns JSON, and is rate-limited per key.": "Интегрируйтесь с CreateMod.com для программного поиска, получения и загрузки схем. API в стиле REST, возвращает JSON и имеет лимит запросов на ключ.",
+	"Search or list schematics. Returns newest schematics when no query is provided. Results are paginated with 24 items per page.": "Поиск или список схем. Возвращает новейшие схемы без запроса. Результаты пагинированы по 24 элемента на страницу.",
+	"Get detailed information about a single schematic by its URL name (slug).": "Получить подробную информацию о схеме по её URL-имени (slug).",
+	"Get aggregate hourly analytics across all your schematics, plus a paginated list of schematics with per-schematic totals.": "Получите агрегированную почасовую аналитику по всем схемам, а также пагинированный список с итогами по каждой схеме.",
+	"Get hourly analytics for a single schematic over the last 30 days. Useful for charting views, downloads, and engagement on a schematic detail page.": "Получите почасовую аналитику схемы за последние 30 дней. Полезно для графиков просмотров, загрузок и активности.",
+	"Upload a new schematic. Send a": "Загрузить новую схему. Отправьте",
+	"URL slug of the schematic (path parameter).": "URL-slug схемы (параметр пути).",
+	"The API uses conventional HTTP status codes.": "API использует стандартные коды состояния HTTP.",
+	"All error responses return JSON with a single": "Все ответы с ошибками возвращают JSON с единственным",
+	"field describing the problem:": "полем, описывающим проблему:",
+	"indicates success,": "означает успех,",
+	"a client-side problem, and": "проблему на стороне клиента, а",
+	"a server-side problem.": "проблему на стороне сервера.",
+	"The": "Заголовок",
+	"header. Keys are scoped to your account and inherit your user-level rate limits.": "Ключи привязаны к вашему аккаунту и наследуют ваши лимиты запросов.",
+	"header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle.": "заголовок, указывающий секунды ожидания. Каждый ответ включает заголовки лимита запросов для саморегулирования.",
+	"request with the": "запрос с",
+	"file plus metadata. Duplicate file hashes return": "файл плюс метаданные. Дублирующиеся хеши файлов возвращают",
+	"Each array contains one entry per hour for 30 days (720 entries). Hours with no data have": "Каждый массив содержит одну запись в час за 30 дней (720 записей). Часы без данных имеют",
+	"values are averages in seconds.": "значения являются средними в секундах.",
 }

--- a/internal/i18n/zh_hans.go
+++ b/internal/i18n/zh_hans.go
@@ -819,4 +819,58 @@ var LangZhHans = map[string]string{
 	// ── Upload / Publish ──
 	"Select a category":   "选择分类",
 	"delete_draft.confirm": "确定要删除此草稿吗？此操作无法撤消。",
+
+	// ── News ──
+	"CHANGELOG":            "更新日志",
+	"RSS feed":             "RSS 订阅",
+	"Read the changelog":   "阅读更新日志",
+	"posts":                "篇文章",
+	"Updates from the workshop - release notes, site changes, and shoutouts to the community.": "工坊更新 - 版本说明、站点变更及社区致谢。",
+	"There are no news posts available at the moment. Please check back later.": "目前没有可用的新闻。请稍后再来查看。",
+
+	// ── Login ──
+	"Invalid username or password.": "用户名或密码错误。",
+
+	// ── Following ──
+	"following.email.tooltip": "邮件通知频率。在订阅设置中更改。",
+
+	// ── Top Creators ──
+	"page.topcreators.description": "发现 Create 模组社区的顶尖创作者，按通过上传、互动和成就获得的贡献积分排名。",
+
+	// ── API Documentation ──
+	"Getting Started":      "快速开始",
+	"Request":              "请求",
+	"Response Headers":     "响应头",
+	"User":                 "用户",
+	"Your API key":         "您的 API 密钥",
+	"Save Key (this session)": "保存密钥（本次会话）",
+	"Page number":          "页码",
+	"Page number for the schematic list": "蓝图列表的页码",
+	"Display title. 2-80 characters.": "显示标题。2-80 个字符。",
+	"Markdown supported. Max 4000 characters.": "支持 Markdown。最多 4000 个字符。",
+	"Up to 10 lowercase tags.": "最多 10 个小写标签。",
+	"Up to 3 from the category list.": "从分类列表中最多选择 3 个。",
+	"The .nbt schematic file. Max 5 MB.": ".nbt 蓝图文件。最大 5 MB。",
+	"Used to populate requests below. Stored only in this tab.": "用于填充下方的请求。仅存储在此标签页中。",
+	"Keys are shown once at creation, store them securely. Never embed keys in client-side code.": "密钥仅在创建时显示一次，请安全保存。切勿将密钥嵌入客户端代码。",
+	"Integrate with CreateMod.com to search, retrieve, and upload schematics programmatically. The API is REST-style, returns JSON, and is rate-limited per key.": "与 CreateMod.com 集成，以编程方式搜索、获取和上传蓝图。API 为 REST 风格，返回 JSON，按密钥限制请求频率。",
+	"Search or list schematics. Returns newest schematics when no query is provided. Results are paginated with 24 items per page.": "搜索或列出蓝图。未提供查询时返回最新蓝图。结果按每页 24 项分页。",
+	"Get detailed information about a single schematic by its URL name (slug).": "通过 URL 名称（slug）获取单个蓝图的详细信息。",
+	"Get aggregate hourly analytics across all your schematics, plus a paginated list of schematics with per-schematic totals.": "获取所有蓝图的每小时汇总分析，以及带有每个蓝图总计的分页列表。",
+	"Get hourly analytics for a single schematic over the last 30 days. Useful for charting views, downloads, and engagement on a schematic detail page.": "获取单个蓝图最近 30 天的每小时分析。适用于制作浏览量、下载量和互动量图表。",
+	"Upload a new schematic. Send a": "上传新蓝图。发送",
+	"URL slug of the schematic (path parameter).": "蓝图的 URL slug（路径参数）。",
+	"The API uses conventional HTTP status codes.": "API 使用标准 HTTP 状态码。",
+	"All error responses return JSON with a single": "所有错误响应返回包含单个",
+	"field describing the problem:": "字段描述问题的 JSON：",
+	"indicates success,": "表示成功，",
+	"a client-side problem, and": "表示客户端问题，",
+	"a server-side problem.": "表示服务端问题。",
+	"The": "该",
+	"header. Keys are scoped to your account and inherit your user-level rate limits.": "头部。密钥绑定到您的账户并继承用户级别的请求限制。",
+	"header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle.": "头部指示等待秒数。每个响应都包含速率限制头部以便自我调节。",
+	"request with the": "请求，附带",
+	"file plus metadata. Duplicate file hashes return": "文件及元数据。重复的文件哈希值将返回",
+	"Each array contains one entry per hour for 30 days (720 entries). Hours with no data have": "每个数组包含 30 天内每小时一条记录（共 720 条）。无数据的小时",
+	"values are averages in seconds.": "值为以秒为单位的平均值。",
 }

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -87,9 +87,11 @@ func (s *Service) Send(msg *Message) error {
 
 	addr := fmt.Sprintf("%s:%d", s.smtpHost, s.smtpPort)
 	auth := smtp.PlainAuth("", s.smtpUsername, s.smtpPassword, s.smtpHost)
+	tlsConfig := &tls.Config{ServerName: s.smtpHost}
 
-	if s.smtpTLS {
-		conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: s.smtpHost})
+	if s.smtpTLS && s.smtpPort == 465 {
+		// Implicit TLS (port 465): connect with TLS from the start.
+		conn, err := tls.Dial("tcp", addr, tlsConfig)
 		if err != nil {
 			return fmt.Errorf("mailer: TLS dial failed: %w", err)
 		}
@@ -123,10 +125,40 @@ func (s *Service) Send(msg *Message) error {
 		return client.Quit()
 	}
 
-	if err := smtp.SendMail(addr, auth, from.Address, toAddrs, []byte(body.String())); err != nil {
-		return fmt.Errorf("mailer: failed to send: %w", err)
+	// STARTTLS (port 587, 2525, etc.): connect plain, upgrade if available.
+	client, err := smtp.Dial(addr)
+	if err != nil {
+		return fmt.Errorf("mailer: dial failed: %w", err)
 	}
-	return nil
+	defer client.Close()
+
+	if s.smtpTLS {
+		if err := client.StartTLS(tlsConfig); err != nil {
+			return fmt.Errorf("mailer: STARTTLS failed: %w", err)
+		}
+	}
+	if err := client.Auth(auth); err != nil {
+		return fmt.Errorf("mailer: auth failed: %w", err)
+	}
+	if err := client.Mail(from.Address); err != nil {
+		return fmt.Errorf("mailer: MAIL FROM failed: %w", err)
+	}
+	for _, to := range toAddrs {
+		if err := client.Rcpt(to); err != nil {
+			return fmt.Errorf("mailer: RCPT TO failed: %w", err)
+		}
+	}
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("mailer: DATA failed: %w", err)
+	}
+	if _, err := w.Write([]byte(body.String())); err != nil {
+		return fmt.Errorf("mailer: write body failed: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("mailer: close body failed: %w", err)
+	}
+	return client.Quit()
 }
 
 // DefaultFrom returns a mail.Address with the configured sender identity.

--- a/internal/pages/login.go
+++ b/internal/pages/login.go
@@ -15,6 +15,7 @@ var loginTemplates = append([]string{
 
 type LoginData struct {
 	DefaultData
+	LoginError string
 }
 
 func LoginHandler(registry *server.Registry, appStore *store.Store) func(e *server.RequestEvent) error {
@@ -27,6 +28,9 @@ func LoginHandler(registry *server.Registry, appStore *store.Store) func(e *serv
 		d.Slug = "/login"
 		d.Thumbnail = "https://createmod.com/assets/x/logo_sq_lg.png"
 		d.OAuthError = oauthErrorMessage(d.Language, e.Request.URL.Query().Get("oauth_error"))
+		if e.Request.URL.Query().Get("error") == "credentials" {
+			d.LoginError = i18n.T(d.Language, "Invalid username or password.")
+		}
 		html, err := registry.LoadFiles(loginTemplates...).Render(d)
 		if err != nil {
 			return err

--- a/internal/pages/login_post.go
+++ b/internal/pages/login_post.go
@@ -24,7 +24,7 @@ func LoginPostHandler(appStore *store.Store, sessStore *session.Store, mailServi
 			if e.Request.Header.Get("HX-Request") != "" {
 				return e.String(http.StatusBadRequest, "missing credentials")
 			}
-			return e.Redirect(http.StatusFound, LangRedirectURL(e, "/login"))
+			return e.Redirect(http.StatusFound, LangRedirectURL(e, "/login?error=credentials"))
 		}
 
 		return loginWithStore(e, appStore, sessStore, mailService, identity, password)
@@ -66,5 +66,5 @@ func loginFailed(e *server.RequestEvent) error {
 	if e.Request.Header.Get("HX-Request") != "" {
 		return e.String(http.StatusUnauthorized, "invalid username or password")
 	}
-	return e.Redirect(http.StatusFound, LangRedirectURL(e, "/login"))
+	return e.Redirect(http.StatusFound, LangRedirectURL(e, "/login?error=credentials"))
 }

--- a/template/login.html
+++ b/template/login.html
@@ -12,6 +12,9 @@
                 {{ if .OAuthError }}
                 <div class="alert alert-danger" role="alert">{{ .OAuthError }}</div>
                 {{ end }}
+                {{ if .LoginError }}
+                <div class="alert alert-danger" role="alert">{{ .LoginError }}</div>
+                {{ end }}
                 <form id="login-form" method="post" action="/login" autocomplete="off" novalidate hx-boost="false">
                     <div class="mb-3">
                         <label class="form-label">{{ T .Language "Email or username" }}</label>


### PR DESCRIPTION
Login: redirect to /login?error=credentials on failed auth so the template can show an error message. Previously the redirect had no indicator and the user saw no feedback.

Mailer: use STARTTLS (plain connect then upgrade) for all ports except 465 which uses implicit TLS. The security hardening commit introduced tls.Dial for all TLS-enabled sends, which broke Mailtrap (port 2525) and standard SMTP (port 587) since they expect STARTTLS, not direct TLS.