### PR TITLE
Send verification email async, add resend cooldown, fix email HTML

### DIFF
--- a/internal/mailer/templates.go
+++ b/internal/mailer/templates.go
@@ -62,6 +62,60 @@ CreateMod.com &mdash; Minecraft Create mod schematics
 </html>`, escapedTitle, imageBlock, escapedBody, linkBlock)
 }
 
+// EmailHTMLRaw is like EmailHTML but bodyHTML is inserted as-is (no escaping).
+// Use when the caller builds trusted HTML (e.g. verification code with <strong>).
+func EmailHTMLRaw(title, imageURL, linkURL, buttonLabel, bodyHTML string) string {
+	escapedTitle := html.EscapeString(title)
+
+	imageBlock := ""
+	if imageURL != "" {
+		imageBlock = fmt.Sprintf(`<tr><td style="padding:0 0 16px 0;text-align:center">
+<img src="%s" alt="%s" style="max-width:100%%;height:auto;border-radius:8px" />
+</td></tr>`, imageURL, escapedTitle)
+	}
+
+	linkBlock := ""
+	if linkURL != "" {
+		if buttonLabel == "" {
+			buttonLabel = "View"
+		}
+		linkBlock = fmt.Sprintf(`<tr><td style="padding:16px 0 0 0;text-align:center">
+<a href="%s" style="display:inline-block;padding:10px 24px;background-color:#206bc4;color:#ffffff;text-decoration:none;border-radius:6px;font-weight:bold">%s</a>
+</td></tr>`, linkURL, html.EscapeString(buttonLabel))
+	}
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background-color:#f4f6fa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table width="100%%" cellpadding="0" cellspacing="0" style="background-color:#f4f6fa;padding:32px 0">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1)">
+<tr><td style="background-color:#206bc4;padding:20px 24px;text-align:center">
+<span style="color:#ffffff;font-size:20px;font-weight:bold">CreateMod.com</span>
+</td></tr>
+<tr><td style="padding:24px">
+<table width="100%%" cellpadding="0" cellspacing="0">
+<tr><td style="padding:0 0 16px 0">
+<h2 style="margin:0;font-size:18px;color:#1e293b">%s</h2>
+</td></tr>
+%s
+<tr><td style="padding:0;font-size:14px;line-height:1.6;color:#475569">
+%s
+</td></tr>
+%s
+</table>
+</td></tr>
+<tr><td style="padding:16px 24px;text-align:center;font-size:12px;color:#94a3b8;border-top:1px solid #e2e8f0">
+CreateMod.com &mdash; Minecraft Create mod schematics
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`, escapedTitle, imageBlock, bodyHTML, linkBlock)
+}
+
 // SchematicEmailHTML is a convenience wrapper for schematic-related emails.
 func SchematicEmailHTML(title, imageURL, schematicURL, bodyText string) string {
 	return EmailHTML(title, imageURL, schematicURL, "View Schematic", bodyText)

--- a/internal/pages/security_ip.go
+++ b/internal/pages/security_ip.go
@@ -9,6 +9,7 @@ import (
 	"crypto/subtle"
 	"net/http"
 	"strings"
+	"time"
 
 	"createmod/internal/server"
 )
@@ -139,18 +140,30 @@ func IPVerificationResendHandler(appStore *store.Store, mailService *mailer.Serv
 			return e.Redirect(http.StatusFound, LangRedirectURL(e, "/login"))
 		}
 
-		if pending.ResendCount >= 3 {
+		cooldowns := []int64{60, 300, 600, 1200}
+		idx := pending.ResendCount
+		if idx >= len(cooldowns) {
 			if e.Request.Header.Get("HX-Request") != "" {
 				return e.String(http.StatusTooManyRequests, "Too many resend attempts. Please try logging in again.")
 			}
 			return e.Redirect(http.StatusFound, LangRedirectURL(e, "/auth/verify-ip"))
 		}
 
+		if idx > 0 && pending.LastResend > 0 {
+			wait := cooldowns[idx-1]
+			if time.Now().Unix()-pending.LastResend < wait {
+				if e.Request.Header.Get("HX-Request") != "" {
+					return e.String(http.StatusTooManyRequests, "Please wait before requesting another code.")
+				}
+				return e.Redirect(http.StatusFound, LangRedirectURL(e, "/auth/verify-ip"))
+			}
+		}
+
 		pending.ResendCount++
+		pending.LastResend = time.Now().Unix()
 		_ = setPendingAuthCookie(e, *pending)
 
-		ctx := e.Request.Context()
-		sendIPVerificationEmail(ctx, appStore, mailService, pending.UserID, pending.IP)
+		go sendIPVerificationEmail(appStore, mailService, pending.UserID, pending.IP)
 
 		if e.Request.Header.Get("HX-Request") != "" {
 			return e.String(http.StatusOK, "Verification code sent.")

--- a/internal/pages/security_pending.go
+++ b/internal/pages/security_pending.go
@@ -28,6 +28,7 @@ type pendingAuth struct {
 	Exp         int64  `json:"e"`
 	FailCount   int    `json:"fc"`
 	ResendCount int    `json:"rc"`
+	LastResend  int64  `json:"lr,omitempty"`
 }
 
 func encodePendingAuth(p pendingAuth) (string, error) {

--- a/internal/pages/security_session.go
+++ b/internal/pages/security_session.go
@@ -57,7 +57,7 @@ func maybeCreateSessionOrChallenge(e *server.RequestEvent, appStore *store.Store
 		}
 
 		if contains(needs, "ip") {
-			sendIPVerificationEmail(ctx, appStore, mailService, userID, e.RealIP())
+			go sendIPVerificationEmail(appStore, mailService, userID, e.RealIP())
 		}
 
 		first := needs[0]
@@ -97,10 +97,13 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
-func sendIPVerificationEmail(ctx context.Context, appStore *store.Store, mailService *mailer.Service, userID, ipAddress string) {
+func sendIPVerificationEmail(appStore *store.Store, mailService *mailer.Service, userID, ipAddress string) {
 	if mailService == nil {
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
 	user, err := appStore.Users.GetUserByID(ctx, userID)
 	if err != nil || user == nil || user.Email == "" {
@@ -125,17 +128,15 @@ func sendIPVerificationEmail(ctx context.Context, appStore *store.Store, mailSer
 		return
 	}
 
+	body := "Your verification code is: <strong>" + raw + "</strong>" +
+		"<br><br>This code expires in 15 minutes." +
+		"<br><br>If you didn't try to log in, please change your password immediately."
+
 	msg := &mailer.Message{
-		From: mailService.DefaultFrom(),
-		To:   []mail.Address{{Address: user.Email}},
+		From:    mailService.DefaultFrom(),
+		To:      []mail.Address{{Address: user.Email}},
 		Subject: "CreateMod.com - Verify your login",
-		HTML: mailer.EmailHTML(
-			"Login Verification",
-			"",
-			"",
-			"",
-			"Your verification code is: <strong>"+raw+"</strong><br><br>This code expires in 15 minutes. If you didn't try to log in, please change your password immediately.",
-		),
+		HTML:    mailer.EmailHTMLRaw("Login Verification", "", "", "", body),
 	}
 	if err := mailService.Send(msg); err != nil {
 		slog.Error("ip verification: failed to send email", "error", err)


### PR DESCRIPTION
- Send IP verification email in a goroutine so the verify page loads instantly instead of blocking on SMTP
- Add exponential resend cooldown: 1min, 5min, 10min, 20min between resends (4 max) instead of a flat cap of 3
- Add EmailHTMLRaw to mailer for pre-formatted HTML body, fixing the verification code email showing escaped <strong> tags