### PR TITLE
fix(upload): strip image metadata before storage and reject animated GIFs

### DIFF
--- a/internal/pages/api_schematic_edit.go
+++ b/internal/pages/api_schematic_edit.go
@@ -263,6 +263,9 @@ func SchematicUpdateHandler(
 			if errors.Is(convErr, errImageTooLarge) {
 				return e.BadRequestError("featured image resolution is too large", nil)
 			}
+			if errors.Is(convErr, errAnimatedGIF) {
+				return e.BadRequestError("animated GIFs are not allowed", nil)
+			}
 			if storageSvc != nil {
 				if uploadErr := storageSvc.UploadBytes(ctx, s3CollectionSchematics, schematicID, filename, data, contentType); uploadErr != nil {
 					slog.Error("schematic update: failed to upload featured image to S3", "error", uploadErr, "id", schematicID)
@@ -512,11 +515,15 @@ const (
 // maxDecodePixels. Callers should skip/reject the image rather than decode it.
 var errImageTooLarge = errors.New("image resolution too large")
 
-// convertToWebP converts image data to WebP format. GIF and WebP files are
-// passed through unchanged (GIF may be animated; WebP is already the target).
-// Returns the (possibly converted) data, filename, and content type. Falls back
-// to the original bytes if conversion fails. Returns errImageTooLarge if the
-// image exceeds maxDecodePixels, in which case the data return is nil.
+// convertToWebP converts image data to WebP format. Embedded metadata
+// (EXIF/XMP/GPS/comments) is stripped before anything is stored. WebP files are
+// passed through after stripping (already the target format; preserves
+// animation); everything else is decoded and re-encoded to WebP. Animated GIFs
+// are rejected with errAnimatedGIF. Returns the (possibly converted) data,
+// filename, and content type. Falls back to the (stripped) original bytes if
+// re-encoding fails. Returns errImageTooLarge if the image exceeds
+// maxDecodePixels, or errAnimatedGIF for animated GIFs — in both cases the data
+// return is nil.
 func convertToWebP(data []byte, filename string) ([]byte, string, string, error) {
 	ext := strings.ToLower(filepath.Ext(filename))
 
@@ -529,7 +536,18 @@ func convertToWebP(data []byte, filename string) ([]byte, string, string, error)
 		}
 	}
 
-	if ext == ".gif" || ext == ".webp" {
+	// Animated GIFs are not allowed.
+	if ext == ".gif" && isAnimatedGIF(data) {
+		return nil, "", "", errAnimatedGIF
+	}
+
+	// Strip embedded metadata before any conversion or passthrough, so a user's
+	// original EXIF/GPS data is never stored or served.
+	data = stripImageMetadata(data)
+
+	// WebP is already the target format; serve the stripped bytes as-is. This
+	// preserves animated WebP, which we deliberately don't re-encode.
+	if ext == ".webp" {
 		return data, filename, http.DetectContentType(data), nil
 	}
 

--- a/internal/pages/image_metadata.go
+++ b/internal/pages/image_metadata.go
@@ -1,0 +1,261 @@
+package pages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+)
+
+// errAnimatedGIF is returned by convertToWebP when an uploaded GIF has more than
+// one frame. Animated GIFs are not allowed.
+var errAnimatedGIF = errors.New("animated GIFs are not allowed")
+
+// stripImageMetadata removes embedded metadata (EXIF, XMP, GPS coordinates,
+// textual comments) from an encoded image before it is stored, so a user's
+// original camera/phone metadata is never persisted or served. It is format
+// aware and lenient: it parses the container, drops the metadata segments, and
+// copies all image-bearing data through verbatim. Inputs it does not recognize
+// or cannot safely parse are returned unchanged.
+//
+// JPEG and PNG are also re-encoded downstream (which strips metadata on its
+// own), but stripping here keeps the WebP passthrough — the one path that is
+// NOT re-encoded — safe as well.
+func stripImageMetadata(data []byte) []byte {
+	switch {
+	case len(data) >= 3 && data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF:
+		return stripJPEGMetadata(data)
+	case len(data) >= 8 && bytes.Equal(data[:8], pngSignature):
+		return stripPNGMetadata(data)
+	case len(data) >= 12 && bytes.Equal(data[:4], []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WEBP")):
+		return stripWebPMetadata(data)
+	default:
+		return data
+	}
+}
+
+var pngSignature = []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a}
+
+// stripJPEGMetadata drops APPn (0xFFE0–0xFFEF, which hold EXIF/JFIF/XMP/ICC) and
+// COM (0xFFFE) comment segments. All other segments and the entropy-coded scan
+// data are preserved.
+func stripJPEGMetadata(data []byte) []byte {
+	if len(data) < 2 || data[0] != 0xFF || data[1] != 0xD8 {
+		return data
+	}
+	out := make([]byte, 0, len(data))
+	out = append(out, 0xFF, 0xD8) // SOI
+	i := 2
+	for i+1 < len(data) {
+		if data[i] != 0xFF {
+			out = append(out, data[i:]...)
+			return out
+		}
+		// Skip any 0xFF fill bytes; the marker is the first non-0xFF byte.
+		j := i + 1
+		for j < len(data) && data[j] == 0xFF {
+			j++
+		}
+		if j >= len(data) {
+			out = append(out, data[i:]...)
+			return out
+		}
+		marker := data[j]
+		switch {
+		case marker == 0x01 || (marker >= 0xD0 && marker <= 0xD7):
+			// Standalone markers (TEM, RSTn) carry no length.
+			out = append(out, 0xFF, marker)
+			i = j + 1
+			continue
+		case marker == 0xD9: // EOI
+			out = append(out, 0xFF, 0xD9)
+			return out
+		case marker == 0xDA: // SOS — copy the scan header and all entropy data verbatim.
+			out = append(out, data[i:]...)
+			return out
+		}
+		if j+3 > len(data) {
+			out = append(out, data[i:]...)
+			return out
+		}
+		segLen := int(binary.BigEndian.Uint16(data[j+1 : j+3]))
+		segEnd := j + 1 + segLen
+		if segLen < 2 || segEnd > len(data) {
+			out = append(out, data[i:]...)
+			return out
+		}
+		if (marker >= 0xE0 && marker <= 0xEF) || marker == 0xFE {
+			i = segEnd // drop APPn / COM
+			continue
+		}
+		out = append(out, 0xFF, marker)
+		out = append(out, data[j+1:segEnd]...)
+		i = segEnd
+	}
+	out = append(out, data[i:]...)
+	return out
+}
+
+// pngMetadataChunks are the ancillary chunks that carry text/EXIF/timestamps.
+var pngMetadataChunks = map[string]bool{
+	"tEXt": true, "zTXt": true, "iTXt": true, "eXIf": true, "tIME": true,
+}
+
+// stripPNGMetadata drops textual, EXIF, and timestamp chunks while keeping all
+// critical and rendering chunks (IHDR, PLTE, IDAT, IEND, tRNS, iCCP, gAMA, …).
+func stripPNGMetadata(data []byte) []byte {
+	if len(data) < 8 || !bytes.Equal(data[:8], pngSignature) {
+		return data
+	}
+	out := make([]byte, 0, len(data))
+	out = append(out, pngSignature...)
+	i := 8
+	for i+8 <= len(data) {
+		length := int(binary.BigEndian.Uint32(data[i : i+4]))
+		ctype := string(data[i+4 : i+8])
+		end := i + 12 + length // length(4) + type(4) + data + crc(4)
+		if length < 0 || end < i || end > len(data) {
+			out = append(out, data[i:]...)
+			return out
+		}
+		if !pngMetadataChunks[ctype] {
+			out = append(out, data[i:end]...)
+		}
+		i = end
+		if ctype == "IEND" {
+			return out
+		}
+	}
+	if i < len(data) {
+		out = append(out, data[i:]...)
+	}
+	return out
+}
+
+// stripWebPMetadata drops the EXIF and "XMP " RIFF chunks and clears the
+// corresponding flags in the VP8X header, preserving image and animation data
+// (VP8/VP8L/VP8X/ANIM/ANMF/ALPH/ICCP). On any structural anomaly it returns the
+// input unchanged.
+func stripWebPMetadata(data []byte) []byte {
+	if len(data) < 12 || !bytes.Equal(data[:4], []byte("RIFF")) || !bytes.Equal(data[8:12], []byte("WEBP")) {
+		return data
+	}
+	body := data[12:]
+	var kept [][]byte
+	vp8xIdx := -1
+	i := 0
+	for i+8 <= len(body) {
+		fourcc := string(body[i : i+4])
+		size := int(binary.LittleEndian.Uint32(body[i+4 : i+8]))
+		if size < 0 {
+			return data
+		}
+		end := i + 8 + size
+		padded := end + (size & 1) // chunks are padded to an even size
+		if end < i || end > len(body) || padded > len(body) {
+			return data
+		}
+		seg := body[i:padded]
+		if fourcc == "EXIF" || fourcc == "XMP " {
+			// drop
+		} else {
+			if fourcc == "VP8X" {
+				vp8xIdx = len(kept)
+			}
+			kept = append(kept, seg)
+		}
+		i = padded
+	}
+	if i != len(body) {
+		return data // trailing bytes we don't understand — leave as-is
+	}
+	// Clear the EXIF (bit 3) and XMP (bit 2) flags in the VP8X flags byte
+	// (payload byte 0 == chunk byte 8).
+	if vp8xIdx >= 0 && len(kept[vp8xIdx]) >= 9 {
+		c := append([]byte(nil), kept[vp8xIdx]...)
+		c[8] &^= 0x0C
+		kept[vp8xIdx] = c
+	}
+	var bodyOut bytes.Buffer
+	for _, c := range kept {
+		bodyOut.Write(c)
+	}
+	out := make([]byte, 0, 12+bodyOut.Len())
+	out = append(out, 'R', 'I', 'F', 'F')
+	var sz [4]byte
+	binary.LittleEndian.PutUint32(sz[:], uint32(4+bodyOut.Len()))
+	out = append(out, sz[:]...)
+	out = append(out, 'W', 'E', 'B', 'P')
+	out = append(out, bodyOut.Bytes()...)
+	return out
+}
+
+// isAnimatedGIF reports whether the GIF contains more than one frame. It walks
+// the block structure without decoding pixels, so it is safe against
+// decompression bombs.
+func isAnimatedGIF(data []byte) bool {
+	n, ok := gifFrameCount(data)
+	return ok && n > 1
+}
+
+// gifFrameCount counts image descriptors (frames) by walking GIF blocks. The
+// bool is false when the structure can't be parsed.
+func gifFrameCount(data []byte) (int, bool) {
+	if len(data) < 13 || (!bytes.HasPrefix(data, []byte("GIF87a")) && !bytes.HasPrefix(data, []byte("GIF89a"))) {
+		return 0, false
+	}
+	i := 13
+	if packed := data[10]; packed&0x80 != 0 { // global color table present
+		i += 3 * (1 << ((packed & 0x07) + 1))
+	}
+	frames := 0
+	for i < len(data) {
+		switch data[i] {
+		case 0x3B: // trailer
+			return frames, true
+		case 0x21: // extension introducer: skip label + sub-blocks
+			i += 2
+			var ok bool
+			if i, ok = skipGIFSubBlocks(data, i); !ok {
+				return frames, false
+			}
+		case 0x2C: // image descriptor
+			frames++
+			if i+10 > len(data) {
+				return frames, false
+			}
+			lp := data[i+9]
+			i += 10
+			if lp&0x80 != 0 { // local color table
+				i += 3 * (1 << ((lp & 0x07) + 1))
+			}
+			if i >= len(data) {
+				return frames, false
+			}
+			i++ // LZW minimum code size
+			var ok bool
+			if i, ok = skipGIFSubBlocks(data, i); !ok {
+				return frames, false
+			}
+		default:
+			return frames, false
+		}
+	}
+	return frames, false
+}
+
+// skipGIFSubBlocks advances past a chain of GIF sub-blocks (each a length byte
+// followed by that many bytes, terminated by a zero-length block).
+func skipGIFSubBlocks(data []byte, i int) (int, bool) {
+	for i < len(data) {
+		sz := int(data[i])
+		i++
+		if sz == 0 {
+			return i, true
+		}
+		i += sz
+		if i > len(data) {
+			return i, false
+		}
+	}
+	return i, false
+}

--- a/internal/pages/image_metadata_test.go
+++ b/internal/pages/image_metadata_test.go
@@ -1,0 +1,276 @@
+package pages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"image"
+	"image/color"
+	"image/color/palette"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"testing"
+)
+
+// --- WebP chunk surgery ---
+
+func webpChunk(fourcc string, payload []byte) []byte {
+	b := append([]byte(nil), fourcc...)
+	var sz [4]byte
+	binary.LittleEndian.PutUint32(sz[:], uint32(len(payload)))
+	b = append(b, sz[:]...)
+	b = append(b, payload...)
+	if len(payload)%2 == 1 {
+		b = append(b, 0) // even padding
+	}
+	return b
+}
+
+func buildWebP(chunks ...[]byte) []byte {
+	var body bytes.Buffer
+	for _, c := range chunks {
+		body.Write(c)
+	}
+	out := append([]byte(nil), "RIFF"...)
+	var sz [4]byte
+	binary.LittleEndian.PutUint32(sz[:], uint32(4+body.Len()))
+	out = append(out, sz[:]...)
+	out = append(out, "WEBP"...)
+	out = append(out, body.Bytes()...)
+	return out
+}
+
+func webpChunkFourCCs(data []byte) []string {
+	var ccs []string
+	body := data[12:]
+	for i := 0; i+8 <= len(body); {
+		cc := string(body[i : i+4])
+		size := int(binary.LittleEndian.Uint32(body[i+4 : i+8]))
+		ccs = append(ccs, cc)
+		i += 8 + size + (size & 1)
+	}
+	return ccs
+}
+
+func TestStripWebPMetadata(t *testing.T) {
+	vp8x := make([]byte, 10)
+	vp8x[0] = 0x0C // EXIF (bit3) + XMP (bit2) flags set
+	in := buildWebP(
+		webpChunk("VP8X", vp8x),
+		webpChunk("VP8 ", []byte("IMAGEDATA")),
+		webpChunk("EXIF", []byte("EXIF-GPS-SECRET")),
+		webpChunk("XMP ", []byte("<xmp>SECRET</xmp>")),
+	)
+
+	out := stripWebPMetadata(in)
+
+	if bytes.Contains(out, []byte("EXIF-GPS-SECRET")) || bytes.Contains(out, []byte("SECRET</xmp>")) {
+		t.Fatal("metadata payload survived stripping")
+	}
+	if !bytes.Contains(out, []byte("IMAGEDATA")) {
+		t.Fatal("image data chunk was lost")
+	}
+	ccs := webpChunkFourCCs(out)
+	for _, cc := range ccs {
+		if cc == "EXIF" || cc == "XMP " {
+			t.Fatalf("metadata chunk %q not removed", cc)
+		}
+	}
+	// VP8X flags byte (body offset 8 of first chunk) must have EXIF/XMP bits cleared.
+	if out[12+8]&0x0C != 0 {
+		t.Fatalf("VP8X EXIF/XMP flags not cleared: %02x", out[12+8])
+	}
+	// RIFF size header must match the actual remaining bytes.
+	if got := binary.LittleEndian.Uint32(out[4:8]); int(got) != len(out)-8 {
+		t.Fatalf("RIFF size %d != %d", got, len(out)-8)
+	}
+}
+
+func TestStripWebPMetadata_NoMetadataUnchanged(t *testing.T) {
+	in := buildWebP(webpChunk("VP8 ", []byte("IMAGEDATA")))
+	if out := stripWebPMetadata(in); !bytes.Equal(out, in) {
+		t.Fatal("webp without metadata should be byte-identical after strip")
+	}
+}
+
+// --- JPEG ---
+
+func TestStripJPEGMetadata(t *testing.T) {
+	app1 := append([]byte{0xFF, 0xE1}, segLen(2+len("Exif\x00\x00EXIFSECRET"))...)
+	app1 = append(app1, []byte("Exif\x00\x00EXIFSECRET")...)
+	com := append([]byte{0xFF, 0xFE}, segLen(2+len("COMSECRET"))...)
+	com = append(com, []byte("COMSECRET")...)
+	dqt := append([]byte{0xFF, 0xDB}, segLen(2+len("DQTKEEP"))...)
+	dqt = append(dqt, []byte("DQTKEEP")...)
+
+	var in []byte
+	in = append(in, 0xFF, 0xD8) // SOI
+	in = append(in, app1...)
+	in = append(in, com...)
+	in = append(in, dqt...)
+	in = append(in, 0xFF, 0xDA) // SOS
+	in = append(in, []byte("SCANDATA")...)
+	in = append(in, 0xFF, 0xD9) // EOI
+
+	out := stripJPEGMetadata(in)
+	if bytes.Contains(out, []byte("EXIFSECRET")) {
+		t.Fatal("EXIF APP1 not stripped")
+	}
+	if bytes.Contains(out, []byte("COMSECRET")) {
+		t.Fatal("COM comment not stripped")
+	}
+	if !bytes.Contains(out, []byte("DQTKEEP")) || !bytes.Contains(out, []byte("SCANDATA")) {
+		t.Fatal("essential JPEG segments were dropped")
+	}
+}
+
+func segLen(n int) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(n))
+	return b
+}
+
+func TestStripJPEGMetadata_StillDecodes(t *testing.T) {
+	// Real JPEG with an injected EXIF APP1 segment must still decode after strip.
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	img.Set(1, 1, color.RGBA{R: 200, G: 100, B: 50, A: 255})
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		t.Fatal(err)
+	}
+	enc := buf.Bytes()
+	exif := append([]byte{0xFF, 0xE1}, segLen(2+len("Exif\x00\x00GPSDATA"))...)
+	exif = append(exif, []byte("Exif\x00\x00GPSDATA")...)
+	withExif := append([]byte{}, enc[:2]...) // SOI
+	withExif = append(withExif, exif...)
+	withExif = append(withExif, enc[2:]...)
+
+	out := stripJPEGMetadata(withExif)
+	if bytes.Contains(out, []byte("GPSDATA")) {
+		t.Fatal("EXIF survived")
+	}
+	if _, err := jpeg.Decode(bytes.NewReader(out)); err != nil {
+		t.Fatalf("stripped JPEG no longer decodes: %v", err)
+	}
+}
+
+// --- PNG ---
+
+func TestStripPNGMetadata_StillDecodes(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	enc := buf.Bytes()
+	// Inject a tEXt chunk just before the trailing IEND chunk (last 12 bytes).
+	text := pngChunk("tEXt", []byte("Comment\x00PNGSECRET"))
+	withText := append([]byte{}, enc[:len(enc)-12]...)
+	withText = append(withText, text...)
+	withText = append(withText, enc[len(enc)-12:]...)
+
+	out := stripPNGMetadata(withText)
+	if bytes.Contains(out, []byte("PNGSECRET")) {
+		t.Fatal("tEXt metadata survived strip")
+	}
+	if _, err := png.Decode(bytes.NewReader(out)); err != nil {
+		t.Fatalf("stripped PNG no longer decodes: %v", err)
+	}
+}
+
+func pngChunk(ctype string, payload []byte) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(len(payload)))
+	b = append(b, ctype...)
+	b = append(b, payload...)
+	// CRC over type+payload
+	crc := pngCRC(append([]byte(ctype), payload...))
+	var c [4]byte
+	binary.BigEndian.PutUint32(c[:], crc)
+	return append(b, c[:]...)
+}
+
+func pngCRC(b []byte) uint32 {
+	// minimal IEEE CRC32 (same as hash/crc32 IEEE)
+	var table [256]uint32
+	for i := range table {
+		c := uint32(i)
+		for k := 0; k < 8; k++ {
+			if c&1 != 0 {
+				c = 0xedb88320 ^ (c >> 1)
+			} else {
+				c >>= 1
+			}
+		}
+		table[i] = c
+	}
+	crc := uint32(0xffffffff)
+	for _, x := range b {
+		crc = table[(crc^uint32(x))&0xff] ^ (crc >> 8)
+	}
+	return crc ^ 0xffffffff
+}
+
+// --- GIF animation ---
+
+func buildGIF(frames int) []byte {
+	g := &gif.GIF{}
+	for i := 0; i < frames; i++ {
+		pi := image.NewPaletted(image.Rect(0, 0, 4, 4), palette.Plan9)
+		g.Image = append(g.Image, pi)
+		g.Delay = append(g.Delay, 0)
+	}
+	var buf bytes.Buffer
+	if err := gif.EncodeAll(&buf, g); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+func TestGIFFrameCount(t *testing.T) {
+	if n, ok := gifFrameCount(buildGIF(1)); !ok || n != 1 {
+		t.Fatalf("static gif: got (%d,%v), want (1,true)", n, ok)
+	}
+	if n, ok := gifFrameCount(buildGIF(3)); !ok || n != 3 {
+		t.Fatalf("animated gif: got (%d,%v), want (3,true)", n, ok)
+	}
+	if isAnimatedGIF(buildGIF(1)) {
+		t.Fatal("static gif reported as animated")
+	}
+	if !isAnimatedGIF(buildGIF(2)) {
+		t.Fatal("animated gif not detected")
+	}
+}
+
+func TestConvertToWebP_RejectsAnimatedGIF(t *testing.T) {
+	out, _, _, err := convertToWebP(buildGIF(3), "loop.gif")
+	if !errors.Is(err, errAnimatedGIF) {
+		t.Fatalf("expected errAnimatedGIF, got %v", err)
+	}
+	if out != nil {
+		t.Fatalf("expected nil data for rejected animated gif, got %d bytes", len(out))
+	}
+}
+
+func TestConvertToWebP_StripsWebPPassthroughMetadata(t *testing.T) {
+	// The key regression: a WebP upload is passthrough (not re-encoded), so it
+	// must be stripped inline or its EXIF/GPS leaks to the public.
+	vp8x := make([]byte, 10)
+	vp8x[0] = 0x08 // EXIF flag
+	in := buildWebP(
+		webpChunk("VP8X", vp8x),
+		webpChunk("VP8 ", []byte("PIXELS")),
+		webpChunk("EXIF", []byte("LAT-LONG-LEAK")),
+	)
+	out, filename, ct, err := convertToWebP(in, "photo.webp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bytes.Contains(out, []byte("LAT-LONG-LEAK")) {
+		t.Fatal("EXIF metadata leaked through the WebP passthrough")
+	}
+	if filename != "photo.webp" || ct != "image/webp" {
+		t.Fatalf("unexpected filename/ct: %q %q", filename, ct)
+	}
+}

--- a/internal/pages/image_upload.go
+++ b/internal/pages/image_upload.go
@@ -67,10 +67,13 @@ func ImageUploadHandler(storageSvc *storage.Service) func(e *server.RequestEvent
 			return writeJSON(e, http.StatusInternalServerError, map[string]string{"error": "failed to read file"})
 		}
 
-		// Convert to WebP (GIF and WebP pass through). Rejects decompression bombs.
+		// Convert to WebP, stripping metadata. Rejects decompression bombs and animated GIFs.
 		data, filename, contentType, convErr := convertToWebP(data, sanitizeFilename(filepath.Base(header.Filename)))
 		if errors.Is(convErr, errImageTooLarge) {
 			return writeJSON(e, http.StatusBadRequest, map[string]string{"error": "image resolution too large"})
+		}
+		if errors.Is(convErr, errAnimatedGIF) {
+			return writeJSON(e, http.StatusBadRequest, map[string]string{"error": "animated GIFs are not allowed"})
 		}
 
 		// Generate unique ID


### PR DESCRIPTION
## Problem
`convertToWebP` passed **GIF and WebP** uploads through byte-for-byte. JPEG/PNG lost their metadata as a side effect of re-encoding, but WebP (and GIF) were stored unchanged — so embedded **EXIF / XMP / GPS** metadata from phone exports (both formats support metadata chunks) was persisted and served publicly. There was no explicit strip step anywhere.

## Fix
A metadata-strip layer that runs **before any conversion or passthrough**, plus rejecting animated GIFs (as requested):

- **`stripImageMetadata`** — lenient, format-aware, bomb-safe:
  - **JPEG** → drop `APPn` (EXIF/JFIF/XMP/ICC) and `COM` segments
  - **PNG** → drop `tEXt`/`zTXt`/`iTXt`/`eXIf`/`tIME` chunks
  - **WebP** → drop `EXIF`/`XMP ` chunks and clear the `VP8X` EXIF/XMP flags, preserving image + animation
- **Animated GIFs rejected** (`errAnimatedGIF`) via a frame-count walk that never decodes pixels (bomb-safe). Static GIFs now re-encode to WebP like JPEG/PNG.
- Single-file upload endpoints return a clear **"animated GIFs are not allowed"**; batch paths already skip on any conversion error.

### Coverage by path
| Upload | Before | After |
|--------|--------|-------|
| JPEG / PNG | stripped (via re-encode) | stripped (strip layer + re-encode) |
| **WebP** | **stored as-is (metadata leaked)** | **metadata stripped, passthrough** |
| **GIF (animated)** | stored as-is | **rejected** |
| GIF (static) | stored as-is | re-encoded to WebP (stripped) |

## Tests
WebP/JPEG/PNG metadata removal (including the WebP passthrough leak), images still decode after stripping, and animated-GIF rejection. Full `go build ./...` + `go test ./internal/pages/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)