### PR TITLE
perf(images): lossy WebP thumbnails, versioned cache, eager loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/apokalyptik/phpass v0.0.0-20140806224508-cd4a744fe20c
 	github.com/disintegration/imaging v1.6.2
 	github.com/drexedam/gravatar v0.0.0-20210327211422-e94eea8c338e
+	github.com/gen2brain/webp v0.6.4
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-ego/gse v1.0.2
 	github.com/go-webauthn/webauthn v0.17.4
@@ -51,6 +52,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-webauthn/x v0.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,14 @@ github.com/drexedam/gravatar v0.0.0-20210327211422-e94eea8c338e h1:2R8DvYLNr5DL2
 github.com/drexedam/gravatar v0.0.0-20210327211422-e94eea8c338e/go.mod h1:YjikoytuRI4q+GRd3xrOrKJN+Ayi2dwRomHLDDeMHfs=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
+github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/gen2brain/webp v0.6.4 h1:SUDdmxADOAiPQ+5ylNmuHhuYf2dOi0KgKZHL5vpVCNU=
+github.com/gen2brain/webp v0.6.4/go.mod h1:iGWMaCSw7t3I/Cv9llzEKmpnR36S8lS8VL/ZVjxU0JE=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
 github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-ego/gse v1.0.2 h1:+27lYFPhQEhA9igtdOsJPRKYL/k3TwYsxBF5jr6KFv4=

--- a/internal/models/schematic.go
+++ b/internal/models/schematic.go
@@ -52,6 +52,9 @@ type Schematic struct {
 	ShortCode            string             `json:"shortCode,omitempty"`
 	ModerationState      string             `json:"-"`
 	Language             string             `json:"-"`
+	// EagerImage marks cards rendered above the fold: their thumbnails get
+	// loading="eager" fetchpriority="high" instead of lazy-loading.
+	EagerImage           bool               `json:"-"`
 }
 
 // ModerationChatMessage holds a single message in the moderation discussion thread.

--- a/internal/pages/api_schematic_edit.go
+++ b/internal/pages/api_schematic_edit.go
@@ -549,10 +549,7 @@ func convertToWebP(data []byte, filename string) ([]byte, string, string, error)
 
 	var out bytes.Buffer
 	bw := bufio.NewWriter(&out)
-	if err := imgconv.Write(bw, img, &imgconv.FormatOption{
-		Format:       imgconv.WEBP,
-		EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)},
-	}); err != nil {
+	if err := encodeWebP(bw, img); err != nil {
 		return data, filename, http.DetectContentType(data), nil
 	}
 	_ = bw.Flush()

--- a/internal/pages/collections_collage.go
+++ b/internal/pages/collections_collage.go
@@ -125,7 +125,7 @@ func generateCollectionCollage(storageSvc *storage.Service, appStore *store.Stor
 
 	var out bytes.Buffer
 	bw := bufio.NewWriter(&out)
-	if err := imgconv.Write(bw, dst, &imgconv.FormatOption{Format: imgconv.WEBP, EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)}}); err != nil {
+	if err := encodeWebP(bw, dst); err != nil {
 		slog.Error("collage: failed to encode", "error", err)
 		return
 	}

--- a/internal/pages/collections_create.go
+++ b/internal/pages/collections_create.go
@@ -110,7 +110,7 @@ func CollectionsCreateHandler(registry *server.Registry, cacheService *cache.Ser
 			draw.CatmullRom.Scale(dst, dst.Bounds(), cropped, cropped.Bounds(), draw.Over, nil)
 			var out bytes.Buffer
 			bw := bufio.NewWriter(&out)
-			if err := imgconv.Write(bw, dst, &imgconv.FormatOption{Format: imgconv.WEBP, EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)}}); err != nil {
+			if err := encodeWebP(bw, dst); err != nil {
 				return e.String(http.StatusInternalServerError, "failed to encode banner image")
 			}
 			_ = bw.Flush()

--- a/internal/pages/collections_edit.go
+++ b/internal/pages/collections_edit.go
@@ -224,7 +224,7 @@ func CollectionsUpdateHandler(registry *server.Registry, cacheService *cache.Ser
 			draw.CatmullRom.Scale(dst, dst.Bounds(), cropped, cropped.Bounds(), draw.Over, nil)
 			var out bytes.Buffer
 			bw := bufio.NewWriter(&out)
-			if err := imgconv.Write(bw, dst, &imgconv.FormatOption{Format: imgconv.WEBP, EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)}}); err != nil {
+			if err := encodeWebP(bw, dst); err != nil {
 				return e.String(http.StatusInternalServerError, "failed to encode banner image")
 			}
 			_ = bw.Flush()

--- a/internal/pages/files.go
+++ b/internal/pages/files.go
@@ -22,13 +22,22 @@ import (
 	"createmod/internal/storage"
 
 	"github.com/disintegration/imaging"
-	"github.com/sunshineplan/imgconv"
 )
 
 const (
 	maxThumbWidth  = 1920
 	maxThumbHeight = 1080
+
+	// thumbsVersion namespaces the S3 thumbnail cache. Bump it when the
+	// encoding changes so stale thumbnails regenerate lazily instead of
+	// being served forever. v2: lossless WebP -> lossy q80.
+	thumbsVersion = "v2"
 )
+
+// thumbS3Key returns the S3 key for a cached thumbnail.
+func thumbS3Key(s3Collection, recordID string, w, h int, filename string) string {
+	return fmt.Sprintf("_thumbs/%s/%s/%s/%dx%d_%s.webp", thumbsVersion, s3Collection, recordID, w, h, filename)
+}
 
 // FileServingHandler serves files from S3 with optional ?thumb=WxH image resizing.
 // URL pattern: GET /api/files/{collection}/{recordID}/{filename}
@@ -56,7 +65,7 @@ func FileServingHandler(storageSvc *storage.Service) func(e *server.RequestEvent
 		// Compute ETag from path components (files are immutable by content hash)
 		etagInput := collection + "/" + recordID + "/" + filename
 		if thumbW > 0 || thumbH > 0 {
-			etagInput += fmt.Sprintf("?thumb=%dx%d", thumbW, thumbH)
+			etagInput += fmt.Sprintf("?thumb=%dx%d&%s", thumbW, thumbH, thumbsVersion)
 		}
 		h := sha256.Sum256([]byte(etagInput))
 		etag := `"` + hex.EncodeToString(h[:8]) + `"`
@@ -95,7 +104,7 @@ func FileServingHandler(storageSvc *storage.Service) func(e *server.RequestEvent
 		}
 
 		// Thumbnail requested — check cache, generate if missing
-		thumbKey := fmt.Sprintf("_thumbs/%s/%s/%dx%d_%s.webp", s3Collection, recordID, thumbW, thumbH, filename)
+		thumbKey := thumbS3Key(s3Collection, recordID, thumbW, thumbH, filename)
 
 		// Try cached thumbnail first
 		ctx := e.Request.Context()
@@ -144,10 +153,7 @@ func FileServingHandler(storageSvc *storage.Service) func(e *server.RequestEvent
 		thumbContentType := "image/webp"
 
 		bw := bufio.NewWriter(&thumbBuf)
-		if err := imgconv.Write(bw, resized, &imgconv.FormatOption{
-			Format:       imgconv.WEBP,
-			EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)},
-		}); err != nil {
+		if err := encodeWebP(bw, resized); err != nil {
 			return e.String(http.StatusNotFound, "file not found")
 		}
 		_ = bw.Flush()
@@ -218,7 +224,7 @@ func PrewarmThumbnails(storageSvc *storage.Service, schematicID, filename string
 
 	for _, size := range prewarmSizes {
 		w, h := size[0], size[1]
-		thumbKey := fmt.Sprintf("_thumbs/%s/%s/%dx%d_%s.webp", s3Collection, schematicID, w, h, filename)
+		thumbKey := thumbS3Key(s3Collection, schematicID, w, h, filename)
 
 		if exists, _ := storageSvc.ExistsRaw(ctx, thumbKey); exists {
 			continue
@@ -228,10 +234,7 @@ func PrewarmThumbnails(storageSvc *storage.Service, schematicID, filename string
 
 		var buf bytes.Buffer
 		bw := bufio.NewWriter(&buf)
-		if err := imgconv.Write(bw, resized, &imgconv.FormatOption{
-			Format:       imgconv.WEBP,
-			EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)},
-		}); err != nil {
+		if err := encodeWebP(bw, resized); err != nil {
 			continue
 		}
 		_ = bw.Flush()

--- a/internal/pages/guides_create.go
+++ b/internal/pages/guides_create.go
@@ -144,7 +144,7 @@ func GuidesCreateHandler(cacheService *cache.Service, appStore *store.Store, sto
 			draw.CatmullRom.Scale(dst, dst.Bounds(), cropped, cropped.Bounds(), draw.Over, nil)
 			var out bytes.Buffer
 			bw := bufio.NewWriter(&out)
-			if err := imgconv.Write(bw, dst, &imgconv.FormatOption{Format: imgconv.WEBP, EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)}}); err != nil {
+			if err := encodeWebP(bw, dst); err != nil {
 				return e.String(http.StatusInternalServerError, "failed to encode banner image")
 			}
 			_ = bw.Flush()

--- a/internal/pages/guides_edit.go
+++ b/internal/pages/guides_edit.go
@@ -188,7 +188,7 @@ func GuidesUpdateHandler(cacheService *cache.Service, appStore *store.Store, sto
 			draw.CatmullRom.Scale(dst, dst.Bounds(), cropped, cropped.Bounds(), draw.Over, nil)
 			var out bytes.Buffer
 			bw := bufio.NewWriter(&out)
-			if err := imgconv.Write(bw, dst, &imgconv.FormatOption{Format: imgconv.WEBP, EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)}}); err != nil {
+			if err := encodeWebP(bw, dst); err != nil {
 				return e.String(http.StatusInternalServerError, "failed to encode banner image")
 			}
 			_ = bw.Flush()

--- a/internal/pages/index.go
+++ b/internal/pages/index.go
@@ -271,6 +271,16 @@ func IndexHandler(cacheService *cache.Service, registry *server.Registry, appSto
 			return iFull && !jFull
 		})
 
+		// The trending grid is the first section on the page; its first three
+		// rows (4 cards per row at desktop width) are above the fold and
+		// should not lazy-load.
+		for i := range trendingSchematics {
+			if i >= 12 {
+				break
+			}
+			trendingSchematics[i].EagerImage = true
+		}
+
 		d := IndexData{
 			Schematics:       latestSchematics,
 			Trending:         trendingSchematics,

--- a/internal/pages/schematic_card_eager_template_test.go
+++ b/internal/pages/schematic_card_eager_template_test.go
@@ -1,0 +1,86 @@
+package pages
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"createmod/internal/models"
+)
+
+func renderIndexWithTrending(t *testing.T, trending []models.Schematic) string {
+	t.Helper()
+	r := NewTestRegistry()
+
+	files := append([]string{
+		"./template/index.html",
+		"./template/include/schematic_card.html",
+		"./template/include/schematic_card_small.html",
+	}, commonTemplates...)
+
+	root := projectRootFromThisFile(t)
+	var paths []string
+	for _, f := range files {
+		paths = append(paths, filepath.Join(root, f))
+	}
+
+	d := IndexData{Trending: trending}
+	d.DefaultData.Language = "en"
+	d.Title = "Home"
+
+	out, err := r.LoadFiles(paths...).Render(d)
+	if err != nil {
+		t.Fatalf("render index.html failed: %v", err)
+	}
+	return out
+}
+
+func Test_Schematic_Card_Eager_Image_Loading(t *testing.T) {
+	trending := make([]models.Schematic, 14)
+	for i := range trending {
+		trending[i] = models.Schematic{
+			ID:            fmt.Sprintf("id%02d", i),
+			Name:          fmt.Sprintf("name-%02d", i),
+			Title:         fmt.Sprintf("Title %02d", i),
+			FeaturedImage: "img.png",
+			Language:      "en",
+		}
+		if i < 12 {
+			trending[i].EagerImage = true
+		}
+	}
+
+	out := renderIndexWithTrending(t, trending)
+
+	if got := strings.Count(out, `fetchpriority="high"`); got != 12 {
+		t.Fatalf("expected 12 fetchpriority=high thumbnails, got %d", got)
+	}
+	// Each eager card has two eager imgs (placeholder + thumbnail).
+	if got := strings.Count(out, `loading="eager"`); got != 24 {
+		t.Fatalf("expected 24 eager-loading imgs, got %d", got)
+	}
+	// The remaining 2 cards stay lazy (2 imgs each).
+	if got := strings.Count(out, `loading="lazy"`); got != 4 {
+		t.Fatalf("expected 4 lazy-loading imgs, got %d", got)
+	}
+}
+
+func Test_Schematic_Card_Thumb_URLs_Versioned(t *testing.T) {
+	trending := []models.Schematic{{
+		ID:            "id01",
+		Name:          "name-01",
+		Title:         "Title 01",
+		FeaturedImage: "img.png",
+		Language:      "en",
+	}}
+
+	out := renderIndexWithTrending(t, trending)
+
+	if !strings.Contains(out, "?thumb=320x180&v=2") {
+		t.Fatalf("expected thumbnail URLs to carry the v=2 cache-bust parameter")
+	}
+	if strings.Contains(out, `?thumb=320x180"`) {
+		t.Fatalf("found unversioned thumbnail URL; all thumb URLs must include v=2")
+	}
+}

--- a/internal/pages/trending_page.go
+++ b/internal/pages/trending_page.go
@@ -279,7 +279,7 @@ func GenerateFeedOGImage(storageSvc *storage.Service, appStore *store.Store, cac
 
 	var out bytes.Buffer
 	bw := bufio.NewWriter(&out)
-	if err := imgconv.Write(bw, dst, &imgconv.FormatOption{Format: imgconv.WEBP, EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)}}); err != nil {
+	if err := encodeWebP(bw, dst); err != nil {
 		slog.Error("feed OG: failed to encode", "error", err)
 		return
 	}

--- a/internal/pages/webp_encode.go
+++ b/internal/pages/webp_encode.go
@@ -1,0 +1,18 @@
+package pages
+
+import (
+	"image"
+	"io"
+
+	"github.com/gen2brain/webp"
+)
+
+// webpQuality is the lossy quality used for all generated WebP images.
+const webpQuality = 80
+
+// encodeWebP writes img as lossy WebP. Do not use imgconv for WebP output:
+// its nativewebp backend is lossless-only and silently ignores the quality
+// option, producing files 5-20x larger than lossy at equal visual quality.
+func encodeWebP(w io.Writer, img image.Image) error {
+	return webp.Encode(w, img, webp.Options{Quality: webpQuality, Method: webp.DefaultMethod})
+}

--- a/internal/pages/youtube_thumbnail.go
+++ b/internal/pages/youtube_thumbnail.go
@@ -79,10 +79,7 @@ func recoverYouTubeThumbnail(appStore *store.Store, storageSvc *storage.Service,
 
 		var out bytes.Buffer
 		bw := bufio.NewWriter(&out)
-		if err := imgconv.Write(bw, img, &imgconv.FormatOption{
-			Format:       imgconv.WEBP,
-			EncodeOption: []imgconv.EncodeOption{imgconv.Quality(80)},
-		}); err != nil {
+		if err := encodeWebP(bw, img); err != nil {
 			slog.Error("youtube thumbnail recovery: failed to encode WebP",
 				"schematic_id", schematicID, "error", err)
 			return

--- a/template/admin_dashboard.html
+++ b/template/admin_dashboard.html
@@ -157,7 +157,7 @@
                 <tr>
                   <td>
                     {{if .FeaturedImage}}
-                    <span class="avatar avatar-sm" style="background-image: url(/api/files/schematics/{{.ID}}/{{urlPathEscape .FeaturedImage}}?thumb=40x40)"></span>
+                    <span class="avatar avatar-sm" style="background-image: url(/api/files/schematics/{{.ID}}/{{urlPathEscape .FeaturedImage}}?thumb=40x40&v=2)"></span>
                     {{end}}
                   </td>
                   <td>

--- a/template/admin_schematic_edit.html
+++ b/template/admin_schematic_edit.html
@@ -111,7 +111,7 @@
                   </div>
                   {{if .Schematic.FeaturedImage}}
                   <div class="mb-2">
-                    <img src="/api/files/schematics/{{.Schematic.ID}}/{{urlPathEscape .Schematic.FeaturedImage}}?thumb=200x200" class="img-fluid rounded" alt="thumbnail">
+                    <img src="/api/files/schematics/{{.Schematic.ID}}/{{urlPathEscape .Schematic.FeaturedImage}}?thumb=200x200&v=2" class="img-fluid rounded" alt="thumbnail">
                   </div>
                   {{end}}
                   <div class="mb-2">
@@ -127,7 +127,7 @@
                   <div class="mb-3">
                     <label class="form-label">{{ T .Language "Featured Image" }}</label>
                     <div class="d-flex align-items-start gap-2">
-                      <img src="/api/files/schematics/{{.Schematic.ID}}/{{urlPathEscape .Schematic.FeaturedImage}}?thumb=120x120" class="rounded" alt="Featured" style="max-width:120px;max-height:120px;">
+                      <img src="/api/files/schematics/{{.Schematic.ID}}/{{urlPathEscape .Schematic.FeaturedImage}}?thumb=120x120&v=2" class="rounded" alt="Featured" style="max-width:120px;max-height:120px;">
                       <label class="form-check">
                         <input type="checkbox" class="form-check-input" name="remove_featured_image" value="true">
                         <span class="form-check-label text-danger">{{ T .Language "Remove" }}</span>
@@ -141,7 +141,7 @@
                     <div class="d-flex flex-wrap gap-2">
                       {{range .Schematic.Gallery}}
                       <div class="position-relative">
-                        <img src="/api/files/schematics/{{$.Schematic.ID}}/{{urlPathEscape .}}?thumb=80x80" class="rounded" alt="Gallery" style="width:80px;height:80px;object-fit:cover;">
+                        <img src="/api/files/schematics/{{$.Schematic.ID}}/{{urlPathEscape .}}?thumb=80x80&v=2" class="rounded" alt="Gallery" style="width:80px;height:80px;object-fit:cover;">
                         <div class="mt-1">
                           <label class="form-check" style="font-size:0.75rem;">
                             <input type="checkbox" class="form-check-input" name="remove_gallery_images" value="{{.}}">

--- a/template/admin_schematics.html
+++ b/template/admin_schematics.html
@@ -101,7 +101,7 @@
                 <tr>
                   <td>
                     {{if .FeaturedImage}}
-                    <span class="avatar avatar-sm" style="background-image: url(/api/files/schematics/{{.ID}}/{{urlPathEscape .FeaturedImage}}?thumb=40x40)"></span>
+                    <span class="avatar avatar-sm" style="background-image: url(/api/files/schematics/{{.ID}}/{{urlPathEscape .FeaturedImage}}?thumb=40x40&v=2)"></span>
                     {{end}}
                   </td>
                   <td>

--- a/template/collections_edit.html
+++ b/template/collections_edit.html
@@ -86,7 +86,7 @@
                   <li class="list-group-item d-flex align-items-center gap-2"
                       draggable="true" data-id="{{ .ID }}" style="cursor: grab;">
                     <span class="me-1 text-secondary" aria-hidden="true">&#x2195;</span>
-                    <img src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=80x45"
+                    <img src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=80x45&v=2"
                          alt="" width="80" height="45" class="rounded"
                          style="object-fit: cover; flex-shrink: 0;" />
                     <span class="flex-fill text-truncate">{{ .Title }}</span>

--- a/template/editschematic.html
+++ b/template/editschematic.html
@@ -99,14 +99,14 @@
                                             <div class="image-upload-grid" id="edit-image-grid">
                                                 {{ if .Schematic.FeaturedImage }}
                                                 <div class="image-upload-item is-featured existing-img" data-filename="{{ .Schematic.FeaturedImage }}" data-type="featured" title="Featured image">
-                                                    <img src="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=200x200" alt="Featured image">
+                                                    <img src="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=200x200&v=2" alt="Featured image">
                                                     <span class="featured-badge">Featured</span>
                                                     <button type="button" class="remove-btn" title="Remove image">&times;</button>
                                                 </div>
                                                 {{ end }}
                                                 {{ range .Schematic.Gallery }}
                                                 <div class="image-upload-item existing-img" data-filename="{{ . }}" data-type="gallery" title="Click to set as featured">
-                                                    <img src="/api/files/schematics/{{ $.Schematic.ID }}/{{ urlPathEscape . }}?thumb=200x200" alt="Gallery image">
+                                                    <img src="/api/files/schematics/{{ $.Schematic.ID }}/{{ urlPathEscape . }}?thumb=200x200&v=2" alt="Gallery image">
                                                     <button type="button" class="remove-btn" title="Remove image">&times;</button>
                                                 </div>
                                                 {{ end }}

--- a/template/explore.html
+++ b/template/explore.html
@@ -44,7 +44,7 @@
                     {{range $i, $image := .Images }}
                         <a class="explore-item" href="/schematics/{{ $image.Name }}" title="{{ $image.Title }}">
                             <img class="lazy"
-                                 data-src="/api/files/schematics/{{ $image.ID }}/{{ urlPathEscape $image.Image }}{{ if eq $image.Size "lg" }}?thumb=640x0{{ else if eq $image.Size "md" }}?thumb=400x0{{ else }}?thumb=320x0{{ end }}"
+                                 data-src="/api/files/schematics/{{ $image.ID }}/{{ urlPathEscape $image.Image }}{{ if eq $image.Size "lg" }}?thumb=640x0&v=2{{ else if eq $image.Size "md" }}?thumb=400x0&v=2{{ else }}?thumb=320x0&v=2{{ end }}"
                                  alt="{{ $image.Title }}"
                                  onerror="this.parentElement.remove()">
                         </a>
@@ -81,9 +81,9 @@
   var loading = false;
 
   function thumbParam(size) {
-    if (size === 'lg') return '?thumb=640x0';
-    if (size === 'md') return '?thumb=400x0';
-    return '?thumb=320x0';
+    if (size === 'lg') return '?thumb=640x0&v=2';
+    if (size === 'md') return '?thumb=400x0&v=2';
+    return '?thumb=320x0&v=2';
   }
 
   function appendImages(images) {

--- a/template/include/schematic_card.html
+++ b/template/include/schematic_card.html
@@ -2,10 +2,10 @@
 <a href="{{ LangURL .Language "/schematics" }}/{{ .Name }}" class="d-block text-decoration-none">
   <div class="card card-sm card-hover-lift overflow-hidden">
     <div class="card-body-borderless ratio ratio-16x9">
-      <img loading="lazy" src="{{ PlaceholderImg .ID }}" alt="" class="object-fit-cover" width="640" height="360" style="z-index:0;">
+      <img loading="{{ if .EagerImage }}eager{{ else }}lazy{{ end }}" src="{{ PlaceholderImg .ID }}" alt="" class="object-fit-cover" width="640" height="360" style="z-index:0;">
       {{ if ne .FeaturedImage "" }}
-      <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180"
-           srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360 640w"
+      <img loading="{{ if .EagerImage }}eager{{ else }}lazy{{ end }}"{{ if .EagerImage }} fetchpriority="high"{{ end }} src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180&v=2"
+           srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180&v=2 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360&v=2 640w"
            sizes="(max-width: 767px) 100vw, (max-width: 991px) 50vw, (max-width: 1199px) 33vw, 25vw"
            alt="Featured image of {{ .Title }}" class="object-fit-cover" width="640" height="360" style="z-index:1;"
            onerror="this.style.display='none'">

--- a/template/include/schematic_card_featured.html
+++ b/template/include/schematic_card_featured.html
@@ -5,8 +5,8 @@
       <div class="ratio ratio-16x9">
         <img loading="lazy" src="{{ PlaceholderImg .ID }}" alt="" class="object-fit-cover" width="640" height="360" style="z-index:0;">
         {{ if ne .FeaturedImage "" }}
-        <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180"
-             srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360 640w"
+        <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180&v=2"
+             srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180&v=2 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360&v=2 640w"
              sizes="(max-width: 767px) 100vw, 33vw"
              alt="Featured image of {{ .Title }}" class="object-fit-cover" width="640" height="360" style="z-index:1;"
              onerror="this.style.display='none'">

--- a/template/include/schematic_card_list.html
+++ b/template/include/schematic_card_list.html
@@ -3,7 +3,7 @@
   <div class="flex-shrink-0" style="width: 120px; height: 68px; position:relative;">
     <img loading="lazy" src="{{ PlaceholderImg .ID }}" alt="" class="object-fit-cover" width="120" height="68" style="position:absolute;inset:0;width:120px;height:68px;border-radius:.4rem;z-index:0;">
     {{ if ne .FeaturedImage "" }}
-    <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=240x136"
+    <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=240x136&v=2"
          alt="Featured image of {{ .Title }}" class="object-fit-cover" width="120" height="68" style="position:absolute;inset:0;width:120px;height:68px;border-radius:.4rem;z-index:1;"
          onerror="this.style.display='none'">
     {{ end }}

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -1,8 +1,8 @@
 {{template "head.html" .}}
 <!-- Preload the LCP image so the browser starts fetching it immediately -->
 {{ if ne .Schematic.FeaturedImage "" }}
-<link rel="preload" as="image" href="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540"
-      imagesrcset="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=640x360 640w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540 960w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=1920x1080 1920w"
+<link rel="preload" as="image" href="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540&v=2"
+      imagesrcset="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=640x360&v=2 640w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540&v=2 960w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=1920x1080&v=2 1920w"
       imagesizes="(max-width: 767px) 100vw, (max-width: 1199px) 60vw, 50vw" fetchpriority="high">
 {{ end }}
 <!-- Non-critical page-specific CSS loaded async -->
@@ -129,7 +129,7 @@
                             <!-- 360° Rotation Viewer -->
                             <div class="rotation-viewer" id="rotation-viewer">
                                 <div class="ratio ratio-16x9">
-                                    <img id="rotation-img" src="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape (index .Schematic.RotationImages 0) }}?thumb=960x540" alt="360° view of {{ .Schematic.Title }}" class="object-fit-cover" style="user-select:none;-webkit-user-drag:none;">
+                                    <img id="rotation-img" src="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape (index .Schematic.RotationImages 0) }}?thumb=960x540&v=2" alt="360° view of {{ .Schematic.Title }}" class="object-fit-cover" style="user-select:none;-webkit-user-drag:none;">
                                     <div class="rotation-loading" id="rotation-loading" style="display:none;">
                                         <div class="rotation-spinner"></div>
                                         <div class="rotation-loading-pct" id="rotation-loading-pct">0%</div>
@@ -164,7 +164,7 @@
                             </div>
                             <script>
                             (function(){
-                                var urls = [{{ range $i, $img := .Schematic.RotationImages }}{{ if $i }},{{ end }}"/api/files/schematics/{{ $.Schematic.ID }}/{{ urlPathEscape $img }}?thumb=960x540"{{ end }}];
+                                var urls = [{{ range $i, $img := .Schematic.RotationImages }}{{ if $i }},{{ end }}"/api/files/schematics/{{ $.Schematic.ID }}/{{ urlPathEscape $img }}?thumb=960x540&v=2"{{ end }}];
                                 var total = urls.length;
                                 var images = new Array(total);
                                 var loaded = 0;
@@ -317,8 +317,8 @@
                                 <div class="ratio ratio-16x9">
                                 <img src="{{ PlaceholderImg .Schematic.ID }}" alt="" class="object-fit-cover" width="1920" height="1080" style="z-index:0;">
                                 <img
-                                        src="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540"
-                                        srcset="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=640x360 640w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540 960w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=1920x1080 1920w"
+                                        src="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540&v=2"
+                                        srcset="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=640x360&v=2 640w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540&v=2 960w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=1920x1080&v=2 1920w"
                                         sizes="(max-width: 767px) 100vw, (max-width: 1199px) 60vw, 50vw"
                                         class="card-img-top object-fit-cover" width="1920" height="1080" alt="Featured image of {{ .Schematic.Title }}" fetchpriority="high" style="z-index:1;"
                                         onerror="this.style.display='none'">
@@ -341,14 +341,14 @@
                                         <a class="gallery-strip-item" data-fslightbox="gallery" hx-boost="false"
                                            href="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}">
                                             <div class="gallery-strip-thumb"
-                                                 style="background-image: url('/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=300x300')"></div>
+                                                 style="background-image: url('/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=300x300&v=2')"></div>
                                         </a>
                                         {{ end }}
                                         {{ range .Schematic.Gallery }}
                                         <a class="gallery-strip-item" data-fslightbox="gallery" hx-boost="false"
                                            href="/api/files/schematics/{{ $.Schematic.ID }}/{{ urlPathEscape . }}">
                                             <div class="gallery-strip-thumb"
-                                                 style="background-image: url('/api/files/schematics/{{ $.Schematic.ID }}/{{ urlPathEscape . }}?thumb=300x300')"></div>
+                                                 style="background-image: url('/api/files/schematics/{{ $.Schematic.ID }}/{{ urlPathEscape . }}?thumb=300x300&v=2')"></div>
                                         </a>
                                         {{ end }}
                                     </div>

--- a/template/user-statistics.html
+++ b/template/user-statistics.html
@@ -120,7 +120,7 @@
                                                     <tr class="cursor-pointer" onclick="window.location='/schematics/{{ .Name }}'">
                                                         <td class="w-1">
                                                             {{ if ne .FeaturedImage "" }}
-                                                            <span class="avatar" style="background-image: url(/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=40x40)"></span>
+                                                            <span class="avatar" style="background-image: url(/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=40x40&v=2)"></span>
                                                             {{ else }}
                                                             <span class="avatar">{{ slice .Title 0 1 }}</span>
                                                             {{ end }}


### PR DESCRIPTION
Thumbnails were encoded as lossless WebP: imgconv's nativewebp backend only supports lossless output and silently ignores Quality(80), making listing thumbnails 5-20x heavier than intended (320x180 averaged 63KB live, 640x360 up to 300KB). Cloudflare cached them fine — the bytes themselves were the bottleneck on slower connections.

- Encode all generated WebP through a shared encodeWebP helper using gen2brain/webp (libwebp via WASM, no CGo) at lossy q80 (~84% smaller)
- Bump the S3 thumbnail cache to _thumbs/v2/ so stale lossless thumbs regenerate lazily; fold the version into thumbnail ETags
- Append v=2 to every ?thumb= URL in templates to bust Cloudflare's year-long edge cache of the old heavy files
- Eager-load the first 3 rows (12 cards) of the homepage trending grid with fetchpriority=high instead of lazy-loading everything