### PR TITLE
chore(renovate): track Meilisearch k8s manifests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "kubernetes": {
+    "managerFilePatterns": [
+      "/k8s/meilisearch/.+\\.ya?ml$/"
+    ]
+  }
 }


### PR DESCRIPTION
## What
Enables Renovate's **kubernetes manager**, scoped to `k8s/meilisearch/`, so the `getmeili/meilisearch` image in `k8s/meilisearch/dev/deployment.yaml` and `k8s/meilisearch/prod/statefulset.yaml` gets version-bump PRs from now on.

## Why
These manifests were tracked by **nothing**:
- Renovate's kubernetes manager is off by default (no file patterns) and only saw `docker-compose.yml`.
- The CI image pipeline only rewrites `k8s/createmod/*`.

That's why Meilisearch sat at **v1.12 for months** while `docker-compose.yml` got bumped to v1.48. Both clusters were just upgraded to v1.48 manually (#1388 dev, #1393 prod), so enabling this now won't trigger a giant jump — at most a minor bump if a newer release exists.

## Scope
Deliberately limited to `k8s/meilisearch/` so Renovate does **not** touch the createmod app-image manifests (`k8s/createmod/*`), whose `master-<sha>` tags are owned by the CI deploy pipeline.

⚠️ Note: a future Renovate Meilisearch PR is a manifest bump only — for a major jump the prod PVC still needs the same wipe-and-reindex cutover (the data is rebuilt from Postgres).