### PR TITLE
chore(meilisearch): upgrade dev to v1.48

### DIFF
--- a/k8s/meilisearch/dev/deployment.yaml
+++ b/k8s/meilisearch/dev/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: meilisearch
-          image: getmeili/meilisearch:v1.12
+          image: getmeili/meilisearch:v1.48
           ports:
             - containerPort: 7700
               name: http


### PR DESCRIPTION
## What
Bumps the **dev** Meilisearch image from `v1.12` → `v1.48` in `k8s/meilisearch/dev/deployment.yaml` (synced by the ArgoCD app `meilisearch-dev` from `master`).

## Why it was stuck at v1.12
- Renovate only tracks the `docker-compose.yml` tag — the Renovate **kubernetes manager is not enabled**, so it never sees `k8s/meilisearch/*`.
- The CI image pipeline only rewrites `k8s/createmod/*`.
- So nothing ever updated these manifests.

## Why this is safe (no dump needed)
Dev Meilisearch uses an `emptyDir` volume — its index is **already ephemeral** and rebuilt from Postgres on every restart:
- `EnsureMeiliIndexes` recreates the index + settings on connect (`server/start.go`).
- `SearchIndexWorker` (River, `RunOnStart: true`, every 10 min) repopulates all documents (~12s for ~4k docs).

On merge, ArgoCD rolls the pod; it starts empty on v1.48 and the app re-indexes. This also validates `meilisearch-go v0.36.3` against server v1.48 before we touch prod.

## Prod follow-up (separate PR)
Prod uses a **persistent PVC**, so it additionally needs the v1.12 data dir wiped (delete pod + PVC so the StatefulSet recreates an empty one). Handled separately once dev is verified.