### PR TITLE
feat(api): admin-managed multiple HMAC shared secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,8 @@ SECURITY_SECRET=           # AES key for TOTP secret encryption
 WEBHOOK_SECRET=            # AES key for webhook URL encryption
 OAUTH_SIGN_SECRET=         # HMAC key for OAuth/auth pending cookies
 METRICS_TOKEN=             # Bearer token for /metrics endpoint (optional, blocks access if set)
-MOD_DOWNLOAD_SECRET=       # HMAC key for mod download API signing
+MOD_DOWNLOAD_SECRET=       # HMAC key for mod download API signing (primary)
+MOD_DOWNLOAD_SECRETS=      # optional comma-separated additional accepted HMAC secrets; more can be managed at /admin/api-secrets
 
 # Base URL for OAuth callbacks and sitemap generation
 BASE_URL=http://localhost:8080

--- a/internal/database/migrations/072_mod_secrets.down.sql
+++ b/internal/database/migrations/072_mod_secrets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS mod_secrets;

--- a/internal/database/migrations/072_mod_secrets.up.sql
+++ b/internal/database/migrations/072_mod_secrets.up.sql
@@ -1,0 +1,16 @@
+-- Admin-managed shared HMAC secrets for the mod / partner API. The value is
+-- stored in plaintext because HMAC verification needs the raw secret (the
+-- values are treated as public). Env-var secrets (MOD_DOWNLOAD_SECRET) remain
+-- accepted in addition to these.
+CREATE TABLE IF NOT EXISTS mod_secrets (
+    id         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    label      TEXT NOT NULL DEFAULT '',
+    note       TEXT NOT NULL DEFAULT '',
+    secret     TEXT NOT NULL,
+    active     BOOLEAN NOT NULL DEFAULT true,
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Hot path lists only active secrets.
+CREATE INDEX IF NOT EXISTS idx_mod_secrets_active ON mod_secrets (active) WHERE active;

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -2710,12 +2710,12 @@ func (vs *ViewRatingStoreImpl) RecordView(ctx context.Context, schematicID strin
 		typ    string
 		period string
 	}{
-		{"0", now.Format("20060102")},                    // daily: YYYYMMDD
-		{"1", fmt.Sprintf("%d%02d", year, week)},         // weekly: YYYYWW
-		{"2", now.Format("200601")},                      // monthly: YYYYMM
-		{"3", now.Format("2006")},                        // yearly: YYYY
-		{"4", "total"},                                    // all-time
-		{"5", now.Format("2006010215")},                   // hourly: YYYYMMDDHH
+		{"0", now.Format("20060102")},            // daily: YYYYMMDD
+		{"1", fmt.Sprintf("%d%02d", year, week)}, // weekly: YYYYWW
+		{"2", now.Format("200601")},              // monthly: YYYYMM
+		{"3", now.Format("2006")},                // yearly: YYYY
+		{"4", "total"},                           // all-time
+		{"5", now.Format("2006010215")},          // hourly: YYYYMMDDHH
 	}
 
 	for _, p := range periods {
@@ -3945,51 +3945,110 @@ func NewStoreFromPool(pool *pgxpool.Pool) *store.Store {
 	q := db.New(pool)
 	ps := &PostgresStore{q: q, pool: pool}
 	return &store.Store{
-		Users:          &UserStoreImpl{q: q},
-		Sessions:       ps,
-		Schematics:     ps,
-		Categories:     &CategoryStoreImpl{q: q},
-		Tags:           &TagStoreImpl{q: q},
-		Comments:       &CommentStoreImpl{q: q},
-		Guides:         &GuideStoreImpl{q: q},
-		Collections:    &CollectionStoreImpl{q: q},
-		Achievements:   &AchievementStoreImpl{q: q},
-		Translations:   &TranslationStoreImpl{q: q},
-		ViewRatings:    &ViewRatingStoreImpl{q: q},
-		Versions:       &VersionStoreImpl{q: q},
-		APIKeys:        &APIKeyStoreImpl{q: q},
-		Auth:           &AuthStoreImpl{q: q},
-		Reports:        &ReportStoreImpl{q: q},
-		ModMetadata:    &ModMetadataStoreImpl{q: q},
-		VersionLookup:  &VersionLookupStoreImpl{q: q},
-		SearchTracking: &SearchTrackingStoreImpl{q: q},
-		OutgoingClicks: &OutgoingClickStoreImpl{q: q},
-		Contact:        &ContactStoreImpl{q: q},
-		Stats:           &StatsStoreImpl{q: q},
-		TempUploads:      &TempUploadStoreImpl{q: q},
-		TempUploadFiles:  &TempUploadFileStoreImpl{q: q},
-		TempUploadImages: &TempUploadImageStoreImpl{q: q},
-		NBTHashes:       &NBTHashStoreImpl{q: q},
-		DownloadTokens:  &DownloadTokenStoreImpl{q: q},
-		SchematicFiles:  &SchematicFileStoreImpl{q: q},
+		Users:               &UserStoreImpl{q: q},
+		Sessions:            ps,
+		Schematics:          ps,
+		Categories:          &CategoryStoreImpl{q: q},
+		Tags:                &TagStoreImpl{q: q},
+		Comments:            &CommentStoreImpl{q: q},
+		Guides:              &GuideStoreImpl{q: q},
+		Collections:         &CollectionStoreImpl{q: q},
+		Achievements:        &AchievementStoreImpl{q: q},
+		Translations:        &TranslationStoreImpl{q: q},
+		ViewRatings:         &ViewRatingStoreImpl{q: q},
+		Versions:            &VersionStoreImpl{q: q},
+		APIKeys:             &APIKeyStoreImpl{q: q},
+		Auth:                &AuthStoreImpl{q: q},
+		Reports:             &ReportStoreImpl{q: q},
+		ModMetadata:         &ModMetadataStoreImpl{q: q},
+		VersionLookup:       &VersionLookupStoreImpl{q: q},
+		SearchTracking:      &SearchTrackingStoreImpl{q: q},
+		OutgoingClicks:      &OutgoingClickStoreImpl{q: q},
+		Contact:             &ContactStoreImpl{q: q},
+		Stats:               &StatsStoreImpl{q: q},
+		TempUploads:         &TempUploadStoreImpl{q: q},
+		TempUploadFiles:     &TempUploadFileStoreImpl{q: q},
+		TempUploadImages:    &TempUploadImageStoreImpl{q: q},
+		NBTHashes:           &NBTHashStoreImpl{q: q},
+		DownloadTokens:      &DownloadTokenStoreImpl{q: q},
+		SchematicFiles:      &SchematicFileStoreImpl{q: q},
 		Webhooks:            &WebhookStoreImpl{q: q},
 		SchematicVariations: &SchematicVariationStoreImpl{q: q},
 		ModerationChats:     &ModerationChatStoreImpl{q: q},
 		ModerationLog:       &ModerationLogStoreImpl{q: q},
-		Badges:               &BadgeStoreImpl{q: q},
-		SocialLinks:          &SocialLinkStoreImpl{q: q},
-		Follows:              &FollowStoreImpl{q: q},
-		SchematicVideos:      &SchematicVideoStoreImpl{q: q},
-		References:           &ReferenceStoreImpl{q: q},
-		Modpacks:             &ModpackStoreImpl{q: q},
-		RedditLinks:          &RedditLinkStoreImpl{q: q},
-		Notifications:        &NotificationStoreImpl{q: q},
-		Newsletters:          &NewsletterStoreImpl{q: q},
-		SearchAlerts:         &SearchAlertStoreImpl{q: q},
-		ZeroResults:          &ZeroResultStoreImpl{q: q},
-		Security:             &SecurityStoreImpl{q: q, pool: pool},
-		AdClicks:             &AdClickStoreImpl{q: q},
+		Badges:              &BadgeStoreImpl{q: q},
+		SocialLinks:         &SocialLinkStoreImpl{q: q},
+		Follows:             &FollowStoreImpl{q: q},
+		SchematicVideos:     &SchematicVideoStoreImpl{q: q},
+		References:          &ReferenceStoreImpl{q: q},
+		Modpacks:            &ModpackStoreImpl{q: q},
+		RedditLinks:         &RedditLinkStoreImpl{q: q},
+		Notifications:       &NotificationStoreImpl{q: q},
+		Newsletters:         &NewsletterStoreImpl{q: q},
+		SearchAlerts:        &SearchAlertStoreImpl{q: q},
+		ZeroResults:         &ZeroResultStoreImpl{q: q},
+		Security:            &SecurityStoreImpl{q: q, pool: pool},
+		AdClicks:            &AdClickStoreImpl{q: q},
+		ModSecrets:          &ModSecretStoreImpl{pool: pool},
 	}
+}
+
+// ModSecretStoreImpl implements store.ModSecretStore over raw pgx.
+type ModSecretStoreImpl struct{ pool *pgxpool.Pool }
+
+func (m *ModSecretStoreImpl) ListActive(ctx context.Context) ([]string, error) {
+	rows, err := m.pool.Query(ctx, `SELECT secret FROM mod_secrets WHERE active ORDER BY created_at`)
+	if err != nil {
+		return nil, fmt.Errorf("listing active mod secrets: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+func (m *ModSecretStoreImpl) List(ctx context.Context) ([]store.ModSecret, error) {
+	rows, err := m.pool.Query(ctx, `
+		SELECT id, label, note, secret, active, created_by, created_at
+		FROM mod_secrets ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("listing mod secrets: %w", err)
+	}
+	defer rows.Close()
+	var out []store.ModSecret
+	for rows.Next() {
+		var s store.ModSecret
+		if err := rows.Scan(&s.ID, &s.Label, &s.Note, &s.Secret, &s.Active, &s.CreatedBy, &s.Created); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+func (m *ModSecretStoreImpl) Create(ctx context.Context, s *store.ModSecret) error {
+	return m.pool.QueryRow(ctx, `
+		INSERT INTO mod_secrets (label, note, secret, active, created_by)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, created_at`,
+		s.Label, s.Note, s.Secret, s.Active, s.CreatedBy,
+	).Scan(&s.ID, &s.Created)
+}
+
+func (m *ModSecretStoreImpl) SetActive(ctx context.Context, id string, active bool) error {
+	_, err := m.pool.Exec(ctx, `UPDATE mod_secrets SET active = $2 WHERE id = $1`, id, active)
+	return err
+}
+
+func (m *ModSecretStoreImpl) Delete(ctx context.Context, id string) error {
+	_, err := m.pool.Exec(ctx, `DELETE FROM mod_secrets WHERE id = $1`, id)
+	return err
 }
 
 // --------------------------------------------------------------------------
@@ -4161,37 +4220,37 @@ var (
 
 // Ensure compile-time interface satisfaction for the separate impl types.
 var (
-	_ store.UserStore          = (*UserStoreImpl)(nil)
-	_ store.CategoryStore      = (*CategoryStoreImpl)(nil)
-	_ store.TagStore           = (*TagStoreImpl)(nil)
-	_ store.CommentStore       = (*CommentStoreImpl)(nil)
-	_ store.GuideStore         = (*GuideStoreImpl)(nil)
-	_ store.CollectionStore    = (*CollectionStoreImpl)(nil)
-	_ store.AchievementStore   = (*AchievementStoreImpl)(nil)
-	_ store.TranslationStore   = (*TranslationStoreImpl)(nil)
-	_ store.ViewRatingStore    = (*ViewRatingStoreImpl)(nil)
-	_ store.VersionStore       = (*VersionStoreImpl)(nil)
-	_ store.APIKeyStore        = (*APIKeyStoreImpl)(nil)
-	_ store.AuthStore          = (*AuthStoreImpl)(nil)
-	_ store.ReportStore        = (*ReportStoreImpl)(nil)
-	_ store.ModMetadataStore   = (*ModMetadataStoreImpl)(nil)
-	_ store.VersionLookupStore = (*VersionLookupStoreImpl)(nil)
-	_ store.SearchTrackingStore = (*SearchTrackingStoreImpl)(nil)
-	_ store.OutgoingClickStore = (*OutgoingClickStoreImpl)(nil)
-	_ store.ContactStore       = (*ContactStoreImpl)(nil)
-	_ store.StatsStore          = (*StatsStoreImpl)(nil)
-	_ store.TempUploadStore      = (*TempUploadStoreImpl)(nil)
-	_ store.TempUploadFileStore  = (*TempUploadFileStoreImpl)(nil)
-	_ store.TempUploadImageStore = (*TempUploadImageStoreImpl)(nil)
-	_ store.DownloadTokenStore  = (*DownloadTokenStoreImpl)(nil)
-	_ store.SchematicFileStore  = (*SchematicFileStoreImpl)(nil)
-	_ store.WebhookStore             = (*WebhookStoreImpl)(nil)
-	_ store.SchematicVariationStore  = (*SchematicVariationStoreImpl)(nil)
-	_ store.ModerationLogStore       = (*ModerationLogStoreImpl)(nil)
-	_ store.BadgeStore               = (*BadgeStoreImpl)(nil)
-	_ store.SocialLinkStore          = (*SocialLinkStoreImpl)(nil)
-	_ store.FollowStore              = (*FollowStoreImpl)(nil)
-	_ store.SecurityStore            = (*SecurityStoreImpl)(nil)
+	_ store.UserStore               = (*UserStoreImpl)(nil)
+	_ store.CategoryStore           = (*CategoryStoreImpl)(nil)
+	_ store.TagStore                = (*TagStoreImpl)(nil)
+	_ store.CommentStore            = (*CommentStoreImpl)(nil)
+	_ store.GuideStore              = (*GuideStoreImpl)(nil)
+	_ store.CollectionStore         = (*CollectionStoreImpl)(nil)
+	_ store.AchievementStore        = (*AchievementStoreImpl)(nil)
+	_ store.TranslationStore        = (*TranslationStoreImpl)(nil)
+	_ store.ViewRatingStore         = (*ViewRatingStoreImpl)(nil)
+	_ store.VersionStore            = (*VersionStoreImpl)(nil)
+	_ store.APIKeyStore             = (*APIKeyStoreImpl)(nil)
+	_ store.AuthStore               = (*AuthStoreImpl)(nil)
+	_ store.ReportStore             = (*ReportStoreImpl)(nil)
+	_ store.ModMetadataStore        = (*ModMetadataStoreImpl)(nil)
+	_ store.VersionLookupStore      = (*VersionLookupStoreImpl)(nil)
+	_ store.SearchTrackingStore     = (*SearchTrackingStoreImpl)(nil)
+	_ store.OutgoingClickStore      = (*OutgoingClickStoreImpl)(nil)
+	_ store.ContactStore            = (*ContactStoreImpl)(nil)
+	_ store.StatsStore              = (*StatsStoreImpl)(nil)
+	_ store.TempUploadStore         = (*TempUploadStoreImpl)(nil)
+	_ store.TempUploadFileStore     = (*TempUploadFileStoreImpl)(nil)
+	_ store.TempUploadImageStore    = (*TempUploadImageStoreImpl)(nil)
+	_ store.DownloadTokenStore      = (*DownloadTokenStoreImpl)(nil)
+	_ store.SchematicFileStore      = (*SchematicFileStoreImpl)(nil)
+	_ store.WebhookStore            = (*WebhookStoreImpl)(nil)
+	_ store.SchematicVariationStore = (*SchematicVariationStoreImpl)(nil)
+	_ store.ModerationLogStore      = (*ModerationLogStoreImpl)(nil)
+	_ store.BadgeStore              = (*BadgeStoreImpl)(nil)
+	_ store.SocialLinkStore         = (*SocialLinkStoreImpl)(nil)
+	_ store.FollowStore             = (*FollowStoreImpl)(nil)
+	_ store.SecurityStore           = (*SecurityStoreImpl)(nil)
 )
 
 // --------------------------------------------------------------------------
@@ -4547,15 +4606,16 @@ func (s *SecurityStoreImpl) GetSecuritySettings(ctx context.Context, userID stri
 // --------------------------------------------------------------------------
 
 var (
-	_ store.SchematicVideoStore      = (*SchematicVideoStoreImpl)(nil)
-	_ store.ReferenceStore           = (*ReferenceStoreImpl)(nil)
-	_ store.ModpackStore             = (*ModpackStoreImpl)(nil)
-	_ store.RedditLinkStore          = (*RedditLinkStoreImpl)(nil)
-	_ store.NotificationStore        = (*NotificationStoreImpl)(nil)
-	_ store.NewsletterStore          = (*NewsletterStoreImpl)(nil)
-	_ store.SearchAlertStore         = (*SearchAlertStoreImpl)(nil)
-	_ store.ZeroResultStore = (*ZeroResultStoreImpl)(nil)
-	_ store.AdClickStore    = (*AdClickStoreImpl)(nil)
+	_ store.SchematicVideoStore = (*SchematicVideoStoreImpl)(nil)
+	_ store.ReferenceStore      = (*ReferenceStoreImpl)(nil)
+	_ store.ModpackStore        = (*ModpackStoreImpl)(nil)
+	_ store.RedditLinkStore     = (*RedditLinkStoreImpl)(nil)
+	_ store.NotificationStore   = (*NotificationStoreImpl)(nil)
+	_ store.NewsletterStore     = (*NewsletterStoreImpl)(nil)
+	_ store.SearchAlertStore    = (*SearchAlertStoreImpl)(nil)
+	_ store.ZeroResultStore     = (*ZeroResultStoreImpl)(nil)
+	_ store.AdClickStore        = (*AdClickStoreImpl)(nil)
+	_ store.ModSecretStore      = (*ModSecretStoreImpl)(nil)
 )
 
 // --------------------------------------------------------------------------

--- a/internal/pages/admin_mod_secrets.go
+++ b/internal/pages/admin_mod_secrets.go
@@ -1,0 +1,161 @@
+package pages
+
+import (
+	"context"
+	"createmod/internal/cache"
+	"createmod/internal/i18n"
+	"createmod/internal/server"
+	"createmod/internal/store"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+)
+
+var adminModSecretsTemplates = append([]string{
+	"./template/admin_api_secrets.html",
+}, commonTemplates...)
+
+// AdminModSecretRow is one secret shown in the admin list.
+type AdminModSecretRow struct {
+	ID      string
+	Label   string
+	Note    string
+	Secret  string
+	Active  bool
+	Created string
+}
+
+type AdminModSecretsData struct {
+	DefaultData
+	Secrets []AdminModSecretRow
+}
+
+// AdminModSecretsHandler renders the admin page for managing shared HMAC secrets.
+func AdminModSecretsHandler(registry *server.Registry, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		ctx := context.Background()
+		list, err := appStore.ModSecrets.List(ctx)
+		if err != nil {
+			return e.String(http.StatusInternalServerError, "failed to list secrets")
+		}
+		rows := make([]AdminModSecretRow, len(list))
+		for i, s := range list {
+			rows[i] = AdminModSecretRow{
+				ID:      s.ID,
+				Label:   s.Label,
+				Note:    s.Note,
+				Secret:  s.Secret,
+				Active:  s.Active,
+				Created: s.Created.Format("2006-01-02 15:04"),
+			}
+		}
+
+		d := AdminModSecretsData{Secrets: rows}
+		d.Populate(e)
+		d.AdminSection = "api-secrets"
+		d.Breadcrumbs = NewBreadcrumbs(d.Language, i18n.T(d.Language, "Admin"), "/admin", i18n.T(d.Language, "API Secrets"))
+		d.Title = i18n.T(d.Language, "Admin: API Secrets")
+		d.SubCategory = "Admin"
+		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
+
+		html, err := registry.LoadFiles(adminModSecretsTemplates...).Render(d)
+		if err != nil {
+			return err
+		}
+		return e.HTML(http.StatusOK, html)
+	}
+}
+
+// AdminModSecretCreateHandler adds a new secret. If the secret field is blank a
+// random 64-hex value is generated server-side.
+func AdminModSecretCreateHandler(cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		if err := e.Request.ParseForm(); err != nil {
+			return e.String(http.StatusBadRequest, "invalid form")
+		}
+		label := strings.TrimSpace(e.Request.FormValue("label"))
+		note := strings.TrimSpace(e.Request.FormValue("note"))
+		secret := strings.TrimSpace(e.Request.FormValue("secret"))
+		if secret == "" {
+			buf := make([]byte, 32)
+			if _, err := rand.Read(buf); err != nil {
+				return e.String(http.StatusInternalServerError, "failed to generate secret")
+			}
+			secret = hex.EncodeToString(buf)
+		}
+
+		ms := &store.ModSecret{
+			Label:     label,
+			Note:      note,
+			Secret:    secret,
+			Active:    true,
+			CreatedBy: authenticatedUserID(e),
+		}
+		if err := appStore.ModSecrets.Create(context.Background(), ms); err != nil {
+			return e.String(http.StatusInternalServerError, "failed to create secret")
+		}
+		invalidateModSecretsCache(cacheService)
+		return adminModSecretsRedirect(e)
+	}
+}
+
+// AdminModSecretActiveHandler activates/deactivates a secret (?active=true|false).
+func AdminModSecretActiveHandler(cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		active := e.Request.URL.Query().Get("active") == "true"
+		if err := appStore.ModSecrets.SetActive(context.Background(), id, active); err != nil {
+			return e.String(http.StatusInternalServerError, "failed to update secret")
+		}
+		invalidateModSecretsCache(cacheService)
+		return adminModSecretsRedirect(e)
+	}
+}
+
+// AdminModSecretDeleteHandler permanently removes a secret.
+func AdminModSecretDeleteHandler(cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		if err := appStore.ModSecrets.Delete(context.Background(), id); err != nil {
+			return e.String(http.StatusInternalServerError, "failed to delete secret")
+		}
+		invalidateModSecretsCache(cacheService)
+		return adminModSecretsRedirect(e)
+	}
+}
+
+// invalidateModSecretsCache clears the cached active-secret list so admin
+// changes take effect on the next request (on this pod; other pods refresh
+// within the cache TTL).
+func invalidateModSecretsCache(cacheService *cache.Service) {
+	if cacheService != nil {
+		cacheService.Delete(modSecretsCacheKey)
+	}
+}
+
+func adminModSecretsRedirect(e *server.RequestEvent) error {
+	if e.Request.Header.Get("HX-Request") != "" {
+		e.Response.Header().Set("HX-Redirect", LangRedirectURL(e, "/admin/api-secrets"))
+		return e.HTML(http.StatusNoContent, "")
+	}
+	return e.Redirect(http.StatusSeeOther, LangRedirectURL(e, "/admin/api-secrets"))
+}

--- a/internal/pages/api_browse.go
+++ b/internal/pages/api_browse.go
@@ -55,10 +55,10 @@ type apiFiltersResponse struct {
 
 // APIHomeHandler serves GET /api/home returning the trending / latest / highest
 // rated rails, mirroring the website home page. Auth: API key or HMAC.
-func APIHomeHandler(searchEngine search.SearchEngine, rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, modSecret string) func(e *server.RequestEvent) error {
+func APIHomeHandler(searchEngine search.SearchEngine, rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/home"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, modSecret)
+		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
@@ -105,10 +105,10 @@ func APIHomeHandler(searchEngine search.SearchEngine, rl ratelimit.Limiter, cach
 
 // APIFiltersHandler serves GET /api/schematics/filters returning the option
 // lists used to populate the search filter UI. Auth: API key or HMAC.
-func APIFiltersHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, modSecret string) func(e *server.RequestEvent) error {
+func APIFiltersHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/filters"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, modSecret)
+		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}

--- a/internal/pages/api_comments_list.go
+++ b/internal/pages/api_comments_list.go
@@ -20,10 +20,10 @@ type apiCommentsResponse struct {
 
 // APISchematicCommentsHandler serves GET /api/schematics/{name}/comments,
 // returning the approved comment thread for a schematic. Auth: API key or HMAC.
-func APISchematicCommentsHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, modSecret string) func(e *server.RequestEvent) error {
+func APISchematicCommentsHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/{name}/comments"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, modSecret)
+		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}

--- a/internal/pages/api_endpoints_test.go
+++ b/internal/pages/api_endpoints_test.go
@@ -193,7 +193,7 @@ func downloadDeps() (*store.Store, *fakeAPIKeys, *fakeViewRatings, string) {
 func TestAPIDownload(t *testing.T) {
 	t.Run("401 without auth", func(t *testing.T) {
 		appStore, _, _, _ := downloadDeps()
-		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore, testModSecret)
+		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore)
 		e, rec := newEvent("GET", "/api/schematics/gearbox/download", "", map[string]string{"name": "gearbox"})
 		_ = h(e)
 		if rec.Code != http.StatusUnauthorized {
@@ -203,7 +203,7 @@ func TestAPIDownload(t *testing.T) {
 
 	t.Run("404 for non-public schematic", func(t *testing.T) {
 		appStore, _, vr, key := downloadDeps()
-		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore, testModSecret)
+		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore)
 		e, rec := newEvent("GET", "/api/schematics/hidden/download", key, map[string]string{"name": "hidden"})
 		_ = h(e)
 		if rec.Code != http.StatusNotFound {
@@ -216,7 +216,7 @@ func TestAPIDownload(t *testing.T) {
 
 	t.Run("302 redirect and counts on success", func(t *testing.T) {
 		appStore, _, vr, key := downloadDeps()
-		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore, testModSecret)
+		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore)
 		e, rec := newEvent("GET", "/api/schematics/gearbox/download", key, map[string]string{"name": "gearbox"})
 		_ = h(e)
 		if rec.Code != http.StatusFound {
@@ -232,7 +232,7 @@ func TestAPIDownload(t *testing.T) {
 
 	t.Run("variation ?f= redirects and counts", func(t *testing.T) {
 		appStore, _, vr, key := downloadDeps()
-		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore, testModSecret)
+		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore)
 		e, rec := newEvent("GET", "/api/schematics/gearbox/download?f=var1", key, map[string]string{"name": "gearbox"})
 		_ = h(e)
 		if rec.Code != http.StatusFound {
@@ -248,7 +248,7 @@ func TestAPIDownload(t *testing.T) {
 
 	t.Run("bad ?f= is 404 and does NOT count (ordering fix)", func(t *testing.T) {
 		appStore, _, vr, key := downloadDeps()
-		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore, testModSecret)
+		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore)
 		e, rec := newEvent("GET", "/api/schematics/gearbox/download?f=nope", key, map[string]string{"name": "gearbox"})
 		_ = h(e)
 		if rec.Code != http.StatusNotFound {
@@ -261,7 +261,7 @@ func TestAPIDownload(t *testing.T) {
 
 	t.Run("missing file yields 404", func(t *testing.T) {
 		appStore, _, _, key := downloadDeps()
-		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore, testModSecret)
+		h := APISchematicDownloadHandler(newFakeLimiter(), cache.New(), appStore)
 		e, rec := newEvent("GET", "/api/schematics/nofile/download", key, map[string]string{"name": "nofile"})
 		_ = h(e)
 		if rec.Code != http.StatusNotFound {
@@ -285,7 +285,7 @@ func TestAPIComments(t *testing.T) {
 			"hidden":  {ID: "id-h", Name: "hidden", ModerationState: store.ModerationRejected},
 		}},
 	}
-	h := APISchematicCommentsHandler(newFakeLimiter(), cache.New(), appStore, testModSecret)
+	h := APISchematicCommentsHandler(newFakeLimiter(), cache.New(), appStore)
 
 	t.Run("401 without auth", func(t *testing.T) {
 		e, rec := newEvent("GET", "/api/schematics/gearbox/comments", "", map[string]string{"name": "gearbox"})
@@ -332,7 +332,7 @@ func TestAPICommentsCaching(t *testing.T) {
 		Comments:   comments,
 		Schematics: &fakeSchematics{byName: map[string]*store.Schematic{"warp": publicSchematic("id-w", "warp", "w.nbt")}},
 	}
-	h := APISchematicCommentsHandler(newFakeLimiter(), cache.New(), appStore, testModSecret)
+	h := APISchematicCommentsHandler(newFakeLimiter(), cache.New(), appStore)
 
 	call := func() *httptest.ResponseRecorder {
 		e, rec := newEvent("GET", "/api/schematics/warp/comments", apiKey, map[string]string{"name": "warp"})

--- a/internal/pages/api_public.go
+++ b/internal/pages/api_public.go
@@ -26,16 +26,73 @@ type hmacAuth struct {
 	Identifier string
 }
 
+// envModSecrets holds the HMAC shared secrets configured via environment
+// (MOD_DOWNLOAD_SECRET[S]); the router sets it once at startup. Admin-managed
+// DB secrets are merged in at request time by resolveModSecrets.
+var envModSecrets []string
+
+// SetModSecrets records the environment-configured HMAC secrets. Called once at
+// startup from the router.
+func SetModSecrets(secrets []string) { envModSecrets = secrets }
+
+const (
+	modSecretsCacheKey = "modsecrets:active"
+	modSecretsCacheTTL = 60 * time.Second
+)
+
+// resolveModSecrets returns every currently-accepted HMAC secret: the static
+// environment secrets plus the active DB-managed secrets (cached per-pod so the
+// hot path doesn't hit Postgres on every request). Admin changes invalidate the
+// cache key, so they take effect immediately.
+func resolveModSecrets(appStore *store.Store, cacheService *cache.Service) []string {
+	secrets := append([]string(nil), envModSecrets...)
+	return append(secrets, activeDBModSecrets(appStore, cacheService)...)
+}
+
+func activeDBModSecrets(appStore *store.Store, cacheService *cache.Service) []string {
+	if appStore == nil || appStore.ModSecrets == nil {
+		return nil
+	}
+	if cacheService != nil {
+		if v, ok := cacheService.Get(modSecretsCacheKey); ok {
+			if list, ok := v.([]string); ok {
+				return list
+			}
+		}
+	}
+	list, err := appStore.ModSecrets.ListActive(context.Background())
+	if err != nil {
+		return nil
+	}
+	if cacheService != nil {
+		cacheService.SetWithTTL(modSecretsCacheKey, list, modSecretsCacheTTL)
+	}
+	return list
+}
+
+// matchModSignature returns the first secret in secrets that produces a valid
+// HMAC signature over message, so the caller can reuse that exact secret (the
+// mod-download response is XOR-encoded with the client's own secret). ok is
+// false when no secret matches.
+func matchModSignature(message, signature string, secrets []string) (string, bool) {
+	for _, s := range secrets {
+		if validateModSignature(message, signature, s) {
+			return s, true
+		}
+	}
+	return "", false
+}
+
 // authenticateHMAC checks for X-Mod-Message and X-Mod-Signature headers and
-// validates them against the shared secret. Returns the parsed auth info on
-// success, or nil if the headers are absent or invalid.
-func authenticateHMAC(r *http.Request, secret string) *hmacAuth {
+// validates them against any of the accepted shared secrets. Returns the parsed
+// auth info on success, or nil if the headers are absent or invalid.
+func authenticateHMAC(r *http.Request, secrets []string) *hmacAuth {
 	message := strings.TrimSpace(r.Header.Get("X-Mod-Message"))
 	signature := strings.TrimSpace(r.Header.Get("X-Mod-Signature"))
 	if message == "" || signature == "" {
 		return nil
 	}
-	if !validateModSignature(message, signature, secret) {
+	if _, ok := matchModSignature(message, signature, secrets); !ok {
 		return nil
 	}
 	timestamp, modVersion, mcUsername, identifier, err := parseModMessage(message, maxModTimestampAge)
@@ -54,7 +111,7 @@ func authenticateHMAC(r *http.Request, secret string) *hmacAuth {
 //   - keyID (non-empty for API key auth, empty for HMAC)
 //   - isHMAC (true if authenticated via HMAC)
 //   - error (non-nil if both auth methods failed; response already written)
-func requireAPIKeyOrHMAC(appStore *store.Store, e *server.RequestEvent, modSecret string) (string, bool, error) {
+func requireAPIKeyOrHMAC(appStore *store.Store, e *server.RequestEvent, cacheService *cache.Service) (string, bool, error) {
 	// Try API key first
 	apiKey := getAPIKeyFromRequest(e.Request)
 	if apiKey != "" {
@@ -64,8 +121,8 @@ func requireAPIKeyOrHMAC(appStore *store.Store, e *server.RequestEvent, modSecre
 		}
 	}
 
-	// Try HMAC
-	if auth := authenticateHMAC(e.Request, modSecret); auth != nil {
+	// Try HMAC against the env + admin-managed secrets.
+	if auth := authenticateHMAC(e.Request, resolveModSecrets(appStore, cacheService)); auth != nil {
 		return "", true, nil
 	}
 
@@ -238,10 +295,10 @@ func rateLimitAllow(rl ratelimit.Limiter, keyID string, limit int) (bool, int) {
 
 // APISchematicsListHandler serves GET /api/schematics as a simple JSON API for searching/listing schematics.
 // Accepts either X-API-Key or HMAC authentication (X-Mod-Message + X-Mod-Signature headers).
-func APISchematicsListHandler(searchEngine search.SearchEngine, rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, modSecret string) func(e *server.RequestEvent) error {
+func APISchematicsListHandler(searchEngine search.SearchEngine, rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, modSecret)
+		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
@@ -501,10 +558,10 @@ func apiSearchResults(ctx context.Context, searchEngine search.SearchEngine, app
 
 // APISchematicDetailHandler serves GET /api/schematics/{name} returning one schematic by name.
 // Accepts either X-API-Key or HMAC authentication (X-Mod-Message + X-Mod-Signature headers).
-func APISchematicDetailHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, modSecret string) func(e *server.RequestEvent) error {
+func APISchematicDetailHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/{name}"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, modSecret)
+		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}

--- a/internal/pages/api_schematic_download.go
+++ b/internal/pages/api_schematic_download.go
@@ -16,10 +16,10 @@ import (
 // It increments the download counter and redirects to the schematic's file so
 // API clients (e.g. the Brassworks Launcher) can fetch the .nbt directly.
 // Auth: API key or HMAC. An optional ?f={fileID} downloads a variation file.
-func APISchematicDownloadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, modSecret string) func(e *server.RequestEvent) error {
+func APISchematicDownloadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/{name}/download"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, modSecret)
+		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}

--- a/internal/pages/api_test_helpers_test.go
+++ b/internal/pages/api_test_helpers_test.go
@@ -107,6 +107,17 @@ func (f *fakeViewRatings) GetDownloadCount(ctx context.Context, schematicID stri
 	return f.downloads, nil
 }
 
+type fakeModSecrets struct {
+	store.ModSecretStore
+	active         []string
+	listActiveCall int
+}
+
+func (f *fakeModSecrets) ListActive(ctx context.Context) ([]string, error) {
+	f.listActiveCall++
+	return f.active, nil
+}
+
 type fakeComments struct {
 	store.CommentStore
 	bySchematic map[string][]store.Comment

--- a/internal/pages/api_upload.go
+++ b/internal/pages/api_upload.go
@@ -218,11 +218,11 @@ func processFormImages(ctx context.Context, r *http.Request, formField, category
 // Accepts multipart/form-data with an .nbt file.
 // The upload goes through the same pipeline as web uploads -- returns a preview token, not a published schematic.
 // Uses PostgreSQL store for metadata and direct S3 for file storage.
-func APIUploadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, storageSvc *storage.Service, modSecret string) func(e *server.RequestEvent) error {
+func APIUploadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, storageSvc *storage.Service) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "POST /api/schematics/upload"
 
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, modSecret)
+		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}

--- a/internal/pages/hmac_multi_secret_test.go
+++ b/internal/pages/hmac_multi_secret_test.go
@@ -1,0 +1,93 @@
+package pages
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"createmod/internal/cache"
+	"createmod/internal/store"
+)
+
+func hmacHex(msg, secret string) string {
+	m := hmac.New(sha256.New, []byte(secret))
+	m.Write([]byte(msg))
+	return hex.EncodeToString(m.Sum(nil))
+}
+
+func Test_matchModSignature_MultipleSecrets(t *testing.T) {
+	secrets := []string{"alpha", "bravo", "charlie"}
+	msg := "1700000000:1.0:steve:slug"
+	sig := hmacHex(msg, "bravo")
+
+	got, ok := matchModSignature(msg, sig, secrets)
+	if !ok || got != "bravo" {
+		t.Fatalf("expected to match 'bravo', got %q ok=%v", got, ok)
+	}
+	if _, ok := matchModSignature(msg, sig, []string{"x", "y"}); ok {
+		t.Fatalf("expected no match when the signing secret is absent")
+	}
+	if _, ok := matchModSignature(msg, sig, nil); ok {
+		t.Fatalf("expected no match against an empty secret list")
+	}
+}
+
+func Test_authenticateHMAC_AcceptsAnyAcceptedSecret(t *testing.T) {
+	secrets := []string{"s1", "s2"}
+	ts := time.Now().Unix()
+	msg := fmt.Sprintf("%d:1.0:steve:slug", ts)
+	sig := hmacHex(msg, "s2") // signed with the second secret
+
+	req := httptest.NewRequest("GET", "/api/home", nil)
+	req.Header.Set("X-Mod-Message", msg)
+	req.Header.Set("X-Mod-Signature", sig)
+
+	if auth := authenticateHMAC(req, secrets); auth == nil {
+		t.Fatalf("expected HMAC auth to succeed with a secret from the list")
+	}
+	if auth := authenticateHMAC(req, []string{"other"}); auth != nil {
+		t.Fatalf("expected HMAC auth to fail when no accepted secret matches")
+	}
+}
+
+func Test_resolveModSecrets_MergesEnvAndDB_AndCaches(t *testing.T) {
+	// Isolate the package-level env secrets.
+	old := envModSecrets
+	t.Cleanup(func() { envModSecrets = old })
+	SetModSecrets([]string{"env-secret"})
+
+	ms := &fakeModSecrets{active: []string{"db-secret-1", "db-secret-2"}}
+	appStore := &store.Store{ModSecrets: ms}
+	c := cache.New()
+
+	got := resolveModSecrets(appStore, c)
+	want := map[string]bool{"env-secret": true, "db-secret-1": true, "db-secret-2": true}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d secrets, got %d: %v", len(want), len(got), got)
+	}
+	for _, s := range got {
+		if !want[s] {
+			t.Errorf("unexpected secret %q", s)
+		}
+	}
+
+	// Second call within the TTL must be served from cache (no extra DB hit).
+	_ = resolveModSecrets(appStore, c)
+	if ms.listActiveCall != 1 {
+		t.Fatalf("expected DB ListActive to be called once (cached after), got %d", ms.listActiveCall)
+	}
+}
+
+func Test_resolveModSecrets_NilStoreSafe(t *testing.T) {
+	old := envModSecrets
+	t.Cleanup(func() { envModSecrets = old })
+	SetModSecrets([]string{"only-env"})
+	got := resolveModSecrets(&store.Store{}, cache.New())
+	if len(got) != 1 || got[0] != "only-env" {
+		t.Fatalf("expected just the env secret when no ModSecrets store, got %v", got)
+	}
+}

--- a/internal/pages/mod_download.go
+++ b/internal/pages/mod_download.go
@@ -98,7 +98,7 @@ func xorEncode(data, key []byte) []byte {
 // ModDownloadHandler handles POST /api/mod/download.
 // It validates an HMAC-signed request from the Minecraft mod, looks up the
 // schematic or private upload, and returns the NBT bytes XOR-encoded.
-func ModDownloadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, storageSvc *storage.Service, modSecret string) func(e *server.RequestEvent) error {
+func ModDownloadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store, storageSvc *storage.Service) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if storageSvc == nil {
 			return e.JSON(http.StatusServiceUnavailable, map[string]string{"error": "file storage not configured"})
@@ -118,8 +118,11 @@ func ModDownloadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appSt
 			return e.JSON(http.StatusBadRequest, map[string]string{"error": "invalid type; use 'schematic' or 'upload'"})
 		}
 
-		// Validate HMAC signature.
-		if !validateModSignature(req.Message, req.Signature, modSecret) {
+		// Validate the HMAC signature against any accepted secret (env +
+		// admin-managed). Keep the matched secret so the response is XOR-encoded
+		// with the same secret the client signed with.
+		matchedSecret, ok := matchModSignature(req.Message, req.Signature, resolveModSecrets(appStore, cacheService))
+		if !ok {
 			return e.JSON(http.StatusForbidden, map[string]string{"error": "invalid signature"})
 		}
 
@@ -158,8 +161,8 @@ func ModDownloadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appSt
 			return e.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to retrieve file"})
 		}
 
-		// XOR-encode the response.
-		xorKey := deriveXORKey(modSecret, timestamp)
+		// XOR-encode the response with the client's own secret.
+		xorKey := deriveXORKey(matchedSecret, timestamp)
 		encoded := xorEncode(fileBytes, xorKey)
 
 		e.Response.Header().Set("Content-Type", "application/octet-stream")

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -312,10 +312,12 @@ func Register(p RegisterParams) chi.Router {
 	// Prometheus metrics endpoint
 	r.Method("GET", "/metrics", metricsAuthMiddleware(promhttp.Handler()))
 
-	// Minecraft mod download API (HMAC-signed, XOR-encoded response)
-	modSecret := deriveModDownloadSecret()
+	// Minecraft mod download API (HMAC-signed, XOR-encoded response). Register
+	// the env-configured HMAC secrets once; admin-managed DB secrets are merged
+	// in at request time by the handlers.
+	pages.SetModSecrets(deriveModDownloadSecrets())
 	r.With(rateLimitMiddlewareNew(p.RateLimiter, 30, time.Minute)).
-		Post("/api/mod/download", Adapt(pages.ModDownloadHandler(p.RateLimiter, p.CacheService, p.AppStore, p.StorageService, modSecret)))
+		Post("/api/mod/download", Adapt(pages.ModDownloadHandler(p.RateLimiter, p.CacheService, p.AppStore, p.StorageService)))
 
 	// Custom file serving (replaces PB's /api/files/ handler with image resizing support)
 	r.Get("/api/files/{collection}/{recordID}/{filename}", Adapt(pages.FileServingHandler(p.StorageService)))
@@ -505,21 +507,21 @@ func Register(p RegisterParams) chi.Router {
 	r.Get("/api", Adapt(pages.APIDocsHandler(registry, p.CacheService, p.AppStore)))
 	r.Get("/api/openapi.json", Adapt(pages.OpenAPIHandler()))
 	// Public JSON API (beta) — supports both X-API-Key and HMAC authentication
-	r.Get("/api/home", Adapt(pages.APIHomeHandler(p.SearchEngine, p.RateLimiter, p.CacheService, p.AppStore, modSecret)))
-	r.Get("/api/schematics", Adapt(pages.APISchematicsListHandler(p.SearchEngine, p.RateLimiter, p.CacheService, p.AppStore, modSecret)))
-	r.Get("/api/schematics/filters", Adapt(pages.APIFiltersHandler(p.RateLimiter, p.CacheService, p.AppStore, modSecret)))
+	r.Get("/api/home", Adapt(pages.APIHomeHandler(p.SearchEngine, p.RateLimiter, p.CacheService, p.AppStore)))
+	r.Get("/api/schematics", Adapt(pages.APISchematicsListHandler(p.SearchEngine, p.RateLimiter, p.CacheService, p.AppStore)))
+	r.Get("/api/schematics/filters", Adapt(pages.APIFiltersHandler(p.RateLimiter, p.CacheService, p.AppStore)))
 	r.With(rateLimitMiddlewareNew(p.RateLimiter, 60, time.Minute)).
 		Get("/api/schematics/changes", Adapt(pages.APISchematicChangesHandler(p.AppStore)))
 	r.With(rateLimitMiddlewareNew(p.RateLimiter, 60, time.Minute)).
 		Get("/api/schematics/stats", Adapt(pages.APISchematicBulkStatsHandler(p.AppStore)))
-	r.Get("/api/schematics/{name}", Adapt(pages.APISchematicDetailHandler(p.RateLimiter, p.CacheService, p.AppStore, modSecret)))
-	r.Get("/api/schematics/{name}/download", Adapt(pages.APISchematicDownloadHandler(p.RateLimiter, p.CacheService, p.AppStore, modSecret)))
+	r.Get("/api/schematics/{name}", Adapt(pages.APISchematicDetailHandler(p.RateLimiter, p.CacheService, p.AppStore)))
+	r.Get("/api/schematics/{name}/download", Adapt(pages.APISchematicDownloadHandler(p.RateLimiter, p.CacheService, p.AppStore)))
 	// Additive alias for the REST download route (same handler, same {name} param).
-	r.Get("/api/download/{name}", Adapt(pages.APISchematicDownloadHandler(p.RateLimiter, p.CacheService, p.AppStore, modSecret)))
+	r.Get("/api/download/{name}", Adapt(pages.APISchematicDownloadHandler(p.RateLimiter, p.CacheService, p.AppStore)))
 	r.Get("/api/schematics/{name}/guide", Adapt(pages.SchematicGuideAPIHandler(p.AppStore, p.StorageService)))
 	r.Get("/api/schematics/{name}/stats", Adapt(pages.APISchematicStatsHandler(p.RateLimiter, p.CacheService, p.AppStore)))
-	r.Get("/api/schematics/{name}/comments", Adapt(pages.APISchematicCommentsHandler(p.RateLimiter, p.CacheService, p.AppStore, modSecret)))
-	r.Post("/api/schematics/upload", Adapt(pages.APIUploadHandler(p.RateLimiter, p.CacheService, p.AppStore, p.StorageService, modSecret)))
+	r.Get("/api/schematics/{name}/comments", Adapt(pages.APISchematicCommentsHandler(p.RateLimiter, p.CacheService, p.AppStore)))
+	r.Post("/api/schematics/upload", Adapt(pages.APIUploadHandler(p.RateLimiter, p.CacheService, p.AppStore, p.StorageService)))
 	r.Post("/api/schematics/upload-anonymous", Adapt(pages.APIUploadAnonymousHandler(p.RateLimiter, p.CacheService, p.AppStore, p.StorageService)))
 	r.Get("/api/user/stats", Adapt(pages.APIUserStatsHandler(p.RateLimiter, p.CacheService, p.AppStore)))
 	// Reports
@@ -545,6 +547,10 @@ func Register(p RegisterParams) chi.Router {
 		r.Get("/admin/tags", Adapt(pages.AdminTagsHandler(registry, p.CacheService, p.AppStore)))
 		r.Post("/admin/tags/{id}/approve", Adapt(pages.AdminTagApproveHandler(p.CacheService, p.AppStore)))
 		r.Post("/admin/tags/{id}/reject", Adapt(pages.AdminTagRejectHandler(p.CacheService, p.AppStore)))
+		r.Get("/admin/api-secrets", Adapt(pages.AdminModSecretsHandler(registry, p.CacheService, p.AppStore)))
+		r.Post("/admin/api-secrets", Adapt(pages.AdminModSecretCreateHandler(p.CacheService, p.AppStore)))
+		r.Post("/admin/api-secrets/{id}/active", Adapt(pages.AdminModSecretActiveHandler(p.CacheService, p.AppStore)))
+		r.Post("/admin/api-secrets/{id}/delete", Adapt(pages.AdminModSecretDeleteHandler(p.CacheService, p.AppStore)))
 		r.Get("/admin/mods", Adapt(pages.AdminModsHandler(registry, p.CacheService, p.AppStore)))
 		r.Get("/admin/mods/{namespace}", Adapt(pages.AdminModEditHandler(registry, p.CacheService, p.AppStore)))
 		r.Post("/admin/mods/{namespace}", Adapt(pages.AdminModUpdateHandler(p.AppStore)))
@@ -1273,15 +1279,38 @@ func extractClientIP(r *http.Request) string {
 	return host
 }
 
-// deriveModDownloadSecret returns the shared secret for Minecraft mod download
-// API request signing. Falls back to a deterministic insecure default for dev.
-func deriveModDownloadSecret() string {
-	if s := os.Getenv("MOD_DOWNLOAD_SECRET"); s != "" {
-		return s
+// deriveModDownloadSecrets returns the environment-configured HMAC shared
+// secrets for the mod / partner API. MOD_DOWNLOAD_SECRET is the primary single
+// secret; MOD_DOWNLOAD_SECRETS is an optional comma/space/newline-separated list
+// of additional accepted secrets. Admin-managed DB secrets are merged in
+// separately at request time. Falls back to a deterministic insecure default for
+// dev when nothing is configured.
+func deriveModDownloadSecrets() []string {
+	var out []string
+	seen := map[string]struct{}{}
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
 	}
-	slog.Warn("MOD_DOWNLOAD_SECRET environment variable is not set; using insecure default — set MOD_DOWNLOAD_SECRET in production")
-	h := sha256.Sum256([]byte("createmod-mod-download:default"))
-	return hex.EncodeToString(h[:])
+	add(os.Getenv("MOD_DOWNLOAD_SECRET"))
+	for _, s := range strings.FieldsFunc(os.Getenv("MOD_DOWNLOAD_SECRETS"), func(r rune) bool {
+		return r == ',' || r == '\n' || r == ' ' || r == '\t'
+	}) {
+		add(s)
+	}
+	if len(out) == 0 {
+		slog.Warn("MOD_DOWNLOAD_SECRET / MOD_DOWNLOAD_SECRETS not set and no DB secrets — using insecure default; configure one in production")
+		h := sha256.Sum256([]byte("createmod-mod-download:default"))
+		out = append(out, hex.EncodeToString(h[:]))
+	}
+	return out
 }
 
 // deriveOutSecret returns a stable HMAC key for signing /out redirect URLs.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -470,7 +470,6 @@ type SearchAlert struct {
 	Updated          time.Time
 }
 
-
 // ZeroResultSuggestion represents a suggestion for zero-result queries.
 type ZeroResultSuggestion struct {
 	ID         string
@@ -551,12 +550,12 @@ type SecuritySettings struct {
 
 // APIKey represents a user API key.
 type APIKey struct {
-	ID       string
-	UserID   string
-	KeyHash  string
-	Label    string
-	Last8    string
-	Created  time.Time
+	ID      string
+	UserID  string
+	KeyHash string
+	Label   string
+	Last8   string
+	Created time.Time
 }
 
 // GameVersion represents a Minecraft or Create mod version entry.
@@ -1442,7 +1441,6 @@ type SearchAlertStore interface {
 	UpdateLastNotified(ctx context.Context, id string) error
 }
 
-
 // ZeroResultStore handles zero-result search suggestions.
 type ZeroResultStore interface {
 	Upsert(ctx context.Context, s *ZeroResultSuggestion) error
@@ -1480,6 +1478,30 @@ type SecurityStore interface {
 	GetSecuritySettings(ctx context.Context, userID string) (*SecuritySettings, error)
 }
 
+// ModSecret is a shared HMAC secret for the mod / partner API, managed in the
+// database via the admin area. The secret value is stored in plaintext because
+// HMAC verification needs the raw value (and the values are treated as public).
+type ModSecret struct {
+	ID        string
+	Label     string // short name
+	Note      string // free-text description of what it's used for
+	Secret    string // the shared secret value
+	Active    bool
+	CreatedBy string
+	Created   time.Time
+}
+
+// ModSecretStore manages admin-defined HMAC shared secrets.
+type ModSecretStore interface {
+	// ListActive returns the secret values of all active entries (hot path).
+	ListActive(ctx context.Context) ([]string, error)
+	// List returns all entries (for the admin UI), newest first.
+	List(ctx context.Context) ([]ModSecret, error)
+	Create(ctx context.Context, s *ModSecret) error
+	SetActive(ctx context.Context, id string, active bool) error
+	Delete(ctx context.Context, id string) error
+}
+
 type Store struct {
 	Users               UserStore
 	Sessions            SessionStore
@@ -1512,17 +1534,18 @@ type Store struct {
 	SchematicVariations SchematicVariationStore
 	ModerationChats     ModerationChatStore
 	ModerationLog       ModerationLogStore
-	Badges               BadgeStore
-	SocialLinks          SocialLinkStore
-	Follows              FollowStore
-	SchematicVideos      SchematicVideoStore
-	References           ReferenceStore
-	Modpacks             ModpackStore
-	RedditLinks          RedditLinkStore
-	Notifications        NotificationStore
-	Newsletters          NewsletterStore
-	SearchAlerts         SearchAlertStore
-	ZeroResults          ZeroResultStore
-	Security             SecurityStore
-	AdClicks             AdClickStore
+	Badges              BadgeStore
+	SocialLinks         SocialLinkStore
+	Follows             FollowStore
+	SchematicVideos     SchematicVideoStore
+	References          ReferenceStore
+	Modpacks            ModpackStore
+	RedditLinks         RedditLinkStore
+	Notifications       NotificationStore
+	Newsletters         NewsletterStore
+	SearchAlerts        SearchAlertStore
+	ZeroResults         ZeroResultStore
+	Security            SecurityStore
+	AdClicks            AdClickStore
+	ModSecrets          ModSecretStore
 }

--- a/template/admin_api_secrets.html
+++ b/template/admin_api_secrets.html
@@ -1,0 +1,106 @@
+{{template "head.html" .}}
+<div class="page">
+  {{template "sidebar.html" .}}
+  <div class="page-wrapper">
+    {{template "header.html" .}}
+    <main class="page-body">
+      <div class="container-wide">
+        {{template "admin_nav.html" .}}
+        <div class="page-header d-print-none">
+          <div class="row align-items-center">
+            <div class="col">
+              <h2 class="page-title">Admin: API Secrets</h2>
+              <div class="text-secondary">Shared HMAC secrets accepted for the mod / partner API. Env-var secrets (MOD_DOWNLOAD_SECRET) are also always accepted.</div>
+            </div>
+          </div>
+        </div>
+
+        {{if not .IsAuthenticated}}
+          <div class="alert alert-danger">You must be logged in.</div>
+        {{end}}
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h3 class="card-title">Add a secret</h3>
+          </div>
+          <div class="card-body">
+            <form method="post" action="/admin/api-secrets">
+              <div class="row g-2">
+                <div class="col-md-3">
+                  <label class="form-label">Label</label>
+                  <input type="text" class="form-control" name="label" placeholder="e.g. brassworks-launcher">
+                </div>
+                <div class="col-md-5">
+                  <label class="form-label">Note</label>
+                  <input type="text" class="form-control" name="note" placeholder="What is this used for?">
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label">Secret <span class="text-secondary">(leave blank to generate)</span></label>
+                  <input type="text" class="form-control" name="secret" placeholder="paste an existing secret, or leave blank">
+                </div>
+              </div>
+              <div class="mt-3">
+                <button type="submit" class="btn btn-primary">Add secret</button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h3 class="card-title">Secrets</h3>
+          </div>
+          <div class="table-responsive">
+            <table class="table card-table table-vcenter">
+              <thead>
+                <tr>
+                  <th>Label</th>
+                  <th>Note</th>
+                  <th>Secret</th>
+                  <th>Status</th>
+                  <th>Created</th>
+                  <th class="w-1">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{range .Secrets}}
+                <tr>
+                  <td>{{ if .Label }}{{ .Label }}{{ else }}<span class="text-secondary">—</span>{{ end }}</td>
+                  <td>{{ if .Note }}{{ .Note }}{{ else }}<span class="text-secondary">—</span>{{ end }}</td>
+                  <td><code style="word-break:break-all;">{{ .Secret }}</code></td>
+                  <td>
+                    {{ if .Active }}<span class="badge bg-green-lt">Active</span>{{ else }}<span class="badge bg-secondary-lt">Inactive</span>{{ end }}
+                  </td>
+                  <td class="text-secondary">{{ .Created }}</td>
+                  <td>
+                    <div class="btn-list">
+                      {{ if .Active }}
+                      <form method="post" action="/admin/api-secrets/{{ .ID }}/active?active=false" style="display:inline">
+                        <button type="submit" class="btn btn-sm btn-outline-secondary">Deactivate</button>
+                      </form>
+                      {{ else }}
+                      <form method="post" action="/admin/api-secrets/{{ .ID }}/active?active=true" style="display:inline">
+                        <button type="submit" class="btn btn-sm btn-success">Activate</button>
+                      </form>
+                      {{ end }}
+                      <form method="post" action="/admin/api-secrets/{{ .ID }}/delete" style="display:inline" onsubmit="return confirm('Delete this secret permanently? Clients using it will stop working.');">
+                        <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+                {{else}}
+                <tr>
+                  <td colspan="6" class="text-secondary">No database secrets yet. The env-var secret (MOD_DOWNLOAD_SECRET) is still accepted.</td>
+                </tr>
+                {{end}}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </main>
+    {{template "footer.html" .}}
+  </div>
+</div>
+{{template "foot.html" .}}

--- a/template/include/admin_nav.html
+++ b/template/include/admin_nav.html
@@ -28,6 +28,9 @@
     <li class="nav-item">
       <a class="nav-link{{ if eq .AdminSection "mods" }} active{{ end }}" href="/admin/mods">Mods</a>
     </li>
+    <li class="nav-item">
+      <a class="nav-link{{ if eq .AdminSection "api-secrets" }} active{{ end }}" href="/admin/api-secrets">API Secrets</a>
+    </li>
   </ul>
 </div>
 {{end}}


### PR DESCRIPTION
The mod / partner API now accepts ANY of several shared secrets instead of a single MOD_DOWNLOAD_SECRET, so multiple clients can each hold their own and secrets can be rotated without downtime.

Secret sources, merged at request time:
- env: MOD_DOWNLOAD_SECRET (primary) + MOD_DOWNLOAD_SECRETS (comma-separated)
- DB:  admin-managed via a new /admin/api-secrets page (label + note + value; generate a random value or paste an existing one; activate/deactivate/ delete). Active DB secrets are cached per-pod (60s) and the cache is invalidated on any admin change.

Auth resolves secrets dynamically (resolveModSecrets = env + cached DB) instead of capturing a static value at startup, so admin changes take effect without a redeploy. The mod-download XOR response is encoded with the *matched* secret so each client can still decode. Validation is constant-time per secret (hmac.Equal).

- migration 072 mod_secrets; ModSecretStore (raw pgx) + wiring
- handlers drop the modSecret param; requireAPIKeyOrHMAC/ModDownloadHandler resolve internally
- tests: multi-secret match, any-accepted-secret auth, env+DB resolver + caching
- docs: .env.example notes MOD_DOWNLOAD_SECRETS and the admin page