### PR TITLE
fix(ads): stop dual sticky-stack ads overlapping; keep both pinned

### DIFF
--- a/template/collections.html
+++ b/template/collections.html
@@ -166,7 +166,7 @@ window['nitroAds'].createAd('collections-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/collections_show.html
+++ b/template/collections_show.html
@@ -245,7 +245,7 @@ window['nitroAds'].createAd('collshow-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/explore.html
+++ b/template/explore.html
@@ -113,7 +113,7 @@ window['nitroAds'].createAd('explore-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/generators.html
+++ b/template/generators.html
@@ -96,7 +96,7 @@ window['nitroAds'].createAd('generators-sticky-adrail-1', {
 });
 window['nitroAds'].createAd('generators-sticky-adrail-2', {
   "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
+  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 674, "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,generators,schematics", "targeting": { "pageType": "generators" },
   "mediaQuery": "(min-width: 1200px)"

--- a/template/guides.html
+++ b/template/guides.html
@@ -119,7 +119,7 @@ window['nitroAds'].createAd('guides-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/guides_show.html
+++ b/template/guides_show.html
@@ -148,7 +148,7 @@ window['nitroAds'].createAd('guideshow-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/highest_scores.html
+++ b/template/highest_scores.html
@@ -63,7 +63,7 @@ window['nitroAds'].createAd('highscores-sticky-adrail-1', {
 });
 window['nitroAds'].createAd('highscores-sticky-adrail-2', {
   "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
+  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 674, "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,schematics,highest-scores", "targeting": { "pageType": "highest-scores" },
   "mediaQuery": "(min-width: 1200px)"

--- a/template/index.html
+++ b/template/index.html
@@ -170,7 +170,7 @@ window['nitroAds'].createAd('index-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,schematics,home",

--- a/template/mod_detail.html
+++ b/template/mod_detail.html
@@ -340,7 +340,8 @@ var moddetailStickyAd = {
   "mediaQuery": "(min-width: 1200px)"
 };
 window['nitroAds'].createAd('moddetail-sticky-adrail-1', moddetailStickyAd);
-window['nitroAds'].createAd('moddetail-sticky-adrail-2', moddetailStickyAd);
+// adrail-2 pins below adrail-1 (offset = adrail-1 top 8 + its max-height 650 + 1rem gap)
+window['nitroAds'].createAd('moddetail-sticky-adrail-2', Object.assign({}, moddetailStickyAd, { "stickyStackOffset": 674 }));
 window['nitroAds'].createAd('moddetail-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/modify.html
+++ b/template/modify.html
@@ -699,7 +699,7 @@ window['nitroAds'].createAd('modify-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/mods.html
+++ b/template/mods.html
@@ -84,7 +84,7 @@ window['nitroAds'].createAd('mods-sticky-adrail-1', {
 });
 window['nitroAds'].createAd('mods-sticky-adrail-2', {
   "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
+  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 674, "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,mods,addons", "targeting": { "pageType": "mods" },
   "mediaQuery": "(min-width: 1200px)"

--- a/template/profile.html
+++ b/template/profile.html
@@ -214,7 +214,7 @@ window['nitroAds'].createAd('profile-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -1642,7 +1642,8 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     "mediaQuery": "(min-width: 1200px)"
   };
   window['nitroAds'].createAd('schematic-sticky-adrail-1', wideStickyAd);
-  window['nitroAds'].createAd('schematic-sticky-adrail-2', wideStickyAd);
+  // adrail-2 pins below adrail-1 (offset = adrail-1 top 8 + its max-height 650 + 1rem gap)
+  window['nitroAds'].createAd('schematic-sticky-adrail-2', Object.assign({}, wideStickyAd, { "stickyStackOffset": 674 }));
   // Mobile ad (in-content on smaller screens)
   window['nitroAds'].createAd('schematic-mobile', {
     "refreshTime": 60,

--- a/template/schematics.html
+++ b/template/schematics.html
@@ -109,7 +109,7 @@ window['nitroAds'].createAd('schematics-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/search.html
+++ b/template/search.html
@@ -291,7 +291,8 @@
                 "mediaQuery": "(min-width: 1200px)"
             };
             window['nitroAds'].createAd('search-sticky-adrail-1', searchStickyAd);
-            window['nitroAds'].createAd('search-sticky-adrail-2', searchStickyAd);
+            // adrail-2 pins below adrail-1 (offset = adrail-1 top 8 + its max-height 650 + 1rem gap)
+            window['nitroAds'].createAd('search-sticky-adrail-2', Object.assign({}, searchStickyAd, { "stickyStackOffset": 674 }));
 
             // Infinite scroll via IntersectionObserver
             (function() {

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -1055,7 +1055,10 @@ body.sidebar-open::after {
 .search-ad-rail-wide {
   min-width: 160px;
   flex-shrink: 0;
-  align-self: start;
+  /* Full height so both stacked sticky ads stay pinned while scrolling
+     (align-self: start makes the rail only as tall as its content, so the
+     second ad unsticks and scrolls away). */
+  align-self: stretch;
 }
 .search-ad-rail-wide > [id*="sticky-adrail"] {
   position: sticky;

--- a/template/top-creators.html
+++ b/template/top-creators.html
@@ -209,7 +209,7 @@ window['nitroAds'].createAd('topcreators-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/trending.html
+++ b/template/trending.html
@@ -63,7 +63,7 @@ window['nitroAds'].createAd('trending-sticky-adrail-1', {
 });
 window['nitroAds'].createAd('trending-sticky-adrail-2', {
   "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
+  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 674, "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,schematics,trending", "targeting": { "pageType": "trending" },
   "mediaQuery": "(min-width: 1200px)"

--- a/template/upload_modify.html
+++ b/template/upload_modify.html
@@ -542,7 +542,7 @@ window['nitroAds'].createAd('upload-modify-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/upload_preview.html
+++ b/template/upload_preview.html
@@ -762,7 +762,7 @@ window['nitroAds'].createAd('upload-preview-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
+  "stickyStackOffset": 674,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/videos.html
+++ b/template/videos.html
@@ -109,7 +109,7 @@ if (window['nitroAds']) {
     "format": "sticky-stack",
     "stickyStackLimit": 15,
     "stickyStackSpace": 2.5,
-    "stickyStackOffset": 8,
+    "stickyStackOffset": 674,
     "stickyStackResizable": false,
     "report": {
       "enabled": true,


### PR DESCRIPTION
Both wide-rail sticky ads (-1 and -2) used the same stickyStackOffset: 8, so NitroPay pinned them to the same viewport position and they stacked on top of each other (observed on /mods and /mods/<slug> at 2560x1440).

- adrail-2 now uses stickyStackOffset 674 (= adrail-1 top 8 + its 650px max-height + 1rem gap), matching the CSS container stagger, so the two pin one below the other. The narrow -lg/-sm and generator overlay ads keep offset 8. Shared-config pages (schematic/search/mod_detail) give adrail-2 its own offset via Object.assign.
- .search-ad-rail-wide (search, mod_detail) changes align-self start -> stretch so the rail is full-height; otherwise the second sticky ad unsticks and scrolls away once you scroll past the short rail.

Keeps the NitroPay sticky-stack format. The video ad stays above the stack and scrolls away as before.