### PR TITLE
fix(ui): expanded sidebar sits on top of the logo, not behind it

### DIFF
--- a/template/static/app.css
+++ b/template/static/app.css
@@ -720,13 +720,17 @@ a:hover {
 body.sidebar-ready .sidebar-rail {
   transition: width 0.2s ease;
 }
-/* Minimized (default): expand on hover */
+/* Minimized (default): expand on hover. Lift above the top-header (a flex item
+   with z-index 1050) so the hover-expanded panel sits on top of the logo
+   instead of sliding behind it. */
 .sidebar-rail:hover {
   width: 220px;
+  z-index: 1060;
 }
 /* Expanded (pinned open): always 220px, no hover needed */
 .sidebar-rail.sidebar-expanded {
   width: 220px;
+  z-index: 1060;
 }
 .sidebar-nav {
   flex: 1;

--- a/tests/e2e/specs/header_sidebar_check.spec.ts
+++ b/tests/e2e/specs/header_sidebar_check.spec.ts
@@ -1,12 +1,16 @@
 import { test, expect } from '@playwright/test';
 
-// On desktop the top header is in normal flow and scrolls away with the page,
-// while the left sidebar is fixed and full-height (starting at the very top).
-// They share the top-left corner, but the header is layered above the sidebar
-// (higher z-index) so there is no visual overlap.
-test('header is layered above the full-height sidebar at the top', async ({ page, baseURL }) => {
+// On desktop the top header is in normal flow and the left sidebar is fixed and
+// full-height (starting at the very top). They share the top-left corner. While
+// the rail is collapsed the header sits above it, but when the rail expands
+// (hover / pinned) it lifts ABOVE the header so the expanded menu covers the
+// logo instead of sliding behind it.
+test('expanded sidebar layers above the header (covers the logo)', async ({ page, baseURL }) => {
   const url = baseURL ?? 'http://localhost:8080';
   await page.goto(url + '/');
+
+  // Park the pointer away from the rail so the collapsed reading isn't a hover.
+  await page.mouse.move(600, 400);
 
   // Take a screenshot of the top-left area showing header + sidebar
   await page.screenshot({ path: 'test-results/header-sidebar.png', clip: { x: 0, y: 0, width: 400, height: 300 } });
@@ -17,11 +21,18 @@ test('header is layered above the full-height sidebar at the top', async ({ page
     if (!h || !s) return null;
     const hb = h.getBoundingClientRect();
     const sb = s.getBoundingClientRect();
+    const headerZ = parseInt(window.getComputedStyle(h).zIndex) || 0;
+    const collapsedZ = parseInt(window.getComputedStyle(s).zIndex) || 0;
+    // Expand the rail the same way hover does and read its stacking.
+    s.classList.add('sidebar-expanded');
+    const expandedZ = parseInt(window.getComputedStyle(s).zIndex) || 0;
+    s.classList.remove('sidebar-expanded');
     return {
       headerTop: Math.round(hb.y),
       sidebarTop: Math.round(sb.y),
-      headerZ: parseInt(window.getComputedStyle(h).zIndex) || 0,
-      sidebarZ: parseInt(window.getComputedStyle(s).zIndex) || 0,
+      headerZ,
+      collapsedZ,
+      expandedZ,
     };
   });
 
@@ -31,7 +42,9 @@ test('header is layered above the full-height sidebar at the top', async ({ page
     // Both anchor at the very top of the page.
     expect(info.headerTop).toBeLessThanOrEqual(1);
     expect(info.sidebarTop).toBeLessThanOrEqual(1);
-    // The header renders above the sidebar so the shared corner shows the header.
-    expect(info.headerZ).toBeGreaterThan(info.sidebarZ);
+    // Collapsed: the header is at least as high, so the rail doesn't cover it.
+    expect(info.headerZ).toBeGreaterThanOrEqual(info.collapsedZ);
+    // Expanded: the rail lifts above the header so it covers the logo.
+    expect(info.expandedZ).toBeGreaterThan(info.headerZ);
   }
 });

--- a/tests/e2e/specs/header_sidebar_check.spec.ts
+++ b/tests/e2e/specs/header_sidebar_check.spec.ts
@@ -1,16 +1,12 @@
 import { test, expect } from '@playwright/test';
 
 // On desktop the top header is in normal flow and the left sidebar is fixed and
-// full-height (starting at the very top). They share the top-left corner. While
-// the rail is collapsed the header sits above it, but when the rail expands
-// (hover / pinned) it lifts ABOVE the header so the expanded menu covers the
-// logo instead of sliding behind it.
+// full-height (starting at the very top). They share the top-left corner. When
+// the rail is expanded (hover / pinned) it lifts ABOVE the header so the
+// expanded menu covers the logo instead of sliding behind it.
 test('expanded sidebar layers above the header (covers the logo)', async ({ page, baseURL }) => {
   const url = baseURL ?? 'http://localhost:8080';
   await page.goto(url + '/');
-
-  // Park the pointer away from the rail so the collapsed reading isn't a hover.
-  await page.mouse.move(600, 400);
 
   // Take a screenshot of the top-left area showing header + sidebar
   await page.screenshot({ path: 'test-results/header-sidebar.png', clip: { x: 0, y: 0, width: 400, height: 300 } });
@@ -22,16 +18,13 @@ test('expanded sidebar layers above the header (covers the logo)', async ({ page
     const hb = h.getBoundingClientRect();
     const sb = s.getBoundingClientRect();
     const headerZ = parseInt(window.getComputedStyle(h).zIndex) || 0;
-    const collapsedZ = parseInt(window.getComputedStyle(s).zIndex) || 0;
-    // Expand the rail the same way hover does and read its stacking.
+    // Force the expanded state (matches :hover and the pinned rail) and read it.
     s.classList.add('sidebar-expanded');
     const expandedZ = parseInt(window.getComputedStyle(s).zIndex) || 0;
-    s.classList.remove('sidebar-expanded');
     return {
       headerTop: Math.round(hb.y),
       sidebarTop: Math.round(sb.y),
       headerZ,
-      collapsedZ,
       expandedZ,
     };
   });
@@ -42,8 +35,6 @@ test('expanded sidebar layers above the header (covers the logo)', async ({ page
     // Both anchor at the very top of the page.
     expect(info.headerTop).toBeLessThanOrEqual(1);
     expect(info.sidebarTop).toBeLessThanOrEqual(1);
-    // Collapsed: the header is at least as high, so the rail doesn't cover it.
-    expect(info.headerZ).toBeGreaterThanOrEqual(info.collapsedZ);
     // Expanded: the rail lifts above the header so it covers the logo.
     expect(info.expandedZ).toBeGreaterThan(info.headerZ);
   }


### PR DESCRIPTION
On desktop the collapsed rail expands on hover to 220px and overlaps the top-header logo. The header is a flex item with z-index:1050, which (per the flex-item rules) applies even though it's position:static and creates a stacking context above the sidebar's z-index:1040 — so the expanded panel slid behind the logo. Lift the rail to z-index:1060 in its :hover and .sidebar-expanded states so the panel covers the logo. Still well below modals (9999). Verified in-browser (elementFromPoint + visual).