### PR TITLE
Cap sticky ad rail height to viewport instead of page height

### DIFF
--- a/template/static/app.css
+++ b/template/static/app.css
@@ -439,7 +439,7 @@ a:hover {
   position: sticky;
   top: 108px;
   z-index: 1;
-  min-height: 100vh;
+  height: calc(100vh - 108px);
 }
 
 /***************
@@ -508,7 +508,7 @@ a:hover {
   position: sticky;
   top: 108px;
   z-index: 1;
-  min-height: 100vh;
+  height: calc(100vh - 108px);
 }
 
 /***************


### PR DESCRIPTION
Change min-height: 100vh to height: calc(100vh - 108px) so the sticky-adrail is sized to the visible viewport below the header, not stretched to the full page height by the flex parent.