### PR TITLE
Disable kin-tile insertion in ad rails

### DIFF
--- a/template/static/kin-tiles.js
+++ b/template/static/kin-tiles.js
@@ -400,13 +400,4 @@
   }
 
   fetchLiveServers();
-  fillSlots();
-  observeAdrails();
-
-  document.addEventListener('htmx:afterSettle', function(evt) {
-    if (evt.detail && evt.detail.target === document.body) {
-      fillSlots();
-      observeAdrails();
-    }
-  });
 })();


### PR DESCRIPTION
Kin-tiles conflict with NitroPay sticky-stack ads, overlapping ad content. Disable automatic insertion while keeping tile definitions intact for future use.