### PR TITLE
Fix kin-tile green dot smear and place tiles inside sticky-adrail

### DIFF
--- a/template/static/kin-tiles.css
+++ b/template/static/kin-tiles.css
@@ -114,7 +114,7 @@
 .kin-list .dot {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--cm-success, #2fb344);
-  box-shadow: 0 0 0 3px rgba(47,179,68,.15);
+  flex-shrink: 0;
 }
 .kin-list .players {
   font-family: var(--cm-font-mono, monospace);
@@ -228,7 +228,7 @@
   justify-content: center;
 }
 
-/* Kin-slot container sits below NitroPay ads in the ad rail */
+/* Kin-slot container inside the sticky-adrail, below NitroPay ads */
 .kin-slot {
   margin-top: 12px;
 }

--- a/template/static/kin-tiles.js
+++ b/template/static/kin-tiles.js
@@ -350,35 +350,24 @@
     }
   }
 
-  var railSelectors = [
-    '.ad-rail',
-    '.ad-rail-sm',
-    '.generator-ad-rail',
-    '.generator-ad-rail-sm',
-    '.search-ad-rail-wide',
-    '.search-ad-rail',
-    '.guide-ad-rail',
-    '.guide-ad-rail-sm'
-  ];
-
-  function findAdRails() {
-    return document.querySelectorAll(railSelectors.join(','));
+  function findStickyAdrails() {
+    return document.querySelectorAll('[id*="sticky-adrail"]');
   }
 
-  function ensureKinSlot(rail) {
-    var slot = rail.querySelector('.kin-slot');
+  function ensureKinSlot(container) {
+    var slot = container.querySelector('.kin-slot');
     if (slot) return slot;
     slot = document.createElement('div');
     slot.className = 'kin-slot';
-    rail.appendChild(slot);
+    container.appendChild(slot);
     return slot;
   }
 
   function fillSlots() {
-    var rails = findAdRails();
-    for (var i = 0; i < rails.length; i++) {
-      if (rails[i].offsetParent === null) continue;
-      var slot = ensureKinSlot(rails[i]);
+    var adrails = findStickyAdrails();
+    for (var i = 0; i < adrails.length; i++) {
+      if (adrails[i].offsetParent === null) continue;
+      var slot = ensureKinSlot(adrails[i]);
       insertTile(slot);
     }
   }


### PR DESCRIPTION
Remove box-shadow glow from server list dots that rendered as smeared blobs on some displays. Insert kin-tiles inside the sticky-adrail container instead of as a sibling, so they appear below NitroPay ads within the same sticky block and scroll together.