### PR TITLE
Fix kin-tiles covering sticky ad rail

### DIFF
--- a/template/static/kin-tiles.js
+++ b/template/static/kin-tiles.js
@@ -372,12 +372,25 @@
     return false;
   }
 
+  function removeTileIfAdLoaded(slot) {
+    if (!slot) return;
+    var observer = new MutationObserver(function() {
+      if (slotHasAd(slot)) {
+        var tile = slot.querySelector('.kin-tile');
+        if (tile) tile.remove();
+        observer.disconnect();
+      }
+    });
+    observer.observe(slot, { childList: true, subtree: true });
+  }
+
   function handleAdblock() {
     if (document.querySelector('.kin-tile')) return;
     var slots = document.querySelectorAll('[id*="sticky-adrail"]');
     for (var i = 0; i < slots.length; i++) {
       if (!slotHasAd(slots[i]) && slots[i].offsetParent !== null) {
         insertTile(slots[i]);
+        removeTileIfAdLoaded(slots[i]);
         return;
       }
     }
@@ -401,8 +414,4 @@
   if (window._nitroBlocked) {
     fillEmptySlots();
   }
-
-  setTimeout(function() {
-    fillEmptySlots();
-  }, 3000);
 })();


### PR DESCRIPTION
## Summary
- **Critical**: Kin-tiles were being inserted over the sticky ad rail, covering NitroPay ads
- Root cause: unconditional 3-second `setTimeout` called `fillEmptySlots()` before ads had time to load, so `slotHasAd()` returned false
- Fix: removed the unconditional timer — tiles now only insert when NitroPay's `np.detect` event confirms ad-blocking
- Added a `MutationObserver` safety net that removes any inserted tile if an ad iframe appears afterward

## Test plan
- [ ] Browse schematics page with ads enabled — sticky ad rail should show ads, no kin-tile overlay
- [ ] Browse with ad blocker — kin-tile should appear in the empty ad rail slot
- [ ] Verify kin-tile doesn't flash briefly before ads load

🤖 Generated with [Claude Code](https://claude.com/claude-code)