### PR TITLE
feat(ads): A/B test sticky-stack vs dual display ads via a shared helper

### DIFF
--- a/internal/pages/guides_template_test.go
+++ b/internal/pages/guides_template_test.go
@@ -21,7 +21,7 @@ func Test_Guides_Template_Has_Expected_Elements(t *testing.T) {
 		"hx-select=\"#guides-results\"",
 		"Read guide",
 		"card-link",
-		"guides-sticky-adrail",
+		"data-cm-adrail",
 		"Views",
 	}
 	for _, m := range must {

--- a/internal/pages/videos_template_test.go
+++ b/internal/pages/videos_template_test.go
@@ -19,7 +19,7 @@ func Test_Videos_Template_Has_Expected_Elements(t *testing.T) {
 		"SignedOutURL",
 		"View on YouTube",
 		"View schematic",
-		"videos-sticky-adrail",
+		"data-cm-adrail",
 		"name=\"q\"",
 		"hx-target=\"#videos-results\"",
 		"hx-select=\"#videos-results\"",

--- a/template/collections.html
+++ b/template/collections.html
@@ -88,12 +88,7 @@
           <div class="ad-rail-sm d-none d-lg-block d-xl-none">
             <div id="collections-sticky-adrail-lg" class="mb-3"></div>
           </div>
-          <div class="ad-rail d-none d-xl-block">
-            {{if .IsAdmin}}<div id="collections-smart-flex" class="mb-3"></div>{{else}}<div id="collections-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div class="ad-sticky-stack">
-              <div id="collections-sticky-adrail-1" class="mb-3"></div>
-              <div id="collections-sticky-adrail-2" class="mb-3"></div>
-            </div>
+          <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="collections" data-kw="minecraft,create-mod,collections" data-page="collections"></div>
           </div>
         </div>
       </div>
@@ -105,18 +100,6 @@
 
 <!-- Ad Scripts -->
 <script>
-window['nitroAds'].createAd('collections-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,collections",
-  "targeting": { "pageType": "collections" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
 window['nitroAds'].createAd('collections-sticky-adrail-lg', {
   "refreshLimit": 10,
   "refreshTime": 45,
@@ -137,48 +120,6 @@ window['nitroAds'].createAd('collections-sticky-adrail-lg', {
   "keywords": "minecraft,create-mod,collections",
   "targeting": { "pageType": "collections" },
   "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
-});
-window['nitroAds'].createAd('collections-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,collections",
-  "targeting": { "pageType": "collections" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('collections-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,collections",
-  "targeting": { "pageType": "collections" },
-  "mediaQuery": "(min-width: 1200px)"
 });
 window['nitroAds'].createAd('collections-mobile', {
   "refreshTime": 60,

--- a/template/collections_show.html
+++ b/template/collections_show.html
@@ -138,12 +138,7 @@
           <div class="ad-rail-sm d-none d-lg-block d-xl-none">
             <div id="collshow-sticky-adrail-lg" class="mb-3"></div>
           </div>
-          <div class="ad-rail d-none d-xl-block">
-            {{if .IsAdmin}}<div id="collshow-smart-flex" class="mb-3"></div>{{else}}<div id="collshow-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div class="ad-sticky-stack">
-              <div id="collshow-sticky-adrail-1" class="mb-3"></div>
-              <div id="collshow-sticky-adrail-2" class="mb-3"></div>
-            </div>
+          <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="collshow" data-kw="minecraft,create-mod,collection" data-page="collection"></div>
           </div>
         </div><!-- /d-flex -->
       </div>
@@ -184,18 +179,6 @@ function copyShareLink() {
 
 <!-- Ad Scripts -->
 <script>
-window['nitroAds'].createAd('collshow-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,collection",
-  "targeting": { "pageType": "collection" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
 window['nitroAds'].createAd('collshow-sticky-adrail-lg', {
   "refreshLimit": 10,
   "refreshTime": 45,
@@ -216,48 +199,6 @@ window['nitroAds'].createAd('collshow-sticky-adrail-lg', {
   "keywords": "minecraft,create-mod,collection",
   "targeting": { "pageType": "collection" },
   "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
-});
-window['nitroAds'].createAd('collshow-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,collection",
-  "targeting": { "pageType": "collection" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('collshow-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,collection",
-  "targeting": { "pageType": "collection" },
-  "mediaQuery": "(min-width: 1200px)"
 });
 window['nitroAds'].createAd('collshow-mobile', {
   "refreshTime": 60,

--- a/template/explore.html
+++ b/template/explore.html
@@ -59,12 +59,7 @@
                 </div>
 
                 <!-- Ad Rail (desktop only) -->
-                <div class="ad-rail d-none d-xl-block">
-                    {{if .IsAdmin}}<div id="explore-smart-flex" class="mb-3"></div>{{else}}<div id="explore-video-nc-top-right" class="mb-3"></div>{{end}}
-                    <div class="ad-sticky-stack">
-                      <div id="explore-sticky-adrail-1" class="mb-3"></div>
-                      <div id="explore-sticky-adrail-2" class="mb-3"></div>
-                    </div>
+                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="explore" data-kw="minecraft,create-mod,schematics,explore,discover" data-page="explore"></div>
                 </div>
             </div>
         </main>
@@ -73,60 +68,6 @@
 </div>
 {{template "foot.html" .}}
 <script>
-window['nitroAds'].createAd('explore-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,schematics,explore,discover",
-  "targeting": { "pageType": "explore" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('explore-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,schematics,explore,discover",
-  "targeting": { "pageType": "explore" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('explore-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,schematics,explore,discover",
-  "targeting": { "pageType": "explore" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 </script>
 <script>
 (function(){

--- a/template/generator-balloon.html
+++ b/template/generator-balloon.html
@@ -213,7 +213,7 @@
                     <div id="gen-sticky-adrail-lg" class="mb-3"></div>
                 </div>
                 <div class="generator-ad-rail d-none d-xl-block">
-                    {{if .IsAdmin}}<div id="gen-smart-flex" class="mb-3"></div>{{else}}<div id="gen-video-nc" class="mb-3"></div>{{end}}
+                    <div id="gen-video-nc" class="mb-3"></div>
                     <div id="gen-sticky-adrail" class="mb-3"></div>
                 </div>
             </div>

--- a/template/generator-guide.html
+++ b/template/generator-guide.html
@@ -55,7 +55,7 @@
                         </div>
                     </div>
                     <div class="guide-ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="guide-smart-flex" class="mb-3"></div>{{else}}<div id="guide-video-nc" class="mb-3"></div>{{end}}
+                        <div id="guide-video-nc" class="mb-3"></div>
                         <div id="guide-sticky-adrail" class="mb-3"></div>
                     </div>
                     <div class="guide-ad-rail-sm d-none d-lg-block d-xl-none">

--- a/template/generator-hull.html
+++ b/template/generator-hull.html
@@ -256,7 +256,7 @@
                     <div id="gen-sticky-adrail-lg" class="mb-3"></div>
                 </div>
                 <div class="generator-ad-rail d-none d-xl-block">
-                    {{if .IsAdmin}}<div id="gen-smart-flex" class="mb-3"></div>{{else}}<div id="gen-video-nc" class="mb-3"></div>{{end}}
+                    <div id="gen-video-nc" class="mb-3"></div>
                     <div id="gen-sticky-adrail" class="mb-3"></div>
                 </div>
             </div>

--- a/template/generator-propeller.html
+++ b/template/generator-propeller.html
@@ -140,7 +140,7 @@
                     <div id="gen-sticky-adrail-lg" class="mb-3"></div>
                 </div>
                 <div class="generator-ad-rail d-none d-xl-block">
-                    {{if .IsAdmin}}<div id="gen-smart-flex" class="mb-3"></div>{{else}}<div id="gen-video-nc" class="mb-3"></div>{{end}}
+                    <div id="gen-video-nc" class="mb-3"></div>
                     <div id="gen-sticky-adrail" class="mb-3"></div>
                 </div>
             </div>

--- a/template/generators.html
+++ b/template/generators.html
@@ -67,12 +67,7 @@
                 </div>
                     </div>
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="generators-smart-flex" class="mb-3"></div>{{else}}<div id="generators-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="generators-sticky-adrail-1" class="mb-3"></div>
-                          <div id="generators-sticky-adrail-2" class="mb-3"></div>
-                        </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="generators" data-kw="minecraft,create-mod,generators,schematics" data-page="generators"></div>
                     </div>
                 </div>
             </div>
@@ -82,25 +77,4 @@
 </div>
 {{template "foot.html" .}}
 <script>
-window['nitroAds'].createAd('generators-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,generators,schematics",
-  "targeting": { "pageType": "generators" },
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('generators-sticky-adrail-1', {
-  "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,generators,schematics", "targeting": { "pageType": "generators" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('generators-sticky-adrail-2', {
-  "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,generators,schematics", "targeting": { "pageType": "generators" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 </script>

--- a/template/guides.html
+++ b/template/guides.html
@@ -58,12 +58,7 @@
 
         <!-- Ad Rail (desktop only) -->
         {{if not .IsContributor}}
-        <div class="ad-rail d-none d-xl-block">
-            {{if .IsAdmin}}<div id="guides-smart-flex" class="mb-3"></div>{{else}}<div id="guides-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div class="ad-sticky-stack">
-              <div id="guides-sticky-adrail-1" class="mb-3"></div>
-              <div id="guides-sticky-adrail-2" class="mb-3"></div>
-            </div>
+        <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="guides" data-kw="minecraft,create-mod,guide,tutorial" data-page="guides"></div>
         </div>
         {{end}}
         </div><!-- /d-flex -->
@@ -79,60 +74,6 @@
 {{template "foot.html" .}}
 {{if not .IsContributor}}
 <script>
-window['nitroAds'].createAd('guides-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,guide,tutorial",
-  "targeting": { "pageType": "guides" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('guides-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,guide,tutorial",
-  "targeting": { "pageType": "guides" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('guides-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,guide,tutorial",
-  "targeting": { "pageType": "guides" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 window['nitroAds'].createAd('guides-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/guides_show.html
+++ b/template/guides_show.html
@@ -86,12 +86,7 @@
 
         <!-- Ad Rail (desktop only) -->
         {{if not .IsContributor}}
-        <div class="ad-rail d-none d-xl-block">
-            {{if .IsAdmin}}<div id="guideshow-smart-flex" class="mb-3"></div>{{else}}<div id="guideshow-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div class="ad-sticky-stack">
-              <div id="guideshow-sticky-adrail-1" class="mb-3"></div>
-              <div id="guideshow-sticky-adrail-2" class="mb-3"></div>
-            </div>
+        <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="guideshow" data-kw="minecraft,create-mod,guide,tutorial" data-page="guide"></div>
         </div>
         {{end}}
         </div><!-- /d-flex -->
@@ -108,60 +103,6 @@
 {{template "foot.html" .}}
 {{if not .IsContributor}}
 <script>
-window['nitroAds'].createAd('guideshow-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,guide,tutorial",
-  "targeting": { "pageType": "guide" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('guideshow-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,guide,tutorial",
-  "targeting": { "pageType": "guide" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('guideshow-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,guide,tutorial",
-  "targeting": { "pageType": "guide" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 window['nitroAds'].createAd('guideshow-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/highest_scores.html
+++ b/template/highest_scores.html
@@ -33,12 +33,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="highscores-smart-flex" class="mb-3"></div>{{else}}<div id="highscores-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="highscores-sticky-adrail-1" class="mb-3"></div>
-                          <div id="highscores-sticky-adrail-2" class="mb-3"></div>
-                        </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="highscores" data-kw="minecraft,create-mod,schematics,highest-scores" data-page="highest-scores"></div>
                     </div>
 
                 </div>
@@ -49,25 +44,4 @@
 </div>
 {{template "foot.html" .}}
 <script>
-window['nitroAds'].createAd('highscores-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,schematics,highest-scores",
-  "targeting": { "pageType": "highest-scores" },
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('highscores-sticky-adrail-1', {
-  "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,schematics,highest-scores", "targeting": { "pageType": "highest-scores" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('highscores-sticky-adrail-2', {
-  "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,schematics,highest-scores", "targeting": { "pageType": "highest-scores" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 </script>

--- a/template/include/head.html
+++ b/template/include/head.html
@@ -82,6 +82,9 @@ window.setTheme=function(theme){
     <script src="/assets/x/dev-ads.js?v={{ AssetVer }}" defer></script>
     {{ else }}
     <script data-cfasync="false" async src="https://s.nitropay.com/ads-2143.js" onerror="window._nitroBlocked=true"></script>
+    {{ end }}
+    <script src="/assets/x/adrail.js?v={{ AssetVer }}" defer></script>
+    {{ if not .IsDev }}
     <script>
     // Reload once after the user accepts the NCMP cookie consent so that
     // NitroAds can render ads that were blocked before consent was given.
@@ -143,7 +146,7 @@ window.setTheme=function(theme){
         } catch(e) {}
       }
       document.addEventListener('click', function(ev) {
-        var adEl = ev.target.closest('[id*="-video-nc-"], [id*="-smart-flex"], [id*="-sticky-adrail"], [id*="-mobile"], [id*="outstream-player"]');
+        var adEl = ev.target.closest('[id*="-video-nc-"], [id*="_video"], [id*="-smart-flex"], [id*="-sticky-adrail"], [id*="_a_sticky"], [id*="_b_display"], [id*="-mobile"], [id*="outstream-player"]');
         if (adEl) {
           trackAdClick(adEl.id, '');
         }

--- a/template/index.html
+++ b/template/index.html
@@ -124,12 +124,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="index-smart-flex" class="mb-3"></div>{{else}}<div id="index-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="index-sticky-adrail-1" class="mb-3"></div>
-                          <div id="index-sticky-adrail-2" class="mb-3"></div>
-                        </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="index" data-kw="minecraft,create-mod,schematics,home" data-page="index"></div>
                     </div>
 
                 </div>
@@ -140,45 +135,6 @@
 </div>
 {{template "foot.html" .}}
 <script>
-window['nitroAds'].createAd('index-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,schematics,home",
-  "targeting": { "pageType": "index" },
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('index-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,schematics,home",
-  "targeting": { "pageType": "index" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('index-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,schematics,home",
-  "targeting": { "pageType": "index" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 </script>
 <style>
 .follow-btn{position:relative}

--- a/template/mod_detail.html
+++ b/template/mod_detail.html
@@ -207,13 +207,7 @@
           </div>
 
           <!-- Right: Ad rail (desktop only) -->
-          <div class="search-ad-rail-wide d-none d-xl-block">
-            {{if .IsAdmin}}<div id="moddetail-smart-flex" class="mb-3"></div>{{else}}<div id="moddetail-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div class="ad-sticky-stack">
-              <div id="moddetail-sticky-adrail-1" class="mb-3"></div>
-              <div id="moddetail-sticky-adrail-2" class="mb-3"></div>
-            </div>
-          </div>
+          <div class="search-ad-rail-wide d-none d-xl-block" data-cm-adrail data-prefix="moddetail" data-kw="minecraft,create-mod,mod,addon" data-page="mod"></div>
         </div>
       </div>
     </main>
@@ -308,41 +302,7 @@ document.addEventListener('change', function(e) {
 })();
 </script>
 <script>
-window['nitroAds'].createAd('moddetail-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,mod,addon",
-  "targeting": { "pageType": "mod" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-var moddetailStickyAd = {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,mod,addon",
-  "targeting": { "pageType": "mod" },
-  "mediaQuery": "(min-width: 1200px)"
-};
-window['nitroAds'].createAd('moddetail-sticky-adrail-1', moddetailStickyAd);
-  window['nitroAds'].createAd('moddetail-sticky-adrail-2', moddetailStickyAd);
+// Desktop right-rail ads (xl+) are built by adrail.js via the data-cm-adrail container.
 window['nitroAds'].createAd('moddetail-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/modify.html
+++ b/template/modify.html
@@ -173,12 +173,7 @@
                         <div id="modify-sticky-adrail-lg" class="mb-3"></div>
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="modify-smart-flex" class="mb-3"></div>{{else}}<div id="modify-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="modify-sticky-adrail-1" class="mb-3"></div>
-                          <div id="modify-sticky-adrail-2" class="mb-3"></div>
-                        </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="modify" data-kw="minecraft,create-mod,modify,blocks" data-page="modify"></div>
                     </div>
                 </div><!-- /d-flex -->
             </div>
@@ -636,18 +631,6 @@
 <!-- Ad Scripts -->
 <script>
 // Video NC ad (desktop only)
-window['nitroAds'].createAd('modify-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,modify,blocks",
-  "targeting": { "pageType": "modify" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
 // Narrow ad rail (lg only: 992-1199px)
 window['nitroAds'].createAd('modify-sticky-adrail-lg', {
   "refreshLimit": 10,
@@ -671,48 +654,6 @@ window['nitroAds'].createAd('modify-sticky-adrail-lg', {
   "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
 });
 // Wide ad rail (xl+: 1200px+)
-window['nitroAds'].createAd('modify-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,modify,blocks",
-  "targeting": { "pageType": "modify" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('modify-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,modify,blocks",
-  "targeting": { "pageType": "modify" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 // Mobile ad (below content on smaller screens)
 window['nitroAds'].createAd('modify-mobile', {
   "refreshTime": 60,

--- a/template/mods.html
+++ b/template/mods.html
@@ -55,13 +55,7 @@
         {{ end }}
           </div>
           <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-          <div class="ad-rail d-none d-xl-block">
-            {{if .IsAdmin}}<div id="mods-smart-flex" class="mb-3"></div>{{else}}<div id="mods-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div class="ad-sticky-stack">
-              <div id="mods-sticky-adrail-1" class="mb-3"></div>
-              <div id="mods-sticky-adrail-2" class="mb-3"></div>
-            </div>
-          </div>
+          <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="mods" data-kw="minecraft,create-mod,mods,addons" data-page="mods"></div>
         </div>
       </div>
     </main>
@@ -69,29 +63,6 @@
   </div>
 </div>
 {{template "foot.html" .}}
-<script>
-window['nitroAds'].createAd('mods-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,mods,addons",
-  "targeting": { "pageType": "mods" },
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('mods-sticky-adrail-1', {
-  "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,mods,addons", "targeting": { "pageType": "mods" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('mods-sticky-adrail-2', {
-  "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,mods,addons", "targeting": { "pageType": "mods" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-</script>
 <script>
 (function() {
   var filter = document.getElementById('mod-filter');

--- a/template/profile.html
+++ b/template/profile.html
@@ -159,12 +159,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only) -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="profile-smart-flex" class="mb-3"></div>{{else}}<div id="profile-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="profile-sticky-adrail-1" class="mb-3"></div>
-                          <div id="profile-sticky-adrail-2" class="mb-3"></div>
-                        </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="profile" data-kw="minecraft,create-mod,profile,builder" data-page="profile"></div>
                     </div>
                 </div>
             </div>
@@ -174,60 +169,6 @@
 </div>
 {{template "foot.html" .}}
 <script>
-window['nitroAds'].createAd('profile-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,profile,builder",
-  "targeting": { "pageType": "profile" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('profile-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,profile,builder",
-  "targeting": { "pageType": "profile" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('profile-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,profile,builder",
-  "targeting": { "pageType": "profile" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 window['nitroAds'].createAd('profile-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/schematic-guide.html
+++ b/template/schematic-guide.html
@@ -55,7 +55,7 @@
                         </div>
                     </div>
                     <div class="guide-ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="guide-smart-flex" class="mb-3"></div>{{else}}<div id="guide-video-nc" class="mb-3"></div>{{end}}
+                        <div id="guide-video-nc" class="mb-3"></div>
                         <div id="guide-sticky-adrail" class="mb-3"></div>
                     </div>
                     <div class="guide-ad-rail-sm d-none d-lg-block d-xl-none">

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -1151,13 +1151,7 @@
                         <div id="schematic-sticky-adrail-lg" class="mb-3"></div>
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+): video ad (scrolls away) above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="schematic-smart-flex" class="mb-3"></div>{{else}}<div id="schematic-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="schematic-sticky-adrail-1" class="mb-3"></div>
-                          <div id="schematic-sticky-adrail-2" class="mb-3"></div>
-                        </div>
-                    </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="schematic" data-kw="minecraft,create-mod,schematic" data-page="schematic"></div>
                 </div><!-- /d-flex -->
 
             </div>
@@ -1584,19 +1578,6 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     "modVersion": "{{ .Schematic.CreatemodVersion }}"
   };
 
-  // Video NC ad (desktop only)
-  window['nitroAds'].createAd('schematic-video-nc-top-right', {
-    "format": "video-nc",
-    "keywords": kwString,
-    "targeting": targeting,
-    "report": {
-      "enabled": true,
-      "icon": true,
-      "wording": "Report Ad",
-      "position": "top-right"
-    },
-    "mediaQuery": "(min-width: 1200px)"
-  });
   // Narrow ad rail (lg only: 992-1199px)
   window['nitroAds'].createAd('schematic-sticky-adrail-lg', {
     "refreshLimit": 10,
@@ -1619,32 +1600,7 @@ document.addEventListener('htmx:afterRequest', function(evt) {
     },
     "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
   });
-  // Pin the sticky stack near the top of the viewport (~8px). The header
-  // scrolls away on desktop and the video ad above scrolls off, so adrail-1
-  // rises to the top. Both wide-rail ads share this offset so NitroPay stacks
-  // adrail-2 directly below adrail-1.
-  var stickyStackTop = 8;
-
-  // Wide ad rail — two stacked 300x600 sticky ads for long schematic pages (xl+: 1200px+)
-  var wideStickyAd = {
-    "refreshVisibleOnly": true,
-    "format": "sticky-stack",
-    "stickyStackLimit": 15,
-    "stickyStackSpace": 2.5,
-    "stickyStackOffset": stickyStackTop,
-    "stickyStackResizable": false,
-    "keywords": kwString,
-    "targeting": targeting,
-    "report": {
-      "enabled": true,
-      "icon": true,
-      "wording": "Report Ad",
-      "position": "top-right"
-    },
-    "mediaQuery": "(min-width: 1200px)"
-  };
-  window['nitroAds'].createAd('schematic-sticky-adrail-1', wideStickyAd);
-  window['nitroAds'].createAd('schematic-sticky-adrail-2', wideStickyAd);
+  // Wide ad rail (xl+) is built by adrail.js via the data-cm-adrail container.
   // Mobile ad (in-content on smaller screens)
   window['nitroAds'].createAd('schematic-mobile', {
     "refreshTime": 60,

--- a/template/schematics.html
+++ b/template/schematics.html
@@ -54,12 +54,7 @@
                 </div>
                 </div>
                 <!-- Ad Rail (desktop only) -->
-                <div class="ad-rail d-none d-xl-block">
-                    {{if .IsAdmin}}<div id="schematics-smart-flex" class="mb-3"></div>{{else}}<div id="schematics-video-nc-top-right" class="mb-3"></div>{{end}}
-                    <div class="ad-sticky-stack">
-                      <div id="schematics-sticky-adrail-1" class="mb-3"></div>
-                      <div id="schematics-sticky-adrail-2" class="mb-3"></div>
-                    </div>
+                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="schematics" data-kw="minecraft,create-mod,schematics,browse" data-page="schematics"></div>
                 </div>
                 </div>
             </div>
@@ -69,60 +64,6 @@
 </div>
 {{template "foot.html" .}}
 <script>
-window['nitroAds'].createAd('schematics-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,schematics,browse",
-  "targeting": { "pageType": "schematics" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('schematics-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,schematics,browse",
-  "targeting": { "pageType": "schematics" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('schematics-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,schematics,browse",
-  "targeting": { "pageType": "schematics" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 window['nitroAds'].createAd('schematics-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/search.html
+++ b/template/search.html
@@ -245,55 +245,14 @@
                     </div>
 
                     <!-- Right: Ad rail (desktop only) -->
-                    <div class="search-ad-rail-wide d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="search-smart-flex" class="mb-3"></div>{{else}}<div id="search-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="search-sticky-adrail-1" class="mb-3"></div>
-                          <div id="search-sticky-adrail-2" class="mb-3"></div>
-                        </div>
-                    </div>
+                    <div class="search-ad-rail-wide d-none d-xl-block" data-cm-adrail data-prefix="search" data-kw="minecraft,create-mod,search,schematics" data-page="search"></div>
                 </div>
             </div>
         </main>
         {{template "footer.html" .}}
         <script>
-            // Video NC ad (desktop only)
-            var searchKw = 'minecraft,create-mod,search,schematics';
-            var searchTarget = { "pageType": "search" };
-            window['nitroAds'].createAd('search-video-nc-top-right', {
-                "format": "video-nc",
-                "keywords": searchKw,
-                "targeting": searchTarget,
-                "report": {
-                    "enabled": true,
-                    "icon": true,
-                    "wording": "Report Ad",
-                    "position": "top-right"
-                },
-                "mediaQuery": "(min-width: 1200px)"
-            });
-            var searchStickyAd = {
-                "refreshTime": 45,
-                "refreshVisibleOnly": true,
-                "renderVisibleOnly": true,
-                "visibleMargin": 300,
-                "format": "sticky-stack",
-                "stickyStackLimit": 15,
-                "stickyStackSpace": 2.5,
-                "stickyStackOffset": 8,
-                "stickyStackResizable": false,
-                "keywords": searchKw,
-                "targeting": searchTarget,
-                "report": {
-                    "enabled": true,
-                    "icon": true,
-                    "wording": "Report Ad",
-                    "position": "top-right"
-                },
-                "mediaQuery": "(min-width: 1200px)"
-            };
-            window['nitroAds'].createAd('search-sticky-adrail-1', searchStickyAd);
-  window['nitroAds'].createAd('search-sticky-adrail-2', searchStickyAd);
+            // Desktop right-rail ads (xl+) are built by adrail.js via the
+            // data-cm-adrail container above.
 
             // Infinite scroll via IntersectionObserver
             (function() {

--- a/template/static/adrail.js
+++ b/template/static/adrail.js
@@ -1,0 +1,96 @@
+// Desktop right-rail ads + A/B test.
+//
+// Each page declares its rail with a container element:
+//   <div class="ad-rail d-none d-xl-block" data-cm-adrail
+//        data-prefix="mods" data-kw="minecraft,..." data-page="mods"></div>
+// (search / mod_detail use .search-ad-rail-wide; the data-cm-adrail attribute
+// is what matters.)
+//
+// On each page view we randomly (~50/50) pick a variant:
+//   Variant A  -> video ad on top + ONE NitroPay sticky-stack ad.
+//   Variant B  -> video ad on top + TWO static display ads (300x600 / 300x250
+//                 / 160x600) that stick together as one unit.
+// The ad-unit ids encode the variant (e.g. mods_a_sticky, mods_b_display_1) so
+// NitroPay reporting can compare revenue/RPM between the two setups.
+(function () {
+  "use strict";
+
+  function slot(id) {
+    var d = document.createElement("div");
+    d.id = id;
+    d.className = "mb-3";
+    return d;
+  }
+
+  function nitro() {
+    return window.nitroAds;
+  }
+
+  // Builds one page's rail and runs the A/B test. Exposed for completeness;
+  // normally invoked by the initializer below via the data attributes.
+  window.cmAdRail = function (rail, prefix, keywords, pageType) {
+    if (!rail || !nitro() || !nitro().createAd || !prefix) return;
+
+    var common = {
+      keywords: keywords || "",
+      targeting: { pageType: pageType || prefix },
+      report: { enabled: true, icon: true, wording: "Report Ad", position: "top-right" },
+      mediaQuery: "(min-width: 1200px)"
+    };
+    var refresh = {
+      refreshLimit: 10, refreshTime: 45,
+      refreshVisibleOnly: true, renderVisibleOnly: true, visibleMargin: 300
+    };
+
+    // Video ad on top in both variants — scrolls away with the page.
+    rail.appendChild(slot(prefix + "_video"));
+    nitro().createAd(prefix + "_video", Object.assign({ format: "video-nc" }, common));
+
+    if (Math.random() < 0.5) {
+      // Variant A: a single NitroPay sticky-stack ad.
+      rail.appendChild(slot(prefix + "_a_sticky"));
+      nitro().createAd(prefix + "_a_sticky", Object.assign({
+        format: "sticky-stack",
+        stickyStackLimit: 15,
+        stickyStackSpace: 2.5,
+        stickyStackOffset: 8,
+        stickyStackResizable: false
+      }, refresh, common));
+    } else {
+      // Variant B: two static display ads stacked in one sticky wrapper, so
+      // they pin together while scrolling and never overlap.
+      var wrap = document.createElement("div");
+      wrap.className = "ad-sticky-stack";
+      wrap.appendChild(slot(prefix + "_b_display_1"));
+      wrap.appendChild(slot(prefix + "_b_display_2"));
+      rail.appendChild(wrap);
+      var display = Object.assign({
+        sizes: [["300", "600"], ["300", "250"], ["160", "600"]]
+      }, refresh, common);
+      nitro().createAd(prefix + "_b_display_1", display);
+      nitro().createAd(prefix + "_b_display_2", display);
+    }
+  };
+
+  function initAdRails() {
+    var rails = document.querySelectorAll("[data-cm-adrail]");
+    for (var i = 0; i < rails.length; i++) {
+      var el = rails[i];
+      if (el.getAttribute("data-cm-adrail-done")) continue;
+      el.setAttribute("data-cm-adrail-done", "1");
+      window.cmAdRail(
+        el,
+        el.getAttribute("data-prefix"),
+        el.getAttribute("data-kw"),
+        el.getAttribute("data-page")
+      );
+    }
+  }
+
+  if (document.readyState !== "loading") {
+    initAdRails();
+  }
+  document.addEventListener("DOMContentLoaded", initAdRails);
+  // hx-boost swaps the body on navigation; rebuild rails for the new page.
+  document.addEventListener("htmx:afterSettle", initAdRails);
+})();

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -432,20 +432,21 @@ a:hover {
   flex-shrink: 0;
   align-self: stretch;
 }
-/* Two stacked 300x600 sticky ads share a single sticky wrapper (.ad-sticky-stack)
-   so they move as one unit: the two ads sit in normal flow inside it (adrail-1
-   above adrail-2, with a 1rem gap) and the whole group pins at the top of the
-   viewport. This keeps a constant gap and makes overlap impossible — unlike
-   independently-sticky ads, where the taller top ad overlaps the lower one
-   while it is still scrolling into place. The preceding video ad is outside the
-   wrapper and scrolls away. */
+/* Right-rail ad sticking (built by adrail.js).
+   Variant B: two static display ads share one sticky wrapper (.ad-sticky-stack)
+   so they pin together as a unit and never overlap — they sit in normal flow
+   inside it (with a 1rem gap) and the group pins near the top of the viewport.
+   Variant A: the single sticky-stack ad (id ends "_a_sticky") pins the same way.
+   The video ad is outside both and scrolls away. */
 .ad-rail .ad-sticky-stack,
-.search-ad-rail-wide .ad-sticky-stack {
+.search-ad-rail-wide .ad-sticky-stack,
+.ad-rail > [id$="_a_sticky"],
+.search-ad-rail-wide > [id$="_a_sticky"] {
   position: sticky;
   top: 8px;
   z-index: 1;
 }
-.ad-sticky-stack > [id*="sticky-adrail"] {
+.ad-sticky-stack > [id*="_b_display"] {
   margin-bottom: 1rem;
 }
 

--- a/template/top-creators.html
+++ b/template/top-creators.html
@@ -150,12 +150,7 @@
             </div>
             </div>
             <!-- Ad Rail (desktop only) -->
-            <div class="ad-rail d-none d-xl-block">
-                {{if .IsAdmin}}<div id="topcreators-smart-flex" class="mb-3"></div>{{else}}<div id="topcreators-video-nc-top-right" class="mb-3"></div>{{end}}
-                <div class="ad-sticky-stack">
-                  <div id="topcreators-sticky-adrail-1" class="mb-3"></div>
-                  <div id="topcreators-sticky-adrail-2" class="mb-3"></div>
-                </div>
+            <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="topcreators" data-kw="minecraft,create-mod,leaderboard,creators" data-page="top-creators"></div>
             </div>
             </div>
             {{ else }}
@@ -169,60 +164,6 @@
 {{ template "footer.html" . }}
 {{ template "foot.html" . }}
 <script>
-window['nitroAds'].createAd('topcreators-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,leaderboard,creators",
-  "targeting": { "pageType": "top-creators" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('topcreators-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,leaderboard,creators",
-  "targeting": { "pageType": "top-creators" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('topcreators-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,leaderboard,creators",
-  "targeting": { "pageType": "top-creators" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 window['nitroAds'].createAd('topcreators-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/trending.html
+++ b/template/trending.html
@@ -33,12 +33,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="trending-smart-flex" class="mb-3"></div>{{else}}<div id="trending-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="trending-sticky-adrail-1" class="mb-3"></div>
-                          <div id="trending-sticky-adrail-2" class="mb-3"></div>
-                        </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="trending" data-kw="minecraft,create-mod,schematics,trending" data-page="trending"></div>
                     </div>
 
                 </div>
@@ -49,25 +44,4 @@
 </div>
 {{template "foot.html" .}}
 <script>
-window['nitroAds'].createAd('trending-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,schematics,trending",
-  "targeting": { "pageType": "trending" },
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('trending-sticky-adrail-1', {
-  "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,schematics,trending", "targeting": { "pageType": "trending" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('trending-sticky-adrail-2', {
-  "refreshLimit": 10, "refreshTime": 45, "refreshVisibleOnly": true, "renderVisibleOnly": true, "visibleMargin": 300,
-  "format": "sticky-stack", "stickyStackLimit": 15, "stickyStackSpace": 2.5, "stickyStackOffset": 8, "stickyStackResizable": false,
-  "report": { "enabled": true, "icon": true, "wording": "Report Ad", "position": "top-right" },
-  "keywords": "minecraft,create-mod,schematics,trending", "targeting": { "pageType": "trending" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 </script>

--- a/template/upload_modify.html
+++ b/template/upload_modify.html
@@ -117,12 +117,7 @@
                         <div id="upload-modify-sticky-adrail-lg" class="mb-3"></div>
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="upload-modify-smart-flex" class="mb-3"></div>{{else}}<div id="upload-modify-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="upload-modify-sticky-adrail-1" class="mb-3"></div>
-                          <div id="upload-modify-sticky-adrail-2" class="mb-3"></div>
-                        </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="upload-modify" data-kw="minecraft,create-mod,modify,blocks,upload" data-page="modify"></div>
                     </div>
                 </div><!-- /d-flex -->
                 <!-- Mobile ad (below content on smaller screens) -->
@@ -479,18 +474,6 @@
 <!-- Ad Scripts -->
 <script>
 // Video NC ad (desktop only)
-window['nitroAds'].createAd('upload-modify-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,modify,blocks,upload",
-  "targeting": { "pageType": "modify" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
 // Narrow ad rail (lg only: 992-1199px)
 window['nitroAds'].createAd('upload-modify-sticky-adrail-lg', {
   "refreshLimit": 10,
@@ -514,48 +497,6 @@ window['nitroAds'].createAd('upload-modify-sticky-adrail-lg', {
   "mediaQuery": "(min-width: 992px) and (max-width: 1199px)"
 });
 // Wide ad rail (xl+: 1200px+)
-window['nitroAds'].createAd('upload-modify-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,modify,blocks,upload",
-  "targeting": { "pageType": "modify" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('upload-modify-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,modify,blocks,upload",
-  "targeting": { "pageType": "modify" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 // Mobile ad (below content on smaller screens)
 window['nitroAds'].createAd('upload-modify-mobile', {
   "refreshTime": 60,

--- a/template/upload_preview.html
+++ b/template/upload_preview.html
@@ -391,12 +391,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only) -->
-                    <div class="ad-rail d-none d-xl-block">
-                        {{if .IsAdmin}}<div id="upload-preview-smart-flex" class="mb-3"></div>{{else}}<div id="upload-preview-video-nc-top-right" class="mb-3"></div>{{end}}
-                        <div class="ad-sticky-stack">
-                          <div id="upload-preview-sticky-adrail-1" class="mb-3"></div>
-                          <div id="upload-preview-sticky-adrail-2" class="mb-3"></div>
-                        </div>
+                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="upload-preview" data-kw="minecraft,create-mod,upload,preview" data-page="upload-preview"></div>
                     </div>
                 </div>
             </div>
@@ -722,60 +717,6 @@ function deleteAdditionalFile(token, fileId, btn) {
 {{ end }}
 {{template "foot.html" .}}
 <script>
-window['nitroAds'].createAd('upload-preview-video-nc-top-right', {
-  "format": "video-nc",
-  "keywords": "minecraft,create-mod,upload,preview",
-  "targeting": { "pageType": "upload-preview" },
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('upload-preview-sticky-adrail-1', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,upload,preview",
-  "targeting": { "pageType": "upload-preview" },
-  "mediaQuery": "(min-width: 1200px)"
-});
-window['nitroAds'].createAd('upload-preview-sticky-adrail-2', {
-  "refreshLimit": 10,
-  "refreshTime": 45,
-  "refreshVisibleOnly": true,
-  "renderVisibleOnly": true,
-  "visibleMargin": 300,
-  "format": "sticky-stack",
-  "stickyStackLimit": 15,
-  "stickyStackSpace": 2.5,
-  "stickyStackOffset": 8,
-  "stickyStackResizable": false,
-  "report": {
-    "enabled": true,
-    "icon": true,
-    "wording": "Report Ad",
-    "position": "top-right"
-  },
-  "keywords": "minecraft,create-mod,upload,preview",
-  "targeting": { "pageType": "upload-preview" },
-  "mediaQuery": "(min-width: 1200px)"
-});
 window['nitroAds'].createAd('upload-preview-mobile', {
   "refreshTime": 60,
   "refreshVisibleOnly": true,

--- a/template/videos.html
+++ b/template/videos.html
@@ -52,12 +52,7 @@
         </div><!-- /flex-grow-1 -->
 
         <!-- Ad Rail (desktop only) -->
-        <div class="ad-rail d-none d-xl-block">
-            {{if .IsAdmin}}<div id="videos-smart-flex" class="mb-3"></div>{{else}}<div id="videos-video-nc-top-right" class="mb-3"></div>{{end}}
-            <div class="ad-sticky-stack">
-              <div id="videos-sticky-adrail-1" class="mb-3"></div>
-              <div id="videos-sticky-adrail-2" class="mb-3"></div>
-            </div>
+        <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="videos" data-kw="minecraft,create-mod,videos" data-page="videos"></div>
         </div>
         </div><!-- /d-flex -->
         <!-- Mobile ad (below content on smaller screens) -->
@@ -69,60 +64,6 @@
 </div>
 <script>
 if (window['nitroAds']) {
-  window['nitroAds'].createAd('videos-video-nc-top-right', {
-    "format": "video-nc",
-    "keywords": "minecraft,create-mod,videos",
-    "targeting": { "pageType": "videos" },
-    "report": {
-      "enabled": true,
-      "icon": true,
-      "wording": "Report Ad",
-      "position": "top-right"
-    },
-    "mediaQuery": "(min-width: 1200px)"
-  });
-  window['nitroAds'].createAd('videos-sticky-adrail-1', {
-    "refreshLimit": 10,
-    "refreshTime": 45,
-    "refreshVisibleOnly": true,
-    "renderVisibleOnly": true,
-    "visibleMargin": 300,
-    "format": "sticky-stack",
-    "stickyStackLimit": 15,
-    "stickyStackSpace": 2.5,
-    "stickyStackOffset": 8,
-    "stickyStackResizable": false,
-    "report": {
-      "enabled": true,
-      "icon": true,
-      "wording": "Report Ad",
-      "position": "top-right"
-    },
-    "keywords": "minecraft,create-mod,videos",
-    "targeting": { "pageType": "videos" },
-    "mediaQuery": "(min-width: 1200px)"
-  });
-  window['nitroAds'].createAd('videos-sticky-adrail-2', {
-    "refreshLimit": 10,
-    "refreshTime": 45,
-    "refreshVisibleOnly": true,
-    "renderVisibleOnly": true,
-    "visibleMargin": 300,
-    "format": "sticky-stack",
-    "stickyStackLimit": 15,
-    "stickyStackSpace": 2.5,
-    "stickyStackOffset": 8,
-    "stickyStackResizable": false,
-    "report": {
-      "enabled": true,
-      "icon": true,
-      "wording": "Report Ad",
-      "position": "top-right"
-    },
-    "keywords": "minecraft,create-mod,videos",
-    "targeting": { "pageType": "videos" },
-    "mediaQuery": "(min-width: 1200px)"
-  });
   window['nitroAds'].createAd('videos-mobile', {
     "refreshTime": 60,
     "refreshVisibleOnly": true,


### PR DESCRIPTION
NitroPay sticky-stack only ever renders one ad, so the previous two-sticky-stack approach fought itself and overlapped. Replace the per-page ad markup/JS with a single shared helper (adrail.js) that builds the desktop right rail and runs a per-pageview 50/50 A/B test:

- Variant A: video ad on top + one sticky-stack ad (<prefix>_a_sticky).
- Variant B: video ad on top + two static display ads (300x600 / 300x250 / 160x600) that stick together in one .ad-sticky-stack wrapper (<prefix>_b_display_1/2) — verified no overlap, constant gap, both pin while scrolling.

Ad-unit ids encode the variant so NitroPay reporting can compare revenue (e.g. schematics_a_sticky vs schematics_b_display_1/2). Each page now declares its rail with one container:
  <div class="ad-rail ..." data-cm-adrail data-prefix data-kw data-page>
Narrow lg/mobile ads and the generator overlay ads are unchanged.

Also removes the admin-only smart-flex ad code from all templates.

NOTE: the new ad-unit ids must be registered in NitroPay before they will fill in production.