### PR TITLE
chore(meilisearch): upgrade prod to v1.48

### DIFF
--- a/k8s/meilisearch/prod/statefulset.yaml
+++ b/k8s/meilisearch/prod/statefulset.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: meilisearch
-          image: getmeili/meilisearch:v1.12
+          image: getmeili/meilisearch:v1.48
           ports:
             - containerPort: 7700
               name: http


### PR DESCRIPTION
Bumps **prod** Meilisearch `v1.12` → `v1.48` in `k8s/meilisearch/prod/statefulset.yaml` (ArgoCD app `meilisearch-prod`, synced from `master`).

## Validated on dev first
Dev (#1388) is on v1.48.2: index recreated with correct settings, **3605 docs synced**, search returns 3517 hits for "create". Confirms `meilisearch-go v0.36.3` ↔ server v1.48 compatibility.

## ⚠️ Required manual cutover after merge
Prod uses a **persistent PVC** holding v1.12-format data that v1.48 cannot read, so merging alone will crashloop `meilisearch-0`. Immediately after merge:
```bash
kubectl -n createmod-com-prod delete pvc data-meilisearch-0 --wait=false  # wipe v1.12 data (Terminating, held by mount)
kubectl -n createmod-com-prod delete pod meilisearch-0                      # STS recreates pod + fresh empty PVC on v1.48
kubectl -n createmod-com-prod rollout restart deploy/createmod             # re-run EnsureMeiliIndexes + immediate reindex
```
The index is 100% derived from Postgres, so nothing is permanently lost. **Brief search-only downtime (~1–2 min)** while it rebuilds — best at low traffic.