### PR TITLE
A/B test smart-flex ad format for admins, keep video-nc for all other…

### DIFF
--- a/internal/pages/default.go
+++ b/internal/pages/default.go
@@ -45,6 +45,7 @@ type DefaultData struct {
 	Avatar          template.URL
 	HasAvatar       bool
 	IsContributor   bool
+	IsAdmin         bool
 	Language        string
 	LangPrefix      string
 	CanonicalURL    string
@@ -189,8 +190,7 @@ func (d *DefaultData) populateFromSession(e *server.RequestEvent, user *session.
 		d.Avatar = template.URL(url)
 	}
 	d.HasAvatar = d.Avatar != ""
-	// Contributor status - check has no direct store access here, so left for handler to set
-	// TODO: This will be set by handlers with store access
+	d.IsAdmin = user.IsAdmin
 }
 
 // setPublicCacheControl overrides the default "no-cache, private" header for

--- a/template/collections.html
+++ b/template/collections.html
@@ -87,7 +87,7 @@
             <div id="collections-sticky-adrail-lg" class="mb-3"></div>
           </div>
           <div class="ad-rail d-none d-xl-block">
-            <div id="collections-video-nc-top-right" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="collections-smart-flex" class="mb-3"></div>{{else}}<div id="collections-video-nc-top-right" class="mb-3"></div>{{end}}
             <div id="collections-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
           </div>
         </div>
@@ -100,6 +100,20 @@
 
 <!-- Ad Scripts -->
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('collections-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,collections",
+  "targeting": { "pageType": "collections" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('collections-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,collections",
@@ -112,6 +126,7 @@ window['nitroAds'].createAd('collections-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('collections-sticky-adrail-lg', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/collections_show.html
+++ b/template/collections_show.html
@@ -139,7 +139,7 @@
             <div id="collshow-sticky-adrail-lg" class="mb-3"></div>
           </div>
           <div class="ad-rail d-none d-xl-block">
-            <div id="collshow-video-nc-top-right" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="collshow-smart-flex" class="mb-3"></div>{{else}}<div id="collshow-video-nc-top-right" class="mb-3"></div>{{end}}
             <div id="collshow-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
           </div>
         </div><!-- /d-flex -->
@@ -181,6 +181,20 @@ function copyShareLink() {
 
 <!-- Ad Scripts -->
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('collshow-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,collection",
+  "targeting": { "pageType": "collection" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('collshow-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,collection",
@@ -193,6 +207,7 @@ window['nitroAds'].createAd('collshow-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('collshow-sticky-adrail-lg', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/download_interstitial.html
+++ b/template/download_interstitial.html
@@ -8,7 +8,7 @@
         <div class="d-flex gap-3 justify-content-center">
           <!-- Left Ad Rail (desktop only) -->
           <div class="ad-rail d-none d-xl-block">
-            <div id="dlinterstitial-video-nc-top-left" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="dlinterstitial-smart-flex-left" class="mb-3"></div>{{else}}<div id="dlinterstitial-video-nc-top-left" class="mb-3"></div>{{end}}
             <div id="dlinterstitial-sticky-adrail-left" class="mb-3"></div>
           </div>
           <div style="max-width:540px; width:100%; padding:2rem 0;">
@@ -36,7 +36,7 @@
           </div>
           <!-- Right Ad Rail (desktop only) -->
           <div class="ad-rail d-none d-xl-block">
-            <div id="dlinterstitial-video-nc-top-right" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="dlinterstitial-smart-flex-right" class="mb-3"></div>{{else}}<div id="dlinterstitial-video-nc-top-right" class="mb-3"></div>{{end}}
             <div id="dlinterstitial-sticky-adrail-right" class="mb-3"></div>
           </div>
         </div>
@@ -164,6 +164,22 @@
 </script>
 <script>
 if (window['nitroAds']) {
+  {{ if .IsAdmin }}
+  ['dlinterstitial-smart-flex-left', 'dlinterstitial-smart-flex-right'].forEach(function(id) {
+    window['nitroAds'].createAd(id, {
+      "format": "smart-flex",
+      "keywords": "minecraft,create-mod,download",
+      "targeting": { "pageType": "download-interstitial" },
+      "report": {
+        "enabled": true,
+        "icon": true,
+        "wording": "Report Ad",
+        "position": "top-right"
+      },
+      "mediaQuery": "(min-width: 1200px)"
+    });
+  });
+  {{ else }}
   ['dlinterstitial-video-nc-top-left', 'dlinterstitial-video-nc-top-right'].forEach(function(id) {
     window['nitroAds'].createAd(id, {
       "format": "video-nc",
@@ -178,6 +194,7 @@ if (window['nitroAds']) {
       "mediaQuery": "(min-width: 1200px)"
     });
   });
+  {{ end }}
   ['dlinterstitial-sticky-adrail-left', 'dlinterstitial-sticky-adrail-right'].forEach(function(id) {
     window['nitroAds'].createAd(id, {
       "refreshLimit": 10,

--- a/template/explore.html
+++ b/template/explore.html
@@ -60,7 +60,7 @@
 
                 <!-- Ad Rail (desktop only) -->
                 <div class="ad-rail d-none d-xl-block">
-                    <div id="explore-video-nc-top-right" class="mb-3"></div>
+                    {{if .IsAdmin}}<div id="explore-smart-flex" class="mb-3"></div>{{else}}<div id="explore-video-nc-top-right" class="mb-3"></div>{{end}}
                     <div id="explore-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                 </div>
             </div>
@@ -70,6 +70,20 @@
 </div>
 {{template "foot.html" .}}
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('explore-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,schematics,explore,discover",
+  "targeting": { "pageType": "explore" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('explore-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,schematics,explore,discover",
@@ -82,6 +96,7 @@ window['nitroAds'].createAd('explore-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('explore-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/external_interstitial.html
+++ b/template/external_interstitial.html
@@ -8,7 +8,7 @@
         <div class="d-flex gap-3 justify-content-center">
           <!-- Left Ad Rail (desktop only) -->
           <div class="ad-rail d-none d-xl-block">
-            <div id="extinterstitial-video-nc-top-left" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="extinterstitial-smart-flex-left" class="mb-3"></div>{{else}}<div id="extinterstitial-video-nc-top-left" class="mb-3"></div>{{end}}
             <div id="extinterstitial-sticky-adrail-left" class="mb-3"></div>
           </div>
           <div style="max-width:540px; width:100%; padding:2rem 0;">
@@ -27,7 +27,7 @@
           </div>
           <!-- Right Ad Rail (desktop only) -->
           <div class="ad-rail d-none d-xl-block">
-            <div id="extinterstitial-video-nc-top-right" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="extinterstitial-smart-flex-right" class="mb-3"></div>{{else}}<div id="extinterstitial-video-nc-top-right" class="mb-3"></div>{{end}}
             <div id="extinterstitial-sticky-adrail-right" class="mb-3"></div>
           </div>
         </div>
@@ -87,6 +87,22 @@
 </script>
 <script>
 if (window['nitroAds']) {
+  {{ if .IsAdmin }}
+  ['extinterstitial-smart-flex-left', 'extinterstitial-smart-flex-right'].forEach(function(id) {
+    window['nitroAds'].createAd(id, {
+      "format": "smart-flex",
+      "keywords": "minecraft,create-mod,external",
+      "targeting": { "pageType": "external-interstitial" },
+      "report": {
+        "enabled": true,
+        "icon": true,
+        "wording": "Report Ad",
+        "position": "top-right"
+      },
+      "mediaQuery": "(min-width: 1200px)"
+    });
+  });
+  {{ else }}
   ['extinterstitial-video-nc-top-left', 'extinterstitial-video-nc-top-right'].forEach(function(id) {
     window['nitroAds'].createAd(id, {
       "format": "video-nc",
@@ -101,6 +117,7 @@ if (window['nitroAds']) {
       "mediaQuery": "(min-width: 1200px)"
     });
   });
+  {{ end }}
   ['extinterstitial-sticky-adrail-left', 'extinterstitial-sticky-adrail-right'].forEach(function(id) {
     window['nitroAds'].createAd(id, {
       "refreshLimit": 10,

--- a/template/generator-balloon.html
+++ b/template/generator-balloon.html
@@ -213,7 +213,7 @@
                     <div id="gen-sticky-adrail-lg" class="mb-3"></div>
                 </div>
                 <div class="generator-ad-rail d-none d-xl-block">
-                    <div id="gen-video-nc" class="mb-3"></div>
+                    {{if .IsAdmin}}<div id="gen-smart-flex" class="mb-3"></div>{{else}}<div id="gen-video-nc" class="mb-3"></div>{{end}}
                     <div id="gen-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                 </div>
             </div>
@@ -392,11 +392,19 @@
 
   // Ads
   window['nitroAds'] = window['nitroAds'] || { createAd: function() { return new Promise(function(e) { window['nitroAds'].queue.push(['createAd', arguments, e]); }); }, queue: [] };
+  {{ if .IsAdmin }}
+  window['nitroAds'].createAd('gen-smart-flex', {
+    "format": "smart-flex",
+    "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
+    "mediaQuery": "(min-width: 1200px)"
+  });
+  {{ else }}
   window['nitroAds'].createAd('gen-video-nc', {
     "format": "video-nc",
     "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
     "mediaQuery": "(min-width: 1200px)"
   });
+  {{ end }}
   window['nitroAds'].createAd('gen-sticky-adrail-lg', {
     "refreshLimit": 10,
     "refreshTime": 45,
@@ -410,6 +418,7 @@
     "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
     "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
   });
+  {{ if not .IsAdmin }}
   var videoNcEl = document.getElementById('gen-video-nc');
   var adRailEl = videoNcEl && videoNcEl.closest('.ad-rail');
   var stickyStackTop = 110 + 200 + 16;
@@ -421,6 +430,7 @@
     new ResizeObserver(updateOffset).observe(videoNcEl);
     updateOffset();
   }
+  {{ end }}
   window['nitroAds'].createAd('gen-sticky-adrail', {
     "refreshVisibleOnly": true,
     "format": "sticky-stack",

--- a/template/generator-guide.html
+++ b/template/generator-guide.html
@@ -55,7 +55,7 @@
                         </div>
                     </div>
                     <div class="guide-ad-rail d-none d-xl-block">
-                        <div id="guide-video-nc" class="mb-3"></div>
+                        {{if .IsAdmin}}<div id="guide-smart-flex" class="mb-3"></div>{{else}}<div id="guide-video-nc" class="mb-3"></div>{{end}}
                         <div id="guide-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                     </div>
                     <div class="guide-ad-rail-sm d-none d-lg-block d-xl-none">
@@ -151,11 +151,19 @@
   }
 
   window['nitroAds'] = window['nitroAds'] || { createAd: function() { return new Promise(function(e) { window['nitroAds'].queue.push(['createAd', arguments, e]); }); }, queue: [] };
+  {{ if .IsAdmin }}
+  window['nitroAds'].createAd('guide-smart-flex', {
+    "format": "smart-flex",
+    "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
+    "mediaQuery": "(min-width: 1200px)"
+  });
+  {{ else }}
   window['nitroAds'].createAd('guide-video-nc', {
     "format": "video-nc",
     "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
     "mediaQuery": "(min-width: 1200px)"
   });
+  {{ end }}
   window['nitroAds'].createAd('guide-sticky-adrail-lg', {
     "refreshLimit": 10,
     "refreshTime": 45,
@@ -169,6 +177,7 @@
     "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
     "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
   });
+  {{ if not .IsAdmin }}
   var guideVideoEl = document.getElementById('guide-video-nc');
   var guideAdRail = guideVideoEl && guideVideoEl.closest('.guide-ad-rail');
   var guideStickyTop = 110 + 200 + 16;
@@ -180,6 +189,7 @@
     new ResizeObserver(updateGuideOffset).observe(guideVideoEl);
     updateGuideOffset();
   }
+  {{ end }}
   window['nitroAds'].createAd('guide-sticky-adrail', {
     "refreshVisibleOnly": true,
     "format": "sticky-stack",

--- a/template/generator-hull.html
+++ b/template/generator-hull.html
@@ -256,7 +256,7 @@
                     <div id="gen-sticky-adrail-lg" class="mb-3"></div>
                 </div>
                 <div class="generator-ad-rail d-none d-xl-block">
-                    <div id="gen-video-nc" class="mb-3"></div>
+                    {{if .IsAdmin}}<div id="gen-smart-flex" class="mb-3"></div>{{else}}<div id="gen-video-nc" class="mb-3"></div>{{end}}
                     <div id="gen-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                 </div>
             </div>
@@ -423,11 +423,19 @@
 
   // Ads
   window['nitroAds'] = window['nitroAds'] || { createAd: function() { return new Promise(function(e) { window['nitroAds'].queue.push(['createAd', arguments, e]); }); }, queue: [] };
+  {{ if .IsAdmin }}
+  window['nitroAds'].createAd('gen-smart-flex', {
+    "format": "smart-flex",
+    "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
+    "mediaQuery": "(min-width: 1200px)"
+  });
+  {{ else }}
   window['nitroAds'].createAd('gen-video-nc', {
     "format": "video-nc",
     "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
     "mediaQuery": "(min-width: 1200px)"
   });
+  {{ end }}
   window['nitroAds'].createAd('gen-sticky-adrail-lg', {
     "refreshLimit": 10,
     "refreshTime": 45,
@@ -441,6 +449,7 @@
     "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
     "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
   });
+  {{ if not .IsAdmin }}
   var videoNcEl = document.getElementById('gen-video-nc');
   var adRailEl = videoNcEl && videoNcEl.closest('.ad-rail');
   var stickyStackTop = 110 + 200 + 16;
@@ -452,6 +461,7 @@
     new ResizeObserver(updateOffset).observe(videoNcEl);
     updateOffset();
   }
+  {{ end }}
   window['nitroAds'].createAd('gen-sticky-adrail', {
     "refreshVisibleOnly": true,
     "format": "sticky-stack",

--- a/template/generator-propeller.html
+++ b/template/generator-propeller.html
@@ -140,7 +140,7 @@
                     <div id="gen-sticky-adrail-lg" class="mb-3"></div>
                 </div>
                 <div class="generator-ad-rail d-none d-xl-block">
-                    <div id="gen-video-nc" class="mb-3"></div>
+                    {{if .IsAdmin}}<div id="gen-smart-flex" class="mb-3"></div>{{else}}<div id="gen-video-nc" class="mb-3"></div>{{end}}
                     <div id="gen-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                 </div>
             </div>
@@ -283,11 +283,19 @@
 
   // Ads
   window['nitroAds'] = window['nitroAds'] || { createAd: function() { return new Promise(function(e) { window['nitroAds'].queue.push(['createAd', arguments, e]); }); }, queue: [] };
+  {{ if .IsAdmin }}
+  window['nitroAds'].createAd('gen-smart-flex', {
+    "format": "smart-flex",
+    "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
+    "mediaQuery": "(min-width: 1200px)"
+  });
+  {{ else }}
   window['nitroAds'].createAd('gen-video-nc', {
     "format": "video-nc",
     "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
     "mediaQuery": "(min-width: 1200px)"
   });
+  {{ end }}
   window['nitroAds'].createAd('gen-sticky-adrail-lg', {
     "refreshLimit": 10,
     "refreshTime": 45,
@@ -301,6 +309,7 @@
     "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
     "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
   });
+  {{ if not .IsAdmin }}
   var videoNcEl = document.getElementById('gen-video-nc');
   var adRailEl = videoNcEl && videoNcEl.closest('.ad-rail');
   var stickyStackTop = 110 + 200 + 16;
@@ -312,6 +321,7 @@
     new ResizeObserver(updateOffset).observe(videoNcEl);
     updateOffset();
   }
+  {{ end }}
   window['nitroAds'].createAd('gen-sticky-adrail', {
     "refreshVisibleOnly": true,
     "format": "sticky-stack",

--- a/template/guides.html
+++ b/template/guides.html
@@ -57,7 +57,7 @@
         <!-- Ad Rail (desktop only) -->
         {{if not .IsContributor}}
         <div class="ad-rail d-none d-xl-block">
-            <div id="guides-video-nc-top-right" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="guides-smart-flex" class="mb-3"></div>{{else}}<div id="guides-video-nc-top-right" class="mb-3"></div>{{end}}
             <div id="guides-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
         </div>
         {{end}}
@@ -74,6 +74,20 @@
 {{template "foot.html" .}}
 {{if not .IsContributor}}
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('guides-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,guide,tutorial",
+  "targeting": { "pageType": "guides" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('guides-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,guide,tutorial",
@@ -86,6 +100,7 @@ window['nitroAds'].createAd('guides-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('guides-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/guides_show.html
+++ b/template/guides_show.html
@@ -87,7 +87,7 @@
         <!-- Ad Rail (desktop only) -->
         {{if not .IsContributor}}
         <div class="ad-rail d-none d-xl-block">
-            <div id="guideshow-video-nc-top-right" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="guideshow-smart-flex" class="mb-3"></div>{{else}}<div id="guideshow-video-nc-top-right" class="mb-3"></div>{{end}}
             <div id="guideshow-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
         </div>
         {{end}}
@@ -105,6 +105,20 @@
 {{template "foot.html" .}}
 {{if not .IsContributor}}
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('guideshow-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,guide,tutorial",
+  "targeting": { "pageType": "guide" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('guideshow-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,guide,tutorial",
@@ -117,6 +131,7 @@ window['nitroAds'].createAd('guideshow-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('guideshow-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/include/head.html
+++ b/template/include/head.html
@@ -149,7 +149,7 @@ window.setTheme=function(theme){
           trackAdClick('kin-' + (link.hostname || 'unknown').replace(/^www\./, ''), link.href || '');
           return;
         }
-        var adEl = ev.target.closest('[id*="-video-nc-"], [id*="-sticky-adrail"], [id*="-mobile"], [id*="outstream-player"]');
+        var adEl = ev.target.closest('[id*="-video-nc-"], [id*="-smart-flex"], [id*="-sticky-adrail"], [id*="-mobile"], [id*="outstream-player"]');
         if (adEl) {
           trackAdClick(adEl.id, '');
         }

--- a/template/mod_detail.html
+++ b/template/mod_detail.html
@@ -180,7 +180,7 @@
 
           <!-- Right: Ad rail (desktop only) -->
           <div class="search-ad-rail-wide d-none d-xl-block">
-            <div id="moddetail-video-nc-top-right" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="moddetail-smart-flex" class="mb-3"></div>{{else}}<div id="moddetail-video-nc-top-right" class="mb-3"></div>{{end}}
             <div id="moddetail-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
           </div>
         </div>
@@ -277,6 +277,20 @@ document.addEventListener('change', function(e) {
 })();
 </script>
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('moddetail-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,mod,addon",
+  "targeting": { "pageType": "mod" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('moddetail-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,mod,addon",
@@ -289,6 +303,7 @@ window['nitroAds'].createAd('moddetail-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('moddetail-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/modify.html
+++ b/template/modify.html
@@ -174,7 +174,7 @@
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
                     <div class="ad-rail d-none d-xl-block">
-                        <div id="modify-video-nc-top-right" class="mb-3"></div>
+                        {{if .IsAdmin}}<div id="modify-smart-flex" class="mb-3"></div>{{else}}<div id="modify-video-nc-top-right" class="mb-3"></div>{{end}}
                         <div id="modify-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                     </div>
                 </div><!-- /d-flex -->
@@ -632,7 +632,20 @@
 
 <!-- Ad Scripts -->
 <script>
-// Video NC ad (desktop only)
+{{ if .IsAdmin }}
+window['nitroAds'].createAd('modify-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,modify,blocks",
+  "targeting": { "pageType": "modify" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{ else }}
 window['nitroAds'].createAd('modify-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,modify,blocks",
@@ -645,6 +658,7 @@ window['nitroAds'].createAd('modify-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{ end }}
 // Narrow ad rail (lg only: 992-1199px)
 window['nitroAds'].createAd('modify-sticky-adrail-lg', {
   "refreshLimit": 10,

--- a/template/profile.html
+++ b/template/profile.html
@@ -160,7 +160,7 @@
 
                     <!-- Ad Rail (desktop only) -->
                     <div class="ad-rail d-none d-xl-block">
-                        <div id="profile-video-nc-top-right" class="mb-3"></div>
+                        {{if .IsAdmin}}<div id="profile-smart-flex" class="mb-3"></div>{{else}}<div id="profile-video-nc-top-right" class="mb-3"></div>{{end}}
                         <div id="profile-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                     </div>
                 </div>
@@ -171,6 +171,20 @@
 </div>
 {{template "foot.html" .}}
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('profile-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,profile,builder",
+  "targeting": { "pageType": "profile" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('profile-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,profile,builder",
@@ -183,6 +197,7 @@ window['nitroAds'].createAd('profile-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('profile-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/schematic-guide.html
+++ b/template/schematic-guide.html
@@ -55,7 +55,7 @@
                         </div>
                     </div>
                     <div class="guide-ad-rail d-none d-xl-block">
-                        <div id="guide-video-nc" class="mb-3"></div>
+                        {{if .IsAdmin}}<div id="guide-smart-flex" class="mb-3"></div>{{else}}<div id="guide-video-nc" class="mb-3"></div>{{end}}
                         <div id="guide-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                     </div>
                     <div class="guide-ad-rail-sm d-none d-lg-block d-xl-none">

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -1158,7 +1158,7 @@
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
                     <div class="ad-rail d-none d-xl-block">
-                        <div id="schematic-video-nc-top-right" class="mb-3"></div>
+                        {{if .IsAdmin}}<div id="schematic-smart-flex" class="mb-3"></div>{{else}}<div id="schematic-video-nc-top-right" class="mb-3"></div>{{end}}
                         <div id="schematic-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                     </div>
                 </div><!-- /d-flex -->
@@ -1587,7 +1587,20 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     "modVersion": "{{ .Schematic.CreatemodVersion }}"
   };
 
-  // Video NC ad (desktop only)
+  {{ if .IsAdmin }}
+  window['nitroAds'].createAd('schematic-smart-flex', {
+    "format": "smart-flex",
+    "keywords": kwString,
+    "targeting": targeting,
+    "report": {
+      "enabled": true,
+      "icon": true,
+      "wording": "Report Ad",
+      "position": "top-right"
+    },
+    "mediaQuery": "(min-width: 1200px)"
+  });
+  {{ else }}
   window['nitroAds'].createAd('schematic-video-nc-top-right', {
     "format": "video-nc",
     "keywords": kwString,
@@ -1600,6 +1613,7 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     },
     "mediaQuery": "(min-width: 1200px)"
   });
+  {{ end }}
   // Narrow ad rail (lg only: 992-1199px)
   window['nitroAds'].createAd('schematic-sticky-adrail-lg', {
     "refreshLimit": 10,
@@ -1622,12 +1636,11 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     },
     "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
   });
-  // Keep the sticky-stack container offset in sync with the video-nc's actual
-  // rendered height so both pin below each other without overlapping.
+  {{ if not .IsAdmin }}
   var videoNcEl = document.getElementById('schematic-video-nc-top-right');
   var adRailEl = videoNcEl && videoNcEl.closest('.ad-rail');
-  var videoNcGap = 16; // matches the mb-3 margin + 1rem in the CSS calc()
-  var stickyStackTop = 110 + 200 + videoNcGap; // fallback matches CSS default
+  var videoNcGap = 16;
+  var stickyStackTop = 110 + 200 + videoNcGap;
   if (videoNcEl && adRailEl && typeof ResizeObserver !== 'undefined') {
     var updateOffset = function () {
       var h = videoNcEl.getBoundingClientRect().height;
@@ -1638,6 +1651,7 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     new ResizeObserver(updateOffset).observe(videoNcEl);
     updateOffset();
   }
+  {{ end }}
 
   // Wide ad rail — sticky-stack for long schematic pages (xl+: 1200px+)
   window['nitroAds'].createAd('schematic-sticky-adrail', {
@@ -1645,7 +1659,7 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     "format": "sticky-stack",
     "stickyStackLimit": 15,
     "stickyStackSpace": 2.5,
-    "stickyStackOffset": stickyStackTop,
+    "stickyStackOffset": {{ if .IsAdmin }}110{{ else }}stickyStackTop{{ end }},
     "stickyStackResizable": false,
     "keywords": kwString,
     "targeting": targeting,

--- a/template/schematics.html
+++ b/template/schematics.html
@@ -45,7 +45,7 @@
                 </div>
                 <!-- Ad Rail (desktop only) -->
                 <div class="ad-rail d-none d-xl-block">
-                    <div id="schematics-video-nc-top-right" class="mb-3"></div>
+                    {{if .IsAdmin}}<div id="schematics-smart-flex" class="mb-3"></div>{{else}}<div id="schematics-video-nc-top-right" class="mb-3"></div>{{end}}
                     <div id="schematics-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                 </div>
                 </div>
@@ -56,6 +56,20 @@
 </div>
 {{template "foot.html" .}}
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('schematics-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,schematics,browse",
+  "targeting": { "pageType": "schematics" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('schematics-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,schematics,browse",
@@ -68,6 +82,7 @@ window['nitroAds'].createAd('schematics-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('schematics-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/search.html
+++ b/template/search.html
@@ -232,7 +232,7 @@
 
                     <!-- Right: Ad rail (desktop only) -->
                     <div class="search-ad-rail-wide d-none d-xl-block">
-                        <div id="search-video-nc-top-right" class="mb-3"></div>
+                        {{if .IsAdmin}}<div id="search-smart-flex" class="mb-3"></div>{{else}}<div id="search-video-nc-top-right" class="mb-3"></div>{{end}}
                         <div id="search-sticky-adrail-top" class="mb-3">{{.KinTileHTML}}</div>
                     </div>
                 </div>
@@ -240,9 +240,22 @@
         </main>
         {{template "footer.html" .}}
         <script>
-            // Video NC ad (desktop only)
             var searchKw = 'minecraft,create-mod,search,schematics';
             var searchTarget = { "pageType": "search" };
+            {{ if .IsAdmin }}
+            window['nitroAds'].createAd('search-smart-flex', {
+                "format": "smart-flex",
+                "keywords": searchKw,
+                "targeting": searchTarget,
+                "report": {
+                    "enabled": true,
+                    "icon": true,
+                    "wording": "Report Ad",
+                    "position": "top-right"
+                },
+                "mediaQuery": "(min-width: 1200px)"
+            });
+            {{ else }}
             window['nitroAds'].createAd('search-video-nc-top-right', {
                 "format": "video-nc",
                 "keywords": searchKw,
@@ -255,6 +268,7 @@
                 },
                 "mediaQuery": "(min-width: 1200px)"
             });
+            {{ end }}
             window['nitroAds'].createAd('search-sticky-adrail-top', {
                 "refreshTime": 45,
                 "refreshVisibleOnly": true,

--- a/template/static/dev-ads.js
+++ b/template/static/dev-ads.js
@@ -118,6 +118,13 @@
     setupVideoNcFloat(container, id);
   }
 
+  function renderSmartFlex(container, id) {
+    var w = 300, h = 600;
+    container.appendChild(makePlaceholder(w, h, [
+      'SMART FLEX AD', id, w + ' × ' + h
+    ]));
+  }
+
   function renderStickyStack(container, id) {
     var isNarrow = !!(container.closest('.ad-rail-sm') ||
                       container.closest('.generator-ad-rail-sm'));
@@ -188,6 +195,9 @@
     switch (format) {
       case 'video-nc':
         renderVideoNc(container, id);
+        break;
+      case 'smart-flex':
+        renderSmartFlex(container, id);
         break;
       case 'sticky-stack':
         renderStickyStack(container, id);

--- a/template/top-creators.html
+++ b/template/top-creators.html
@@ -151,7 +151,7 @@
             </div>
             <!-- Ad Rail (desktop only) -->
             <div class="ad-rail d-none d-xl-block">
-                <div id="topcreators-video-nc-top-right" class="mb-3"></div>
+                {{if .IsAdmin}}<div id="topcreators-smart-flex" class="mb-3"></div>{{else}}<div id="topcreators-video-nc-top-right" class="mb-3"></div>{{end}}
                 <div id="topcreators-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
             </div>
             </div>
@@ -166,6 +166,20 @@
 {{ template "footer.html" . }}
 {{ template "foot.html" . }}
 <script>
+{{if .IsAdmin}}
+window['nitroAds'].createAd('topcreators-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,leaderboard,creators",
+  "targeting": { "pageType": "top-creators" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{else}}
 window['nitroAds'].createAd('topcreators-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,leaderboard,creators",
@@ -178,6 +192,7 @@ window['nitroAds'].createAd('topcreators-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{end}}
 window['nitroAds'].createAd('topcreators-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/upload_modify.html
+++ b/template/upload_modify.html
@@ -118,7 +118,7 @@
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
                     <div class="ad-rail d-none d-xl-block">
-                        <div id="upload-modify-video-nc-top-right" class="mb-3"></div>
+                        {{if .IsAdmin}}<div id="upload-modify-smart-flex" class="mb-3"></div>{{else}}<div id="upload-modify-video-nc-top-right" class="mb-3"></div>{{end}}
                         <div id="upload-modify-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                     </div>
                 </div><!-- /d-flex -->
@@ -475,7 +475,20 @@
 
 <!-- Ad Scripts -->
 <script>
-// Video NC ad (desktop only)
+{{ if .IsAdmin }}
+window['nitroAds'].createAd('upload-modify-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,modify,blocks,upload",
+  "targeting": { "pageType": "modify" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{ else }}
 window['nitroAds'].createAd('upload-modify-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,modify,blocks,upload",
@@ -488,6 +501,7 @@ window['nitroAds'].createAd('upload-modify-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{ end }}
 // Narrow ad rail (lg only: 992-1199px)
 window['nitroAds'].createAd('upload-modify-sticky-adrail-lg', {
   "refreshLimit": 10,

--- a/template/upload_preview.html
+++ b/template/upload_preview.html
@@ -392,7 +392,7 @@
 
                     <!-- Ad Rail (desktop only) -->
                     <div class="ad-rail d-none d-xl-block">
-                        <div id="upload-preview-video-nc-top-right" class="mb-3"></div>
+                        {{if .IsAdmin}}<div id="upload-preview-smart-flex" class="mb-3"></div>{{else}}<div id="upload-preview-video-nc-top-right" class="mb-3"></div>{{end}}
                         <div id="upload-preview-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
                     </div>
                 </div>
@@ -719,6 +719,20 @@ function deleteAdditionalFile(token, fileId, btn) {
 {{ end }}
 {{template "foot.html" .}}
 <script>
+{{ if .IsAdmin }}
+window['nitroAds'].createAd('upload-preview-smart-flex', {
+  "format": "smart-flex",
+  "keywords": "minecraft,create-mod,upload,preview",
+  "targeting": { "pageType": "upload-preview" },
+  "report": {
+    "enabled": true,
+    "icon": true,
+    "wording": "Report Ad",
+    "position": "top-right"
+  },
+  "mediaQuery": "(min-width: 1200px)"
+});
+{{ else }}
 window['nitroAds'].createAd('upload-preview-video-nc-top-right', {
   "format": "video-nc",
   "keywords": "minecraft,create-mod,upload,preview",
@@ -731,6 +745,7 @@ window['nitroAds'].createAd('upload-preview-video-nc-top-right', {
   },
   "mediaQuery": "(min-width: 1200px)"
 });
+{{ end }}
 window['nitroAds'].createAd('upload-preview-sticky-adrail', {
   "refreshLimit": 10,
   "refreshTime": 45,

--- a/template/videos.html
+++ b/template/videos.html
@@ -51,7 +51,7 @@
 
         <!-- Ad Rail (desktop only) -->
         <div class="ad-rail d-none d-xl-block">
-            <div id="videos-video-nc-top-right" class="mb-3"></div>
+            {{if .IsAdmin}}<div id="videos-smart-flex" class="mb-3"></div>{{else}}<div id="videos-video-nc-top-right" class="mb-3"></div>{{end}}
             <div id="videos-sticky-adrail" class="mb-3">{{.KinTileHTML}}</div>
         </div>
         </div><!-- /d-flex -->
@@ -64,6 +64,20 @@
 </div>
 <script>
 if (window['nitroAds']) {
+{{if .IsAdmin}}
+  window['nitroAds'].createAd('videos-smart-flex', {
+    "format": "smart-flex",
+    "keywords": "minecraft,create-mod,videos",
+    "targeting": { "pageType": "videos" },
+    "report": {
+      "enabled": true,
+      "icon": true,
+      "wording": "Report Ad",
+      "position": "top-right"
+    },
+    "mediaQuery": "(min-width: 1200px)"
+  });
+  {{else}}
   window['nitroAds'].createAd('videos-video-nc-top-right', {
     "format": "video-nc",
     "keywords": "minecraft,create-mod,videos",
@@ -76,6 +90,7 @@ if (window['nitroAds']) {
     },
     "mediaQuery": "(min-width: 1200px)"
   });
+  {{end}}
   window['nitroAds'].createAd('videos-sticky-adrail', {
     "refreshLimit": 10,
     "refreshTime": 45,


### PR DESCRIPTION
… users

Add IsAdmin to DefaultData so templates can branch on it. When the logged-in user is an admin, the top-of-rail ad slot uses NitroPay's smart-flex format instead of video-nc. Everyone else continues to see the existing video-nc ads unchanged. This lets us compare performance before committing to a full rollout.