### PR TITLE
Fix broken generators and CORS error on server tiles

### DIFF
--- a/internal/pages/kin_tiles_preview.go
+++ b/internal/pages/kin_tiles_preview.go
@@ -73,6 +73,16 @@ func fetchLiveServersFromAPI() []LiveServer {
 	return online
 }
 
+func LiveServersAPIHandler() func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		servers := getLiveServers()
+		if servers == nil {
+			servers = []LiveServer{}
+		}
+		return e.JSON(http.StatusOK, servers)
+	}
+}
+
 func KinTilesPreviewHandler(registry *server.Registry) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		d := KinTilesPreviewData{}

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -699,6 +699,7 @@ func Register(p RegisterParams) chi.Router {
 	r.With(downloadRateLimit).Post("/api/generators/propeller/download", Adapt(pages.GeneratorDownloadHandler("propeller")))
 	r.With(downloadRateLimit).Post("/api/generators/balloon/download", Adapt(pages.GeneratorDownloadHandler("balloon")))
 	r.With(downloadRateLimit).Post("/api/generators/hull/download", Adapt(pages.GeneratorDownloadHandler("hull")))
+	r.Get("/api/servers", Adapt(pages.LiveServersAPIHandler()))
 	// User
 	r.Get("/following", Adapt(pages.FollowingHandler(p.CacheService, registry, p.AppStore, p.TranslationService)))
 	r.Post("/following/unfollow", Adapt(pages.FollowingUnfollowHandler(p.AppStore)))

--- a/template/generator-balloon.html
+++ b/template/generator-balloon.html
@@ -7,9 +7,9 @@
             <div style="position:relative;min-height:calc(100vh - 60px);">
                 <div id="generator-viewport" style="width:100%;height:100%;position:absolute;top:0;left:0;"></div>
                 <nav class="gen-nav">
-                    <a href="/generators/propeller" class="gen-nav-btn">Propeller</a>
-                    <a href="/generators/balloon" class="gen-nav-btn active">Balloon</a>
-                    <a href="/generators/hull" class="gen-nav-btn">Ship Hull</a>
+                    <a href="/generators/propeller" class="gen-nav-btn" hx-boost="false">Propeller</a>
+                    <a href="/generators/balloon" class="gen-nav-btn active" hx-boost="false">Balloon</a>
+                    <a href="/generators/hull" class="gen-nav-btn" hx-boost="false">Ship Hull</a>
                 </nav>
                 <div class="generator-overlay">
                         <div class="generator-overlay-header" onclick="this.parentElement.classList.toggle('collapsed')">

--- a/template/generator-hull.html
+++ b/template/generator-hull.html
@@ -7,9 +7,9 @@
             <div style="position:relative;min-height:calc(100vh - 60px);">
                 <div id="generator-viewport" style="width:100%;height:100%;position:absolute;top:0;left:0;"></div>
                 <nav class="gen-nav">
-                    <a href="/generators/propeller" class="gen-nav-btn">Propeller</a>
-                    <a href="/generators/balloon" class="gen-nav-btn">Balloon</a>
-                    <a href="/generators/hull" class="gen-nav-btn active">Ship Hull</a>
+                    <a href="/generators/propeller" class="gen-nav-btn" hx-boost="false">Propeller</a>
+                    <a href="/generators/balloon" class="gen-nav-btn" hx-boost="false">Balloon</a>
+                    <a href="/generators/hull" class="gen-nav-btn active" hx-boost="false">Ship Hull</a>
                 </nav>
                 <div class="generator-overlay">
                         <div class="generator-overlay-header" onclick="this.parentElement.classList.toggle('collapsed')">

--- a/template/generator-propeller.html
+++ b/template/generator-propeller.html
@@ -7,9 +7,9 @@
             <div style="position:relative;min-height:calc(100vh - 60px);">
                 <div id="generator-viewport" style="width:100%;height:100%;position:absolute;top:0;left:0;"></div>
                 <nav class="gen-nav">
-                    <a href="/generators/propeller" class="gen-nav-btn active">Propeller</a>
-                    <a href="/generators/balloon" class="gen-nav-btn">Balloon</a>
-                    <a href="/generators/hull" class="gen-nav-btn">Ship Hull</a>
+                    <a href="/generators/propeller" class="gen-nav-btn active" hx-boost="false">Propeller</a>
+                    <a href="/generators/balloon" class="gen-nav-btn" hx-boost="false">Balloon</a>
+                    <a href="/generators/hull" class="gen-nav-btn" hx-boost="false">Ship Hull</a>
                 </nav>
                 <div class="generator-overlay">
                     <div class="generator-overlay-header" onclick="this.parentElement.classList.toggle('collapsed')">

--- a/template/static/generator.js
+++ b/template/static/generator.js
@@ -168,9 +168,11 @@ function initScene(containerId) {
 
   if (!window._genCleanupInit) {
     window._genCleanupInit = true;
-    document.addEventListener('htmx:beforeSwap', function() {
-      if (window.GeneratorApp && window.GeneratorApp._cleanup) {
-        window.GeneratorApp._cleanup();
+    document.addEventListener('htmx:beforeSwap', function(evt) {
+      if (evt.detail && evt.detail.target === document.body) {
+        if (window.GeneratorApp && window.GeneratorApp._cleanup) {
+          window.GeneratorApp._cleanup();
+        }
       }
     });
   }

--- a/template/static/kin-tiles.js
+++ b/template/static/kin-tiles.js
@@ -326,11 +326,11 @@
   function fetchLiveServers() {
     if (liveFetched) return;
     liveFetched = true;
-    fetch('https://www.createmodservers.com/api/v1/servers?sort=votes&per_page=5')
+    fetch('/api/servers')
       .then(function(r) { return r.json(); })
       .then(function(data) {
-        if (data && data.servers) {
-          liveTile = buildServerTile(data.servers);
+        if (data && data.length) {
+          liveTile = buildServerTile(data);
         }
       })
       .catch(function() {});


### PR DESCRIPTION
## Summary
- Fix all three generators (propeller, balloon, hull) being broken — the `htmx:beforeSwap` cleanup listener in `generator.js` was destroying the Three.js scene on every htmx swap (e.g., the notification badge `hx-trigger="load"` in the header), not just on page navigation. Now only triggers on body swaps.
- Add `hx-boost="false"` to generator nav links so switching between generators does a clean full-page load instead of an htmx swap.
- Fix CORS error when fetching live servers from createmodservers.com by adding a `/api/servers` backend proxy endpoint (reuses existing 5-minute cached `getLiveServers()` function).

## Test plan
- [ ] Navigate to each generator page — 3D view should render and be interactive (rotate, zoom, pan)
- [ ] Click preset buttons — view should update immediately
- [ ] Adjust sliders — view should update in real-time
- [ ] Switch between generators via nav links — each should load correctly
- [ ] Check browser console — no CORS errors on server tile fetch
- [ ] Verify kin-tiles server tile appears in ad rail when no ad loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)