### PR TITLE
fix(ads): wrap the two sticky ads in one sticky group so they stack c…

### DIFF
--- a/template/collections.html
+++ b/template/collections.html
@@ -90,8 +90,10 @@
           </div>
           <div class="ad-rail d-none d-xl-block">
             {{if .IsAdmin}}<div id="collections-smart-flex" class="mb-3"></div>{{else}}<div id="collections-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div id="collections-sticky-adrail-1" class="mb-3"></div>
-            <div id="collections-sticky-adrail-2" class="mb-3"></div>
+            <div class="ad-sticky-stack">
+              <div id="collections-sticky-adrail-1" class="mb-3"></div>
+              <div id="collections-sticky-adrail-2" class="mb-3"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -166,7 +168,7 @@ window['nitroAds'].createAd('collections-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/collections_show.html
+++ b/template/collections_show.html
@@ -140,8 +140,10 @@
           </div>
           <div class="ad-rail d-none d-xl-block">
             {{if .IsAdmin}}<div id="collshow-smart-flex" class="mb-3"></div>{{else}}<div id="collshow-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div id="collshow-sticky-adrail-1" class="mb-3"></div>
-            <div id="collshow-sticky-adrail-2" class="mb-3"></div>
+            <div class="ad-sticky-stack">
+              <div id="collshow-sticky-adrail-1" class="mb-3"></div>
+              <div id="collshow-sticky-adrail-2" class="mb-3"></div>
+            </div>
           </div>
         </div><!-- /d-flex -->
       </div>
@@ -245,7 +247,7 @@ window['nitroAds'].createAd('collshow-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/explore.html
+++ b/template/explore.html
@@ -61,8 +61,10 @@
                 <!-- Ad Rail (desktop only) -->
                 <div class="ad-rail d-none d-xl-block">
                     {{if .IsAdmin}}<div id="explore-smart-flex" class="mb-3"></div>{{else}}<div id="explore-video-nc-top-right" class="mb-3"></div>{{end}}
-                    <div id="explore-sticky-adrail-1" class="mb-3"></div>
-                    <div id="explore-sticky-adrail-2" class="mb-3"></div>
+                    <div class="ad-sticky-stack">
+                      <div id="explore-sticky-adrail-1" class="mb-3"></div>
+                      <div id="explore-sticky-adrail-2" class="mb-3"></div>
+                    </div>
                 </div>
             </div>
         </main>
@@ -113,7 +115,7 @@ window['nitroAds'].createAd('explore-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/generators.html
+++ b/template/generators.html
@@ -69,8 +69,10 @@
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="generators-smart-flex" class="mb-3"></div>{{else}}<div id="generators-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="generators-sticky-adrail-1" class="mb-3"></div>
-                        <div id="generators-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="generators-sticky-adrail-1" class="mb-3"></div>
+                          <div id="generators-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -96,7 +98,7 @@ window['nitroAds'].createAd('generators-sticky-adrail-1', {
 });
 window['nitroAds'].createAd('generators-sticky-adrail-2', {
   "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 674, "stickyStackResizable": false,
+  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,generators,schematics", "targeting": { "pageType": "generators" },
   "mediaQuery": "(min-width: 1200px)"

--- a/template/guides.html
+++ b/template/guides.html
@@ -60,8 +60,10 @@
         {{if not .IsContributor}}
         <div class="ad-rail d-none d-xl-block">
             {{if .IsAdmin}}<div id="guides-smart-flex" class="mb-3"></div>{{else}}<div id="guides-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div id="guides-sticky-adrail-1" class="mb-3"></div>
-            <div id="guides-sticky-adrail-2" class="mb-3"></div>
+            <div class="ad-sticky-stack">
+              <div id="guides-sticky-adrail-1" class="mb-3"></div>
+              <div id="guides-sticky-adrail-2" class="mb-3"></div>
+            </div>
         </div>
         {{end}}
         </div><!-- /d-flex -->
@@ -119,7 +121,7 @@ window['nitroAds'].createAd('guides-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/guides_show.html
+++ b/template/guides_show.html
@@ -88,8 +88,10 @@
         {{if not .IsContributor}}
         <div class="ad-rail d-none d-xl-block">
             {{if .IsAdmin}}<div id="guideshow-smart-flex" class="mb-3"></div>{{else}}<div id="guideshow-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div id="guideshow-sticky-adrail-1" class="mb-3"></div>
-            <div id="guideshow-sticky-adrail-2" class="mb-3"></div>
+            <div class="ad-sticky-stack">
+              <div id="guideshow-sticky-adrail-1" class="mb-3"></div>
+              <div id="guideshow-sticky-adrail-2" class="mb-3"></div>
+            </div>
         </div>
         {{end}}
         </div><!-- /d-flex -->
@@ -148,7 +150,7 @@ window['nitroAds'].createAd('guideshow-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/highest_scores.html
+++ b/template/highest_scores.html
@@ -35,8 +35,10 @@
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="highscores-smart-flex" class="mb-3"></div>{{else}}<div id="highscores-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="highscores-sticky-adrail-1" class="mb-3"></div>
-                        <div id="highscores-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="highscores-sticky-adrail-1" class="mb-3"></div>
+                          <div id="highscores-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
 
                 </div>
@@ -63,7 +65,7 @@ window['nitroAds'].createAd('highscores-sticky-adrail-1', {
 });
 window['nitroAds'].createAd('highscores-sticky-adrail-2', {
   "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 674, "stickyStackResizable": false,
+  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,schematics,highest-scores", "targeting": { "pageType": "highest-scores" },
   "mediaQuery": "(min-width: 1200px)"

--- a/template/index.html
+++ b/template/index.html
@@ -126,8 +126,10 @@
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="index-smart-flex" class="mb-3"></div>{{else}}<div id="index-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="index-sticky-adrail-1" class="mb-3"></div>
-                        <div id="index-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="index-sticky-adrail-1" class="mb-3"></div>
+                          <div id="index-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
 
                 </div>
@@ -170,7 +172,7 @@ window['nitroAds'].createAd('index-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,schematics,home",

--- a/template/mod_detail.html
+++ b/template/mod_detail.html
@@ -209,8 +209,10 @@
           <!-- Right: Ad rail (desktop only) -->
           <div class="search-ad-rail-wide d-none d-xl-block">
             {{if .IsAdmin}}<div id="moddetail-smart-flex" class="mb-3"></div>{{else}}<div id="moddetail-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div id="moddetail-sticky-adrail-1" class="mb-3"></div>
-            <div id="moddetail-sticky-adrail-2" class="mb-3"></div>
+            <div class="ad-sticky-stack">
+              <div id="moddetail-sticky-adrail-1" class="mb-3"></div>
+              <div id="moddetail-sticky-adrail-2" class="mb-3"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -340,8 +342,7 @@ var moddetailStickyAd = {
   "mediaQuery": "(min-width: 1200px)"
 };
 window['nitroAds'].createAd('moddetail-sticky-adrail-1', moddetailStickyAd);
-// adrail-2 pins below adrail-1 (offset = adrail-1 top 8 + its max-height 650 + 1rem gap)
-window['nitroAds'].createAd('moddetail-sticky-adrail-2', Object.assign({}, moddetailStickyAd, { "stickyStackOffset": 674 }));
+  window['nitroAds'].createAd('moddetail-sticky-adrail-2', moddetailStickyAd);
 window['nitroAds'].createAd('moddetail-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/modify.html
+++ b/template/modify.html
@@ -175,8 +175,10 @@
                     <!-- Wide 300px rail for xl+ (1200px+) -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="modify-smart-flex" class="mb-3"></div>{{else}}<div id="modify-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="modify-sticky-adrail-1" class="mb-3"></div>
-                        <div id="modify-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="modify-sticky-adrail-1" class="mb-3"></div>
+                          <div id="modify-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
                 </div><!-- /d-flex -->
             </div>
@@ -699,7 +701,7 @@ window['nitroAds'].createAd('modify-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/mods.html
+++ b/template/mods.html
@@ -57,8 +57,10 @@
           <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
           <div class="ad-rail d-none d-xl-block">
             {{if .IsAdmin}}<div id="mods-smart-flex" class="mb-3"></div>{{else}}<div id="mods-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div id="mods-sticky-adrail-1" class="mb-3"></div>
-            <div id="mods-sticky-adrail-2" class="mb-3"></div>
+            <div class="ad-sticky-stack">
+              <div id="mods-sticky-adrail-1" class="mb-3"></div>
+              <div id="mods-sticky-adrail-2" class="mb-3"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -84,7 +86,7 @@ window['nitroAds'].createAd('mods-sticky-adrail-1', {
 });
 window['nitroAds'].createAd('mods-sticky-adrail-2', {
   "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 674, "stickyStackResizable": false,
+  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,mods,addons", "targeting": { "pageType": "mods" },
   "mediaQuery": "(min-width: 1200px)"

--- a/template/profile.html
+++ b/template/profile.html
@@ -161,8 +161,10 @@
                     <!-- Ad Rail (desktop only) -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="profile-smart-flex" class="mb-3"></div>{{else}}<div id="profile-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="profile-sticky-adrail-1" class="mb-3"></div>
-                        <div id="profile-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="profile-sticky-adrail-1" class="mb-3"></div>
+                          <div id="profile-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -214,7 +216,7 @@ window['nitroAds'].createAd('profile-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -1153,8 +1153,10 @@
                     <!-- Wide 300px rail for xl+ (1200px+): video ad (scrolls away) above two stacked 300x600 sticky ads -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="schematic-smart-flex" class="mb-3"></div>{{else}}<div id="schematic-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="schematic-sticky-adrail-1" class="mb-3"></div>
-                        <div id="schematic-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="schematic-sticky-adrail-1" class="mb-3"></div>
+                          <div id="schematic-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
                 </div><!-- /d-flex -->
 
@@ -1642,8 +1644,7 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     "mediaQuery": "(min-width: 1200px)"
   };
   window['nitroAds'].createAd('schematic-sticky-adrail-1', wideStickyAd);
-  // adrail-2 pins below adrail-1 (offset = adrail-1 top 8 + its max-height 650 + 1rem gap)
-  window['nitroAds'].createAd('schematic-sticky-adrail-2', Object.assign({}, wideStickyAd, { "stickyStackOffset": 674 }));
+  window['nitroAds'].createAd('schematic-sticky-adrail-2', wideStickyAd);
   // Mobile ad (in-content on smaller screens)
   window['nitroAds'].createAd('schematic-mobile', {
     "refreshTime": 60,

--- a/template/schematics.html
+++ b/template/schematics.html
@@ -56,8 +56,10 @@
                 <!-- Ad Rail (desktop only) -->
                 <div class="ad-rail d-none d-xl-block">
                     {{if .IsAdmin}}<div id="schematics-smart-flex" class="mb-3"></div>{{else}}<div id="schematics-video-nc-top-right" class="mb-3"></div>{{end}}
-                    <div id="schematics-sticky-adrail-1" class="mb-3"></div>
-                    <div id="schematics-sticky-adrail-2" class="mb-3"></div>
+                    <div class="ad-sticky-stack">
+                      <div id="schematics-sticky-adrail-1" class="mb-3"></div>
+                      <div id="schematics-sticky-adrail-2" class="mb-3"></div>
+                    </div>
                 </div>
                 </div>
             </div>
@@ -109,7 +111,7 @@ window['nitroAds'].createAd('schematics-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/search.html
+++ b/template/search.html
@@ -247,8 +247,10 @@
                     <!-- Right: Ad rail (desktop only) -->
                     <div class="search-ad-rail-wide d-none d-xl-block">
                         {{if .IsAdmin}}<div id="search-smart-flex" class="mb-3"></div>{{else}}<div id="search-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="search-sticky-adrail-1" class="mb-3"></div>
-                        <div id="search-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="search-sticky-adrail-1" class="mb-3"></div>
+                          <div id="search-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -291,8 +293,7 @@
                 "mediaQuery": "(min-width: 1200px)"
             };
             window['nitroAds'].createAd('search-sticky-adrail-1', searchStickyAd);
-            // adrail-2 pins below adrail-1 (offset = adrail-1 top 8 + its max-height 650 + 1rem gap)
-            window['nitroAds'].createAd('search-sticky-adrail-2', Object.assign({}, searchStickyAd, { "stickyStackOffset": 674 }));
+  window['nitroAds'].createAd('search-sticky-adrail-2', searchStickyAd);
 
             // Infinite scroll via IntersectionObserver
             (function() {

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -432,22 +432,21 @@ a:hover {
   flex-shrink: 0;
   align-self: stretch;
 }
-/* Two stacked 300x600 sticky ads. The preceding video ad scrolls away and
-   adrail-1 rises to pin near the top of the viewport (8px; the header scrolls
-   away on desktop). adrail-2 pins below it, offset by adrail-1's max-height
-   plus the gap. Each slot is capped
-   at 650px with spacing underneath. (NitroPay's sticky-stack format manages the
-   live ad pinning via stickyStackOffset; these rules are the layout base and
-   the dev-ads fallback.) */
-.ad-rail > [id*="sticky-adrail"] {
+/* Two stacked 300x600 sticky ads share a single sticky wrapper (.ad-sticky-stack)
+   so they move as one unit: the two ads sit in normal flow inside it (adrail-1
+   above adrail-2, with a 1rem gap) and the whole group pins at the top of the
+   viewport. This keeps a constant gap and makes overlap impossible — unlike
+   independently-sticky ads, where the taller top ad overlaps the lower one
+   while it is still scrolling into place. The preceding video ad is outside the
+   wrapper and scrolls away. */
+.ad-rail .ad-sticky-stack,
+.search-ad-rail-wide .ad-sticky-stack {
   position: sticky;
   top: 8px;
   z-index: 1;
-  max-height: 650px;
-  margin-bottom: 1rem;
 }
-.ad-rail > [id$="-sticky-adrail-2"] {
-  top: calc(8px + 650px + 1rem);
+.ad-sticky-stack > [id*="sticky-adrail"] {
+  margin-bottom: 1rem;
 }
 
 /***************
@@ -1059,16 +1058,6 @@ body.sidebar-open::after {
      (align-self: start makes the rail only as tall as its content, so the
      second ad unsticks and scrolls away). */
   align-self: stretch;
-}
-.search-ad-rail-wide > [id*="sticky-adrail"] {
-  position: sticky;
-  top: 8px;
-  z-index: 1;
-  max-height: 650px;
-  margin-bottom: 1rem;
-}
-.search-ad-rail-wide > [id$="-sticky-adrail-2"] {
-  top: calc(8px + 650px + 1rem);
 }
 
 .search-sidebar {

--- a/template/top-creators.html
+++ b/template/top-creators.html
@@ -152,8 +152,10 @@
             <!-- Ad Rail (desktop only) -->
             <div class="ad-rail d-none d-xl-block">
                 {{if .IsAdmin}}<div id="topcreators-smart-flex" class="mb-3"></div>{{else}}<div id="topcreators-video-nc-top-right" class="mb-3"></div>{{end}}
-                <div id="topcreators-sticky-adrail-1" class="mb-3"></div>
-                <div id="topcreators-sticky-adrail-2" class="mb-3"></div>
+                <div class="ad-sticky-stack">
+                  <div id="topcreators-sticky-adrail-1" class="mb-3"></div>
+                  <div id="topcreators-sticky-adrail-2" class="mb-3"></div>
+                </div>
             </div>
             </div>
             {{ else }}
@@ -209,7 +211,7 @@ window['nitroAds'].createAd('topcreators-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/trending.html
+++ b/template/trending.html
@@ -35,8 +35,10 @@
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="trending-smart-flex" class="mb-3"></div>{{else}}<div id="trending-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="trending-sticky-adrail-1" class="mb-3"></div>
-                        <div id="trending-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="trending-sticky-adrail-1" class="mb-3"></div>
+                          <div id="trending-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
 
                 </div>
@@ -63,7 +65,7 @@ window['nitroAds'].createAd('trending-sticky-adrail-1', {
 });
 window['nitroAds'].createAd('trending-sticky-adrail-2', {
   "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 674, "stickyStackResizable": false,
+  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
   "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
   "keywords": "minecraft,create-mod,schematics,trending", "targeting": { "pageType": "trending" },
   "mediaQuery": "(min-width: 1200px)"

--- a/template/upload_modify.html
+++ b/template/upload_modify.html
@@ -119,8 +119,10 @@
                     <!-- Wide 300px rail for xl+ (1200px+) -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="upload-modify-smart-flex" class="mb-3"></div>{{else}}<div id="upload-modify-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="upload-modify-sticky-adrail-1" class="mb-3"></div>
-                        <div id="upload-modify-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="upload-modify-sticky-adrail-1" class="mb-3"></div>
+                          <div id="upload-modify-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
                 </div><!-- /d-flex -->
                 <!-- Mobile ad (below content on smaller screens) -->
@@ -542,7 +544,7 @@ window['nitroAds'].createAd('upload-modify-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/upload_preview.html
+++ b/template/upload_preview.html
@@ -393,8 +393,10 @@
                     <!-- Ad Rail (desktop only) -->
                     <div class="ad-rail d-none d-xl-block">
                         {{if .IsAdmin}}<div id="upload-preview-smart-flex" class="mb-3"></div>{{else}}<div id="upload-preview-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div id="upload-preview-sticky-adrail-1" class="mb-3"></div>
-                        <div id="upload-preview-sticky-adrail-2" class="mb-3"></div>
+                        <div class="ad-sticky-stack">
+                          <div id="upload-preview-sticky-adrail-1" class="mb-3"></div>
+                          <div id="upload-preview-sticky-adrail-2" class="mb-3"></div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -762,7 +764,7 @@ window['nitroAds'].createAd('upload-preview-sticky-adrail-2', {
   "format": "sticky-stack",
   "stickyStackLimit": 15,
   "stickyStackSpace": 2.5,
-  "stickyStackOffset": 674,
+  "stickyStackOffset": 8,
   "stickyStackResizable": false,
   "report": {
     "enabled": true,

--- a/template/videos.html
+++ b/template/videos.html
@@ -54,8 +54,10 @@
         <!-- Ad Rail (desktop only) -->
         <div class="ad-rail d-none d-xl-block">
             {{if .IsAdmin}}<div id="videos-smart-flex" class="mb-3"></div>{{else}}<div id="videos-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div id="videos-sticky-adrail-1" class="mb-3"></div>
-            <div id="videos-sticky-adrail-2" class="mb-3"></div>
+            <div class="ad-sticky-stack">
+              <div id="videos-sticky-adrail-1" class="mb-3"></div>
+              <div id="videos-sticky-adrail-2" class="mb-3"></div>
+            </div>
         </div>
         </div><!-- /d-flex -->
         <!-- Mobile ad (below content on smaller screens) -->
@@ -109,7 +111,7 @@ if (window['nitroAds']) {
     "format": "sticky-stack",
     "stickyStackLimit": 15,
     "stickyStackSpace": 2.5,
-    "stickyStackOffset": 674,
+    "stickyStackOffset": 8,
     "stickyStackResizable": false,
     "report": {
       "enabled": true,


### PR DESCRIPTION
…leanly

The previous approach gave each ad its own sticky position (adrail-1 at top 8, adrail-2 at top 674). Because adrail-1 is a 600px ad, adrail-2 would stick at 674 while adrail-1 was still scrolling into place, so the bottom ad overlapped the top one during the scroll (and the 674 offset also did not track adrail-1's real height/the video above it).

Put both ads inside a single .ad-sticky-stack wrapper that is the sticky element: the two ads sit in normal flow (adrail-1 above adrail-2 with a 1rem gap) and the whole group pins at top:8 and moves as one unit. This makes overlap impossible and keeps a constant 16px gap at every scroll position (verified on live ads: overlap 0, gap 16 from scroll 0 to bottom). The video ad stays outside the wrapper and scrolls away.

Both ads keep the NitroPay sticky-stack format and share one config (offset back to 8). .search-ad-rail-wide is full-height so the wrapper stays pinned. Removed the now-unused per-ad sticky/stagger CSS.