### PR TITLE
fix(ads): variant A sticky-stack stays pinned (+ busts stale CSS cache)

### DIFF
--- a/template/static/app.css
+++ b/template/static/app.css
@@ -432,22 +432,30 @@ a:hover {
   flex-shrink: 0;
   align-self: stretch;
 }
-/* Right-rail ad sticking (built by adrail.js).
-   Variant B: two static display ads share one sticky wrapper (.ad-sticky-stack)
+/* Right-rail ad sticking (built by adrail.js). The video ad is outside both and
+   scrolls away. */
+/* Variant B: two static display ads share one sticky wrapper (.ad-sticky-stack)
    so they pin together as a unit and never overlap — they sit in normal flow
-   inside it (with a 1rem gap) and the group pins near the top of the viewport.
-   Variant A: the single sticky-stack ad (id ends "_a_sticky") pins the same way.
-   The video ad is outside both and scrolls away. */
+   inside it (with a 1rem gap) and the group pins near the top of the viewport. */
 .ad-rail .ad-sticky-stack,
-.search-ad-rail-wide .ad-sticky-stack,
-.ad-rail > [id$="_a_sticky"],
-.search-ad-rail-wide > [id$="_a_sticky"] {
+.search-ad-rail-wide .ad-sticky-stack {
   position: sticky;
   top: 8px;
   z-index: 1;
 }
 .ad-sticky-stack > [id*="_b_display"] {
   margin-bottom: 1rem;
+}
+/* Variant A: the single NitroPay sticky-stack ad (id ends "_a_sticky"). It needs
+   a tall sticky container so the ad has room to stay pinned while scrolling —
+   without an explicit height the slot collapses (the ad lives in NitroPay's own
+   inner element) and scrolls away. */
+.ad-rail > [id$="_a_sticky"],
+.search-ad-rail-wide > [id$="_a_sticky"] {
+  position: sticky;
+  top: 8px;
+  z-index: 1;
+  height: calc(100vh - 8px);
 }
 
 /***************


### PR DESCRIPTION
## Problem
On prod, the A/B **variant A** (single NitroPay sticky-stack ad) does not stick — it scrolls away. Two causes:

1. **Slot had no height.** The `*_a_sticky` slot was `position: sticky` but height-less. NitroPay's sticky-stack ad lives in its own inner element, so the slot collapsed to ~1px and had no room to keep the ad pinned. Fixed by restoring `height: calc(100vh - 8px)` (the original sticky-stack rail had this). Verified with a headless harness: the slot now pins at `top: 8px` on scroll even when the ad doesn't fill.

2. **Stale Cloudflare CSS.** The deployed pods (all on the new image) serve app.css *with* the ad-rail rules, and the AssetVer hash matched (`4a4672cb`). But Cloudflare had cached `app.css?v=4a4672cb` with **old** content — a request for that versioned URL hit an old pod mid-rollout and poisoned the cache. Since the hash wouldn't change until the CSS changed, waiting wouldn't clear it. This CSS change bumps the hash (`4a4672cb` → `b4c5d22b`), so browsers fetch a fresh, uncached URL.

Variant B (two display ads in `.ad-sticky-stack`) is unchanged.