### PR TITLE
feat(admin): API key oversight with usage stats and per-key rate limits

### DIFF
--- a/internal/database/gen/api_keys.sql.go
+++ b/internal/database/gen/api_keys.sql.go
@@ -7,12 +7,13 @@ package db
 
 import (
 	"context"
+	"time"
 )
 
 const createAPIKey = `-- name: CreateAPIKey :one
 INSERT INTO api_keys (id, user_id, key_hash, label, last8)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, user_id, key_hash, label, last8, created, updated
+RETURNING id, user_id, key_hash, label, last8, created, updated, rate_limit_per_minute
 `
 
 type CreateAPIKeyParams struct {
@@ -40,6 +41,7 @@ func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (Api
 		&i.Last8,
 		&i.Created,
 		&i.Updated,
+		&i.RateLimitPerMinute,
 	)
 	return i, err
 }
@@ -59,7 +61,7 @@ func (q *Queries) DeleteAPIKey(ctx context.Context, arg DeleteAPIKeyParams) erro
 }
 
 const getAPIKeyByLast8 = `-- name: GetAPIKeyByLast8 :one
-SELECT id, user_id, key_hash, label, last8, created, updated FROM api_keys WHERE last8 = $1
+SELECT id, user_id, key_hash, label, last8, created, updated, rate_limit_per_minute FROM api_keys WHERE last8 = $1
 `
 
 func (q *Queries) GetAPIKeyByLast8(ctx context.Context, last8 string) (ApiKey, error) {
@@ -73,12 +75,53 @@ func (q *Queries) GetAPIKeyByLast8(ctx context.Context, last8 string) (ApiKey, e
 		&i.Last8,
 		&i.Created,
 		&i.Updated,
+		&i.RateLimitPerMinute,
 	)
 	return i, err
 }
 
+const listAPIKeyUsageByEndpoint = `-- name: ListAPIKeyUsageByEndpoint :many
+SELECT api_key_id, endpoint, COUNT(*)::BIGINT AS requests, COALESCE(MAX(created), '0001-01-01 00:00:00+00')::TIMESTAMPTZ AS last_used
+FROM api_key_usage
+WHERE created > NOW() - INTERVAL '30 days'
+GROUP BY api_key_id, endpoint
+ORDER BY api_key_id, requests DESC
+`
+
+type ListAPIKeyUsageByEndpointRow struct {
+	ApiKeyID string    `json:"api_key_id"`
+	Endpoint string    `json:"endpoint"`
+	Requests int64     `json:"requests"`
+	LastUsed time.Time `json:"last_used"`
+}
+
+func (q *Queries) ListAPIKeyUsageByEndpoint(ctx context.Context) ([]ListAPIKeyUsageByEndpointRow, error) {
+	rows, err := q.db.Query(ctx, listAPIKeyUsageByEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAPIKeyUsageByEndpointRow{}
+	for rows.Next() {
+		var i ListAPIKeyUsageByEndpointRow
+		if err := rows.Scan(
+			&i.ApiKeyID,
+			&i.Endpoint,
+			&i.Requests,
+			&i.LastUsed,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAPIKeysByUser = `-- name: ListAPIKeysByUser :many
-SELECT id, user_id, key_hash, label, last8, created, updated FROM api_keys WHERE user_id = $1 ORDER BY created DESC
+SELECT id, user_id, key_hash, label, last8, created, updated, rate_limit_per_minute FROM api_keys WHERE user_id = $1 ORDER BY created DESC
 `
 
 func (q *Queries) ListAPIKeysByUser(ctx context.Context, userID string) ([]ApiKey, error) {
@@ -98,6 +141,73 @@ func (q *Queries) ListAPIKeysByUser(ctx context.Context, userID string) ([]ApiKe
 			&i.Last8,
 			&i.Created,
 			&i.Updated,
+			&i.RateLimitPerMinute,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAllAPIKeysWithUsage = `-- name: ListAllAPIKeysWithUsage :many
+SELECT k.id, k.user_id, k.label, k.last8, k.created, k.rate_limit_per_minute,
+       COALESCE(u.username, '') AS username,
+       COALESCE(us.total, 0)::BIGINT AS usage_total,
+       COALESCE(us.last_24h, 0)::BIGINT AS usage_24h,
+       COALESCE(us.last_7d, 0)::BIGINT AS usage_7d,
+       COALESCE(us.last_used, '0001-01-01 00:00:00+00')::TIMESTAMPTZ AS last_used
+FROM api_keys k
+LEFT JOIN users u ON u.id = k.user_id
+LEFT JOIN LATERAL (
+    SELECT COUNT(*) AS total,
+           COUNT(*) FILTER (WHERE created > NOW() - INTERVAL '24 hours') AS last_24h,
+           COUNT(*) FILTER (WHERE created > NOW() - INTERVAL '7 days') AS last_7d,
+           MAX(created) AS last_used
+    FROM api_key_usage
+    WHERE api_key_id = k.id
+) us ON TRUE
+ORDER BY k.created DESC
+`
+
+type ListAllAPIKeysWithUsageRow struct {
+	ID                 string    `json:"id"`
+	UserID             string    `json:"user_id"`
+	Label              string    `json:"label"`
+	Last8              string    `json:"last8"`
+	Created            time.Time `json:"created"`
+	RateLimitPerMinute int32     `json:"rate_limit_per_minute"`
+	Username           string    `json:"username"`
+	UsageTotal         int64     `json:"usage_total"`
+	Usage24h           int64     `json:"usage_24h"`
+	Usage7d            int64     `json:"usage_7d"`
+	LastUsed           time.Time `json:"last_used"`
+}
+
+func (q *Queries) ListAllAPIKeysWithUsage(ctx context.Context) ([]ListAllAPIKeysWithUsageRow, error) {
+	rows, err := q.db.Query(ctx, listAllAPIKeysWithUsage)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAllAPIKeysWithUsageRow{}
+	for rows.Next() {
+		var i ListAllAPIKeysWithUsageRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.Label,
+			&i.Last8,
+			&i.Created,
+			&i.RateLimitPerMinute,
+			&i.Username,
+			&i.UsageTotal,
+			&i.Usage24h,
+			&i.Usage7d,
+			&i.LastUsed,
 		); err != nil {
 			return nil, err
 		}
@@ -122,5 +232,19 @@ type LogAPIKeyUsageParams struct {
 
 func (q *Queries) LogAPIKeyUsage(ctx context.Context, arg LogAPIKeyUsageParams) error {
 	_, err := q.db.Exec(ctx, logAPIKeyUsage, arg.ID, arg.ApiKeyID, arg.Endpoint)
+	return err
+}
+
+const updateAPIKeyRateLimit = `-- name: UpdateAPIKeyRateLimit :exec
+UPDATE api_keys SET rate_limit_per_minute = $2, updated = NOW() WHERE id = $1
+`
+
+type UpdateAPIKeyRateLimitParams struct {
+	ID                 string `json:"id"`
+	RateLimitPerMinute int32  `json:"rate_limit_per_minute"`
+}
+
+func (q *Queries) UpdateAPIKeyRateLimit(ctx context.Context, arg UpdateAPIKeyRateLimitParams) error {
+	_, err := q.db.Exec(ctx, updateAPIKeyRateLimit, arg.ID, arg.RateLimitPerMinute)
 	return err
 }

--- a/internal/database/gen/models.go
+++ b/internal/database/gen/models.go
@@ -31,13 +31,14 @@ type AdClick struct {
 }
 
 type ApiKey struct {
-	ID      string    `json:"id"`
-	UserID  string    `json:"user_id"`
-	KeyHash string    `json:"key_hash"`
-	Label   string    `json:"label"`
-	Last8   string    `json:"last8"`
-	Created time.Time `json:"created"`
-	Updated time.Time `json:"updated"`
+	ID                 string    `json:"id"`
+	UserID             string    `json:"user_id"`
+	KeyHash            string    `json:"key_hash"`
+	Label              string    `json:"label"`
+	Last8              string    `json:"last8"`
+	Created            time.Time `json:"created"`
+	Updated            time.Time `json:"updated"`
+	RateLimitPerMinute int32     `json:"rate_limit_per_minute"`
 }
 
 type ApiKeyUsage struct {
@@ -225,6 +226,16 @@ type ModMetadatum struct {
 	Created            time.Time          `json:"created"`
 	Updated            time.Time          `json:"updated"`
 	BlocksitemsMatched bool               `json:"blocksitems_matched"`
+}
+
+type ModSecret struct {
+	ID        string    `json:"id"`
+	Label     string    `json:"label"`
+	Note      string    `json:"note"`
+	Secret    string    `json:"secret"`
+	Active    bool      `json:"active"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type ModerationLog struct {

--- a/internal/database/gen/querier.go
+++ b/internal/database/gen/querier.go
@@ -255,11 +255,13 @@ type Querier interface {
 	IncrementSchematicDownloads(ctx context.Context, id string) error
 	IncrementWebhookFailure(ctx context.Context, arg IncrementWebhookFailureParams) error
 	IsFollowing(ctx context.Context, arg IsFollowingParams) (bool, error)
+	ListAPIKeyUsageByEndpoint(ctx context.Context) ([]ListAPIKeyUsageByEndpointRow, error)
 	ListAPIKeysByUser(ctx context.Context, userID string) ([]ApiKey, error)
 	ListAchievements(ctx context.Context) ([]Achievement, error)
 	ListActiveSearchAlerts(ctx context.Context, limit int32) ([]SearchAlert, error)
 	ListActiveUserWebhooks(ctx context.Context) ([]ListActiveUserWebhooksRow, error)
 	ListAdminEmails(ctx context.Context) ([]string, error)
+	ListAllAPIKeysWithUsage(ctx context.Context) ([]ListAllAPIKeysWithUsageRow, error)
 	ListAllApprovedSchematicsForIndex(ctx context.Context) ([]Schematic, error)
 	ListAllCategories(ctx context.Context) ([]SchematicCategory, error)
 	ListAllTags(ctx context.Context) ([]SchematicTag, error)
@@ -420,6 +422,7 @@ type Querier interface {
 	UnsubscribeFollow(ctx context.Context, unsubscribeToken string) error
 	UnsubscribeNewsletter(ctx context.Context, unsubscribeToken string) error
 	UnsubscribeSearchAlert(ctx context.Context, unsubscribeToken string) error
+	UpdateAPIKeyRateLimit(ctx context.Context, arg UpdateAPIKeyRateLimitParams) error
 	UpdateCollection(ctx context.Context, arg UpdateCollectionParams) (Collection, error)
 	UpdateCollectionCollageURL(ctx context.Context, arg UpdateCollectionCollageURLParams) error
 	UpdateFollowFrequency(ctx context.Context, arg UpdateFollowFrequencyParams) error

--- a/internal/database/migrations/073_api_key_rate_limits.down.sql
+++ b/internal/database/migrations/073_api_key_rate_limits.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_api_key_usage_key_created;
+ALTER TABLE api_keys DROP COLUMN IF EXISTS rate_limit_per_minute;

--- a/internal/database/migrations/073_api_key_rate_limits.up.sql
+++ b/internal/database/migrations/073_api_key_rate_limits.up.sql
@@ -1,0 +1,6 @@
+-- Admin-managed per-key rate limit override. 0 means "use the endpoint default".
+ALTER TABLE api_keys ADD COLUMN rate_limit_per_minute INTEGER NOT NULL DEFAULT 0;
+
+-- Supports per-key usage aggregates (counts within time windows, last-used)
+-- on the admin API keys page.
+CREATE INDEX idx_api_key_usage_key_created ON api_key_usage (api_key_id, created);

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -220,12 +220,13 @@ func reportFromDB(r db.Report) store.Report {
 
 func apiKeyFromDB(k db.ApiKey) store.APIKey {
 	return store.APIKey{
-		ID:      k.ID,
-		UserID:  k.UserID,
-		KeyHash: k.KeyHash,
-		Label:   k.Label,
-		Last8:   k.Last8,
-		Created: k.Created,
+		ID:                 k.ID,
+		UserID:             k.UserID,
+		KeyHash:            k.KeyHash,
+		Label:              k.Label,
+		Last8:              k.Last8,
+		Created:            k.Created,
+		RateLimitPerMinute: int(k.RateLimitPerMinute),
 	}
 }
 
@@ -3031,6 +3032,56 @@ func (as *APIKeyStoreImpl) LogUsage(ctx context.Context, apiKeyID, endpoint stri
 		ApiKeyID: apiKeyID,
 		Endpoint: endpoint,
 	})
+}
+
+func (as *APIKeyStoreImpl) ListAllWithUsage(ctx context.Context) ([]store.AdminAPIKey, error) {
+	rows, err := as.q.ListAllAPIKeysWithUsage(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.AdminAPIKey, len(rows))
+	for i, r := range rows {
+		result[i] = store.AdminAPIKey{
+			APIKey: store.APIKey{
+				ID:                 r.ID,
+				UserID:             r.UserID,
+				Label:              r.Label,
+				Last8:              r.Last8,
+				Created:            r.Created,
+				RateLimitPerMinute: int(r.RateLimitPerMinute),
+			},
+			Username:   r.Username,
+			UsageTotal: r.UsageTotal,
+			Usage24h:   r.Usage24h,
+			Usage7d:    r.Usage7d,
+			LastUsed:   r.LastUsed,
+		}
+	}
+	return result, nil
+}
+
+func (as *APIKeyStoreImpl) SetRateLimit(ctx context.Context, id string, perMinute int) error {
+	return as.q.UpdateAPIKeyRateLimit(ctx, db.UpdateAPIKeyRateLimitParams{
+		ID:                 id,
+		RateLimitPerMinute: int32(perMinute),
+	})
+}
+
+func (as *APIKeyStoreImpl) UsageByEndpoint(ctx context.Context) ([]store.APIKeyEndpointUsage, error) {
+	rows, err := as.q.ListAPIKeyUsageByEndpoint(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]store.APIKeyEndpointUsage, len(rows))
+	for i, r := range rows {
+		result[i] = store.APIKeyEndpointUsage{
+			APIKeyID: r.ApiKeyID,
+			Endpoint: r.Endpoint,
+			Requests: r.Requests,
+			LastUsed: r.LastUsed,
+		}
+	}
+	return result, nil
 }
 
 // AuthStoreImpl implements store.AuthStore.

--- a/internal/database/queries/api_keys.sql
+++ b/internal/database/queries/api_keys.sql
@@ -15,3 +15,32 @@ DELETE FROM api_keys WHERE id = $1 AND user_id = $2;
 -- name: LogAPIKeyUsage :exec
 INSERT INTO api_key_usage (id, api_key_id, endpoint)
 VALUES ($1, $2, $3);
+
+-- name: UpdateAPIKeyRateLimit :exec
+UPDATE api_keys SET rate_limit_per_minute = $2, updated = NOW() WHERE id = $1;
+
+-- name: ListAllAPIKeysWithUsage :many
+SELECT k.id, k.user_id, k.label, k.last8, k.created, k.rate_limit_per_minute,
+       COALESCE(u.username, '') AS username,
+       COALESCE(us.total, 0)::BIGINT AS usage_total,
+       COALESCE(us.last_24h, 0)::BIGINT AS usage_24h,
+       COALESCE(us.last_7d, 0)::BIGINT AS usage_7d,
+       COALESCE(us.last_used, '0001-01-01 00:00:00+00')::TIMESTAMPTZ AS last_used
+FROM api_keys k
+LEFT JOIN users u ON u.id = k.user_id
+LEFT JOIN LATERAL (
+    SELECT COUNT(*) AS total,
+           COUNT(*) FILTER (WHERE created > NOW() - INTERVAL '24 hours') AS last_24h,
+           COUNT(*) FILTER (WHERE created > NOW() - INTERVAL '7 days') AS last_7d,
+           MAX(created) AS last_used
+    FROM api_key_usage
+    WHERE api_key_id = k.id
+) us ON TRUE
+ORDER BY k.created DESC;
+
+-- name: ListAPIKeyUsageByEndpoint :many
+SELECT api_key_id, endpoint, COUNT(*)::BIGINT AS requests, COALESCE(MAX(created), '0001-01-01 00:00:00+00')::TIMESTAMPTZ AS last_used
+FROM api_key_usage
+WHERE created > NOW() - INTERVAL '30 days'
+GROUP BY api_key_id, endpoint
+ORDER BY api_key_id, requests DESC;

--- a/internal/pages/admin_api_keys.go
+++ b/internal/pages/admin_api_keys.go
@@ -1,0 +1,182 @@
+package pages
+
+import (
+	"context"
+	"createmod/internal/cache"
+	"createmod/internal/i18n"
+	"createmod/internal/server"
+	"createmod/internal/store"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+var adminAPIKeysTemplates = append([]string{
+	"./template/admin_api_keys.html",
+}, commonTemplates...)
+
+// defaultAPIRateLimitPerMinute is the per-key limit applied when no
+// admin-assigned override is set.
+const defaultAPIRateLimitPerMinute = 120
+
+// maxAPIRateLimitPerMinute caps admin-assigned overrides.
+const maxAPIRateLimitPerMinute = 1_000_000
+
+// AdminAPIKeyEndpointRow is one endpoint's usage for a key (last 30 days).
+type AdminAPIKeyEndpointRow struct {
+	Endpoint string
+	Requests int64
+	LastUsed string
+}
+
+// AdminAPIKeyRow is one API key shown in the admin list. Last8 is the only
+// key material exposed — the same display fragment users see on their own
+// settings page; never show more of the key.
+type AdminAPIKeyRow struct {
+	ID         string
+	Username   string
+	UserID     string
+	Label      string
+	Last8      string
+	Created    string
+	LastUsed   string // empty when the key has never been used
+	Usage24h   int64
+	Usage7d    int64
+	UsageTotal int64
+	RateLimit  int // 0 = endpoint default
+	Endpoints  []AdminAPIKeyEndpointRow
+}
+
+type AdminAPIKeysData struct {
+	DefaultData
+	Keys             []AdminAPIKeyRow
+	DefaultRateLimit int
+	Query            string
+}
+
+// filterAdminAPIKeyRows returns the rows whose username or label contains q
+// (case-insensitive). An empty q returns rows unchanged.
+func filterAdminAPIKeyRows(rows []AdminAPIKeyRow, q string) []AdminAPIKeyRow {
+	q = strings.ToLower(strings.TrimSpace(q))
+	if q == "" {
+		return rows
+	}
+	filtered := make([]AdminAPIKeyRow, 0, len(rows))
+	for _, r := range rows {
+		if strings.Contains(strings.ToLower(r.Username), q) || strings.Contains(strings.ToLower(r.Label), q) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+// AdminAPIKeysHandler renders the admin overview of all user API keys with
+// usage aggregates and per-key rate limit overrides.
+func AdminAPIKeysHandler(registry *server.Registry, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		ctx := context.Background()
+		keys, err := appStore.APIKeys.ListAllWithUsage(ctx)
+		if err != nil {
+			return e.String(http.StatusInternalServerError, "failed to list API keys")
+		}
+		endpointUsage, err := appStore.APIKeys.UsageByEndpoint(ctx)
+		if err != nil {
+			return e.String(http.StatusInternalServerError, "failed to load API key usage")
+		}
+		byKey := make(map[string][]AdminAPIKeyEndpointRow)
+		for _, u := range endpointUsage {
+			byKey[u.APIKeyID] = append(byKey[u.APIKeyID], AdminAPIKeyEndpointRow{
+				Endpoint: u.Endpoint,
+				Requests: u.Requests,
+				LastUsed: u.LastUsed.Format("2006-01-02 15:04"),
+			})
+		}
+
+		rows := make([]AdminAPIKeyRow, len(keys))
+		for i, k := range keys {
+			lastUsed := ""
+			if !k.LastUsed.IsZero() {
+				lastUsed = k.LastUsed.Format("2006-01-02 15:04")
+			}
+			rows[i] = AdminAPIKeyRow{
+				ID:         k.ID,
+				Username:   k.Username,
+				UserID:     k.UserID,
+				Label:      k.Label,
+				Last8:      k.Last8,
+				Created:    k.Created.Format("2006-01-02 15:04"),
+				LastUsed:   lastUsed,
+				Usage24h:   k.Usage24h,
+				Usage7d:    k.Usage7d,
+				UsageTotal: k.UsageTotal,
+				RateLimit:  k.RateLimitPerMinute,
+				Endpoints:  byKey[k.ID],
+			}
+		}
+
+		query := strings.TrimSpace(e.Request.URL.Query().Get("q"))
+		rows = filterAdminAPIKeyRows(rows, query)
+
+		d := AdminAPIKeysData{Keys: rows, DefaultRateLimit: defaultAPIRateLimitPerMinute, Query: query}
+		d.Populate(e)
+		d.AdminSection = "api-keys"
+		d.Breadcrumbs = NewBreadcrumbs(d.Language, i18n.T(d.Language, "Admin"), "/admin", i18n.T(d.Language, "API Keys"))
+		d.Title = i18n.T(d.Language, "Admin: API Keys")
+		d.SubCategory = "Admin"
+		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
+
+		html, err := registry.LoadFiles(adminAPIKeysTemplates...).Render(d)
+		if err != nil {
+			return err
+		}
+		return e.HTML(http.StatusOK, html)
+	}
+}
+
+// AdminAPIKeyRateLimitHandler sets or clears the per-minute rate limit
+// override for one key. An empty or zero value clears the override so the
+// endpoint defaults apply again.
+func AdminAPIKeyRateLimitHandler(appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		if err := e.Request.ParseForm(); err != nil {
+			return e.String(http.StatusBadRequest, "invalid form")
+		}
+		raw := strings.TrimSpace(e.Request.FormValue("rate_limit"))
+		limit := 0
+		if raw != "" {
+			v, err := strconv.Atoi(raw)
+			if err != nil || v < 0 || v > maxAPIRateLimitPerMinute {
+				return e.String(http.StatusBadRequest, "rate limit must be a number between 0 and 1000000")
+			}
+			limit = v
+		}
+		if err := appStore.APIKeys.SetRateLimit(context.Background(), id, limit); err != nil {
+			return e.String(http.StatusInternalServerError, "failed to update rate limit")
+		}
+		return adminAPIKeysRedirect(e)
+	}
+}
+
+func adminAPIKeysRedirect(e *server.RequestEvent) error {
+	// Preserve the active search filter across the redirect.
+	target := "/admin/api-keys"
+	if q := strings.TrimSpace(e.Request.FormValue("q")); q != "" {
+		target += "?q=" + url.QueryEscape(q)
+	}
+	if e.Request.Header.Get("HX-Request") != "" {
+		e.Response.Header().Set("HX-Redirect", LangRedirectURL(e, target))
+		return e.HTML(http.StatusNoContent, "")
+	}
+	return e.Redirect(http.StatusSeeOther, LangRedirectURL(e, target))
+}

--- a/internal/pages/admin_api_keys_test.go
+++ b/internal/pages/admin_api_keys_test.go
@@ -1,0 +1,129 @@
+package pages
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"createmod/internal/store"
+)
+
+func structHasField(v interface{}, name string) bool {
+	_, ok := reflect.TypeOf(v).FieldByName(name)
+	return ok
+}
+
+func Test_EffectiveRateLimit(t *testing.T) {
+	cases := []struct {
+		name string
+		key  *store.APIKey
+		def  int
+		want int
+	}{
+		{"nil key uses default", nil, 120, 120},
+		{"zero override uses default", &store.APIKey{}, 120, 120},
+		{"custom limit wins", &store.APIKey{RateLimitPerMinute: 1000}, 120, 1000},
+		{"custom below default wins", &store.APIKey{RateLimitPerMinute: 5}, 120, 5},
+		{"negative treated as unset", &store.APIKey{RateLimitPerMinute: -1}, 120, 120},
+	}
+	for _, c := range cases {
+		if got := effectiveRateLimit(c.key, c.def); got != c.want {
+			t.Errorf("%s: effectiveRateLimit = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func renderAdminAPIKeys(t *testing.T, d AdminAPIKeysData) string {
+	t.Helper()
+	r := NewTestRegistry()
+
+	root := projectRootFromThisFile(t)
+	var paths []string
+	for _, f := range adminAPIKeysTemplates {
+		paths = append(paths, filepath.Join(root, f))
+	}
+
+	d.DefaultData.Language = "en"
+	out, err := r.LoadFiles(paths...).Render(d)
+	if err != nil {
+		t.Fatalf("render admin_api_keys.html failed: %v", err)
+	}
+	return out
+}
+
+func Test_Admin_API_Keys_Template_Lists_Keys(t *testing.T) {
+	d := AdminAPIKeysData{
+		DefaultRateLimit: 120,
+		Keys: []AdminAPIKeyRow{
+			{
+				ID: "k1", Username: "alice", Label: "prod bot", Last8: "abcd1234",
+				Created: "2026-01-01 10:00", LastUsed: "2026-07-01 12:00",
+				Usage24h: 42, Usage7d: 300, UsageTotal: 9000, RateLimit: 1000,
+				Endpoints: []AdminAPIKeyEndpointRow{
+					{Endpoint: "GET /api/schematics", Requests: 250, LastUsed: "2026-07-01 12:00"},
+				},
+			},
+			{
+				ID: "k2", Username: "bob", Last8: "efgh5678",
+				Created: "2026-02-01 10:00",
+			},
+		},
+	}
+	out := renderAdminAPIKeys(t, d)
+
+	for _, want := range []string{
+		"alice", "prod bot", "abcd1234", "GET /api/schematics",
+		`value="1000"`, "custom",
+		"bob", "efgh5678", "never",
+		"/admin/api-keys/k1/rate-limit",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected rendered page to contain %q", want)
+		}
+	}
+	// Key without an override shows the placeholder, not a value
+	if !strings.Contains(out, `placeholder="default"`) {
+		t.Errorf("expected default placeholder on rate limit input")
+	}
+}
+
+func Test_Admin_API_Keys_Row_Carries_No_Secret_Key_Material(t *testing.T) {
+	// Keys are secrets: the admin view model may expose the last8 display
+	// fragment (same as the user's own settings page) but never the hash
+	// or full key.
+	fields := []string{"KeyHash", "Secret", "Key"}
+	row := AdminAPIKeyRow{}
+	for _, f := range fields {
+		if structHasField(row, f) {
+			t.Errorf("AdminAPIKeyRow must not have field %q", f)
+		}
+	}
+}
+
+func Test_FilterAdminAPIKeyRows(t *testing.T) {
+	rows := []AdminAPIKeyRow{
+		{ID: "k1", Username: "Alice", Label: "prod bot"},
+		{ID: "k2", Username: "bob", Label: ""},
+		{ID: "k3", Username: "carol", Label: "alice-integration"},
+	}
+	if got := filterAdminAPIKeyRows(rows, ""); len(got) != 3 {
+		t.Errorf("empty query should return all rows, got %d", len(got))
+	}
+	if got := filterAdminAPIKeyRows(rows, "ALICE"); len(got) != 2 {
+		t.Errorf("case-insensitive username/label match should return 2 rows, got %d", len(got))
+	}
+	if got := filterAdminAPIKeyRows(rows, "bob"); len(got) != 1 || got[0].ID != "k2" {
+		t.Errorf("expected only bob's key, got %+v", got)
+	}
+	if got := filterAdminAPIKeyRows(rows, "nomatch"); len(got) != 0 {
+		t.Errorf("expected no rows, got %d", len(got))
+	}
+}
+
+func Test_Admin_API_Keys_Template_Empty_State(t *testing.T) {
+	out := renderAdminAPIKeys(t, AdminAPIKeysData{DefaultRateLimit: 120})
+	if !strings.Contains(out, "No API keys have been created yet") {
+		t.Errorf("expected empty state message")
+	}
+}

--- a/internal/pages/api_browse.go
+++ b/internal/pages/api_browse.go
@@ -58,15 +58,15 @@ type apiFiltersResponse struct {
 func APIHomeHandler(searchEngine search.SearchEngine, rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/home"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
+		key, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
-		if rejected := applyAPIRateLimit(e, rl, keyID, isHMAC); rejected {
+		if rejected := applyAPIRateLimit(e, rl, key, isHMAC); rejected {
 			return nil
 		}
 		if !isHMAC {
-			defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
+			defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
 		}
 
 		// The home rails are identical for every caller; cache the assembled
@@ -108,15 +108,15 @@ func APIHomeHandler(searchEngine search.SearchEngine, rl ratelimit.Limiter, cach
 func APIFiltersHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/filters"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
+		key, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
-		if rejected := applyAPIRateLimit(e, rl, keyID, isHMAC); rejected {
+		if rejected := applyAPIRateLimit(e, rl, key, isHMAC); rejected {
 			return nil
 		}
 		if !isHMAC {
-			defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
+			defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
 		}
 
 		// Filter option lists change rarely and are the same for every caller.
@@ -170,8 +170,9 @@ func APIFiltersHandler(rl ratelimit.Limiter, cacheService *cache.Service, appSto
 }
 
 // applyAPIRateLimit enforces the standard API rate limit (HMAC: 100/min by IP,
-// API key: 120/min). It writes a 429 response and returns true when rejected.
-func applyAPIRateLimit(e *server.RequestEvent, rl ratelimit.Limiter, keyID string, isHMAC bool) bool {
+// API key: admin-assigned override or 120/min default). It writes a 429
+// response and returns true when rejected.
+func applyAPIRateLimit(e *server.RequestEvent, rl ratelimit.Limiter, key *store.APIKey, isHMAC bool) bool {
 	if isHMAC {
 		if ok, retry := searchRateLimitAllow(rl, e.RealIP(), 100); !ok {
 			e.Response.Header().Set("Retry-After", fmt.Sprintf("%d", retry))
@@ -180,7 +181,7 @@ func applyAPIRateLimit(e *server.RequestEvent, rl ratelimit.Limiter, keyID strin
 		}
 		return false
 	}
-	if ok, retry := rateLimitAllow(rl, keyID, 120); !ok {
+	if ok, retry := rateLimitAllow(rl, key.ID, effectiveRateLimit(key, defaultAPIRateLimitPerMinute)); !ok {
 		e.Response.Header().Set("Retry-After", fmt.Sprintf("%d", retry))
 		_ = writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 		return true

--- a/internal/pages/api_comments_list.go
+++ b/internal/pages/api_comments_list.go
@@ -23,15 +23,15 @@ type apiCommentsResponse struct {
 func APISchematicCommentsHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/{name}/comments"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
+		key, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
-		if rejected := applyAPIRateLimit(e, rl, keyID, isHMAC); rejected {
+		if rejected := applyAPIRateLimit(e, rl, key, isHMAC); rejected {
 			return nil
 		}
 		if !isHMAC {
-			defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
+			defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
 		}
 
 		name := e.Request.PathValue("name")

--- a/internal/pages/api_public.go
+++ b/internal/pages/api_public.go
@@ -108,29 +108,29 @@ func authenticateHMAC(r *http.Request, secrets []string) *hmacAuth {
 }
 
 // requireAPIKeyOrHMAC tries API key auth first, then HMAC auth. Returns:
-//   - keyID (non-empty for API key auth, empty for HMAC)
+//   - key (non-nil for API key auth, nil for HMAC)
 //   - isHMAC (true if authenticated via HMAC)
 //   - error (non-nil if both auth methods failed; response already written)
-func requireAPIKeyOrHMAC(appStore *store.Store, e *server.RequestEvent, cacheService *cache.Service) (string, bool, error) {
+func requireAPIKeyOrHMAC(appStore *store.Store, e *server.RequestEvent, cacheService *cache.Service) (*store.APIKey, bool, error) {
 	// Try API key first
 	apiKey := getAPIKeyFromRequest(e.Request)
 	if apiKey != "" {
-		keyID, ok := verifyAPIKeyFromStore(appStore, apiKey)
+		key, ok := verifyAPIKeyFromStore(appStore, apiKey)
 		if ok {
-			return keyID, false, nil
+			return key, false, nil
 		}
 	}
 
 	// Try HMAC against the env + admin-managed secrets.
 	if auth := authenticateHMAC(e.Request, resolveModSecrets(appStore, cacheService)); auth != nil {
-		return "", true, nil
+		return nil, true, nil
 	}
 
 	// Neither worked
 	_ = writeJSON(e, http.StatusUnauthorized, map[string]string{
 		"error": "Authentication required. Use X-API-Key header or HMAC signature (X-Mod-Message + X-Mod-Signature)",
 	})
-	return "", false, fmt.Errorf("missing authentication")
+	return nil, false, fmt.Errorf("missing authentication")
 }
 
 // searchRateLimitAllow enforces a per-minute IP rate limit for HMAC-authenticated
@@ -176,9 +176,9 @@ func getAPIKeyFromRequest(r *http.Request) string {
 
 // verifyAPIKeyFromStore looks up the API key by its last 8 characters,
 // then verifies by comparing the full sha256 hash.
-func verifyAPIKeyFromStore(appStore *store.Store, plaintext string) (string, bool) {
+func verifyAPIKeyFromStore(appStore *store.Store, plaintext string) (*store.APIKey, bool) {
 	if strings.TrimSpace(plaintext) == "" {
-		return "", false
+		return nil, false
 	}
 	last8 := plaintext
 	if len(plaintext) >= 8 {
@@ -187,15 +187,15 @@ func verifyAPIKeyFromStore(appStore *store.Store, plaintext string) (string, boo
 	ctx := context.Background()
 	key, err := appStore.APIKeys.GetByLast8(ctx, last8)
 	if err != nil || key == nil {
-		return "", false
+		return nil, false
 	}
 	// Verify the full hash
 	sum := sha256.Sum256([]byte(plaintext))
 	hash := hex.EncodeToString(sum[:])
 	if key.KeyHash != hash {
-		return "", false
+		return nil, false
 	}
-	return key.ID, true
+	return key, true
 }
 
 // writeJSON is a small helper for JSON error/success responses.
@@ -245,28 +245,37 @@ func writeAndCacheJSON(e *server.RequestEvent, cacheService *cache.Service, key 
 }
 
 // requireAPIKeyFromStore extracts and validates the API key from the request using store.
-func requireAPIKeyFromStore(appStore *store.Store, e *server.RequestEvent) (string, error) {
+func requireAPIKeyFromStore(appStore *store.Store, e *server.RequestEvent) (*store.APIKey, error) {
 	apiKey := getAPIKeyFromRequest(e.Request)
 	if apiKey == "" {
 		_ = writeJSON(e, http.StatusUnauthorized, map[string]string{
 			"error": "API key required. Get one at /settings/api-keys",
 		})
-		return "", fmt.Errorf("missing api key")
+		return nil, fmt.Errorf("missing api key")
 	}
-	keyID, ok := verifyAPIKeyFromStore(appStore, apiKey)
+	key, ok := verifyAPIKeyFromStore(appStore, apiKey)
 	if !ok {
 		_ = writeJSON(e, http.StatusUnauthorized, map[string]string{
 			"error": "invalid API key",
 		})
-		return "", fmt.Errorf("invalid api key")
+		return nil, fmt.Errorf("invalid api key")
 	}
-	return keyID, nil
+	return key, nil
 }
 
 // recordAPIKeyUsageStore increments counters for the provided key id and endpoint.
 func recordAPIKeyUsageStore(appStore *store.Store, keyID string, endpoint string) {
 	ctx := context.Background()
 	_ = appStore.APIKeys.LogUsage(ctx, keyID, endpoint)
+}
+
+// effectiveRateLimit returns the admin-assigned per-key limit when one is
+// set, otherwise the endpoint's default limit.
+func effectiveRateLimit(key *store.APIKey, endpointDefault int) int {
+	if key != nil && key.RateLimitPerMinute > 0 {
+		return key.RateLimitPerMinute
+	}
+	return endpointDefault
 }
 
 // rateLimitAllow enforces a simple per-minute limit per API key id using the rate limiter.
@@ -298,7 +307,7 @@ func rateLimitAllow(rl ratelimit.Limiter, keyID string, limit int) (bool, int) {
 func APISchematicsListHandler(searchEngine search.SearchEngine, rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
+		key, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
@@ -309,8 +318,8 @@ func APISchematicsListHandler(searchEngine search.SearchEngine, rl ratelimit.Lim
 				return writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 			}
 		} else {
-			defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
-			if ok, retry := rateLimitAllow(rl, keyID, 120); !ok {
+			defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
+			if ok, retry := rateLimitAllow(rl, key.ID, effectiveRateLimit(key, defaultAPIRateLimitPerMinute)); !ok {
 				e.Response.Header().Set("Retry-After", fmt.Sprintf("%d", retry))
 				return writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 			}
@@ -561,7 +570,7 @@ func apiSearchResults(ctx context.Context, searchEngine search.SearchEngine, app
 func APISchematicDetailHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/{name}"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
+		key, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
@@ -572,8 +581,8 @@ func APISchematicDetailHandler(rl ratelimit.Limiter, cacheService *cache.Service
 				return writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 			}
 		} else {
-			defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
-			if ok, retry := rateLimitAllow(rl, keyID, 120); !ok {
+			defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
+			if ok, retry := rateLimitAllow(rl, key.ID, effectiveRateLimit(key, defaultAPIRateLimitPerMinute)); !ok {
 				e.Response.Header().Set("Retry-After", fmt.Sprintf("%d", retry))
 				return writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 			}

--- a/internal/pages/api_schematic_download.go
+++ b/internal/pages/api_schematic_download.go
@@ -19,15 +19,15 @@ import (
 func APISchematicDownloadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/{name}/download"
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
+		key, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
-		if rejected := applyAPIRateLimit(e, rl, keyID, isHMAC); rejected {
+		if rejected := applyAPIRateLimit(e, rl, key, isHMAC); rejected {
 			return nil
 		}
 		if !isHMAC {
-			defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
+			defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
 		}
 
 		name := e.Request.PathValue("name")

--- a/internal/pages/api_stats.go
+++ b/internal/pages/api_stats.go
@@ -2,8 +2,6 @@ package pages
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"createmod/internal/cache"
 	"createmod/internal/ratelimit"
 	"createmod/internal/server"
@@ -82,26 +80,12 @@ func fillHourlyStats(stats []store.HourlyStat) []apiHourlyStat {
 	return result
 }
 
-func resolveAPIKeyUserID(appStore *store.Store, r *http.Request) (keyID, userID string, ok bool) {
+func resolveAPIKeyUserID(appStore *store.Store, r *http.Request) (key *store.APIKey, ok bool) {
 	plaintext := getAPIKeyFromRequest(r)
 	if plaintext == "" {
-		return "", "", false
+		return nil, false
 	}
-	last8 := plaintext
-	if len(plaintext) >= 8 {
-		last8 = plaintext[len(plaintext)-8:]
-	}
-	ctx := context.Background()
-	key, err := appStore.APIKeys.GetByLast8(ctx, last8)
-	if err != nil || key == nil {
-		return "", "", false
-	}
-	sum := sha256.Sum256([]byte(plaintext))
-	hash := hex.EncodeToString(sum[:])
-	if key.KeyHash != hash {
-		return "", "", false
-	}
-	return key.ID, key.UserID, true
+	return verifyAPIKeyFromStore(appStore, plaintext)
 }
 
 // APISchematicStatsHandler serves GET /api/schematics/{name}/stats.
@@ -109,14 +93,14 @@ func APISchematicStatsHandler(rl ratelimit.Limiter, cacheService *cache.Service,
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/schematics/{name}/stats"
 
-		keyID, userID, ok := resolveAPIKeyUserID(appStore, e.Request)
+		key, ok := resolveAPIKeyUserID(appStore, e.Request)
 		if !ok {
 			return writeJSON(e, http.StatusUnauthorized, map[string]string{
 				"error": "API key required. Get one at /settings/api-keys",
 			})
 		}
-		defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
-		if allowed, retry := rateLimitAllow(rl, keyID, 120); !allowed {
+		defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
+		if allowed, retry := rateLimitAllow(rl, key.ID, effectiveRateLimit(key, defaultAPIRateLimitPerMinute)); !allowed {
 			e.Response.Header().Set("Retry-After", fmt.Sprintf("%d", retry))
 			return writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 		}
@@ -131,7 +115,7 @@ func APISchematicStatsHandler(rl ratelimit.Limiter, cacheService *cache.Service,
 		if err != nil || schem == nil {
 			return writeJSON(e, http.StatusNotFound, map[string]string{"error": "schematic not found"})
 		}
-		if schem.AuthorID != userID {
+		if schem.AuthorID != key.UserID {
 			return writeJSON(e, http.StatusForbidden, map[string]string{"error": "you do not own this schematic"})
 		}
 
@@ -199,14 +183,14 @@ func APIUserStatsHandler(rl ratelimit.Limiter, cacheService *cache.Service, appS
 	return func(e *server.RequestEvent) error {
 		const endpoint = "GET /api/user/stats"
 
-		keyID, userID, ok := resolveAPIKeyUserID(appStore, e.Request)
+		key, ok := resolveAPIKeyUserID(appStore, e.Request)
 		if !ok {
 			return writeJSON(e, http.StatusUnauthorized, map[string]string{
 				"error": "API key required. Get one at /settings/api-keys",
 			})
 		}
-		defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
-		if allowed, retry := rateLimitAllow(rl, keyID, 120); !allowed {
+		defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
+		if allowed, retry := rateLimitAllow(rl, key.ID, effectiveRateLimit(key, defaultAPIRateLimitPerMinute)); !allowed {
 			e.Response.Header().Set("Retry-After", fmt.Sprintf("%d", retry))
 			return writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 		}
@@ -214,12 +198,12 @@ func APIUserStatsHandler(rl ratelimit.Limiter, cacheService *cache.Service, appS
 		ctx := context.Background()
 		since := time.Now().UTC().AddDate(0, 0, -30)
 
-		hViews, _ := appStore.Stats.HourlyUserViews(ctx, userID, since)
-		hDownloads, _ := appStore.Stats.HourlyUserDownloads(ctx, userID, since)
-		hVideoPlays, _ := appStore.Stats.HourlyUserEvents(ctx, userID, store.EventVideoPlay, since)
-		hYTClicks, _ := appStore.Stats.HourlyUserEvents(ctx, userID, store.EventYouTubeClick, since)
-		hTimeOnPage, _ := appStore.Stats.HourlyUserEventAvg(ctx, userID, store.EventTimeOnPage, since)
-		hLayerViews, _ := appStore.Stats.HourlyUserEvents(ctx, userID, store.EventLayerViewer, since)
+		hViews, _ := appStore.Stats.HourlyUserViews(ctx, key.UserID, since)
+		hDownloads, _ := appStore.Stats.HourlyUserDownloads(ctx, key.UserID, since)
+		hVideoPlays, _ := appStore.Stats.HourlyUserEvents(ctx, key.UserID, store.EventVideoPlay, since)
+		hYTClicks, _ := appStore.Stats.HourlyUserEvents(ctx, key.UserID, store.EventYouTubeClick, since)
+		hTimeOnPage, _ := appStore.Stats.HourlyUserEventAvg(ctx, key.UserID, store.EventTimeOnPage, since)
+		hLayerViews, _ := appStore.Stats.HourlyUserEvents(ctx, key.UserID, store.EventLayerViewer, since)
 
 		var totalViews, totalDownloads int
 		for _, v := range hViews {
@@ -251,8 +235,8 @@ func APIUserStatsHandler(rl ratelimit.Limiter, cacheService *cache.Service, appS
 		}
 		offset := (page - 1) * pageSize
 
-		totalSchematics, _ := appStore.Stats.CountUserSchematics(ctx, userID)
-		schematicStats, _ := appStore.Stats.ListSchematicStats(ctx, userID, pageSize, offset)
+		totalSchematics, _ := appStore.Stats.CountUserSchematics(ctx, key.UserID)
+		schematicStats, _ := appStore.Stats.ListSchematicStats(ctx, key.UserID, pageSize, offset)
 
 		schematics := make([]apiUserStatsSchematic, 0, len(schematicStats))
 		for _, s := range schematicStats {

--- a/internal/pages/api_upload.go
+++ b/internal/pages/api_upload.go
@@ -222,7 +222,7 @@ func APIUploadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStor
 	return func(e *server.RequestEvent) error {
 		const endpoint = "POST /api/schematics/upload"
 
-		keyID, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
+		key, isHMAC, err := requireAPIKeyOrHMAC(appStore, e, cacheService)
 		if err != nil {
 			return nil
 		}
@@ -233,8 +233,8 @@ func APIUploadHandler(rl ratelimit.Limiter, cacheService *cache.Service, appStor
 				return writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 			}
 		} else {
-			defer func() { recordAPIKeyUsageStore(appStore, keyID, endpoint) }()
-			if ok, retry := rateLimitAllow(rl, keyID, 120); !ok {
+			defer func() { recordAPIKeyUsageStore(appStore, key.ID, endpoint) }()
+			if ok, retry := rateLimitAllow(rl, key.ID, effectiveRateLimit(key, defaultAPIRateLimitPerMinute)); !ok {
 				e.Response.Header().Set("Retry-After", fmt.Sprintf("%d", retry))
 				return writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 			}

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -551,6 +551,8 @@ func Register(p RegisterParams) chi.Router {
 		r.Post("/admin/api-secrets", Adapt(pages.AdminModSecretCreateHandler(p.CacheService, p.AppStore)))
 		r.Post("/admin/api-secrets/{id}/active", Adapt(pages.AdminModSecretActiveHandler(p.CacheService, p.AppStore)))
 		r.Post("/admin/api-secrets/{id}/delete", Adapt(pages.AdminModSecretDeleteHandler(p.CacheService, p.AppStore)))
+		r.Get("/admin/api-keys", Adapt(pages.AdminAPIKeysHandler(registry, p.CacheService, p.AppStore)))
+		r.Post("/admin/api-keys/{id}/rate-limit", Adapt(pages.AdminAPIKeyRateLimitHandler(p.AppStore)))
 		r.Get("/admin/mods", Adapt(pages.AdminModsHandler(registry, p.CacheService, p.AppStore)))
 		r.Get("/admin/mods/{namespace}", Adapt(pages.AdminModEditHandler(registry, p.CacheService, p.AppStore)))
 		r.Post("/admin/mods/{namespace}", Adapt(pages.AdminModUpdateHandler(p.AppStore)))

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -556,6 +556,28 @@ type APIKey struct {
 	Label   string
 	Last8   string
 	Created time.Time
+	// RateLimitPerMinute is an admin-assigned override applied to every API
+	// endpoint. 0 means "use the endpoint's default limit".
+	RateLimitPerMinute int
+}
+
+// AdminAPIKey is an API key with owner and usage information for the admin
+// overview page. LastUsed is the zero time when the key has never been used.
+type AdminAPIKey struct {
+	APIKey
+	Username   string
+	UsageTotal int64
+	Usage24h   int64
+	Usage7d    int64
+	LastUsed   time.Time
+}
+
+// APIKeyEndpointUsage is a per-endpoint request count for one API key.
+type APIKeyEndpointUsage struct {
+	APIKeyID string
+	Endpoint string
+	Requests int64
+	LastUsed time.Time
 }
 
 // GameVersion represents a Minecraft or Create mod version entry.
@@ -1025,6 +1047,15 @@ type APIKeyStore interface {
 	Create(ctx context.Context, k *APIKey) error
 	Delete(ctx context.Context, id, userID string) error
 	LogUsage(ctx context.Context, apiKeyID, endpoint string) error
+	// ListAllWithUsage returns every API key with owner username and usage
+	// aggregates, newest first. For the admin overview page.
+	ListAllWithUsage(ctx context.Context) ([]AdminAPIKey, error)
+	// SetRateLimit sets the per-minute rate limit override for a key
+	// (0 clears the override so endpoint defaults apply).
+	SetRateLimit(ctx context.Context, id string, perMinute int) error
+	// UsageByEndpoint returns per-endpoint request counts for all keys over
+	// the last 30 days.
+	UsageByEndpoint(ctx context.Context) ([]APIKeyEndpointUsage, error)
 }
 
 // AuthStore handles external auth providers (OAuth).

--- a/template/admin_api_keys.html
+++ b/template/admin_api_keys.html
@@ -1,0 +1,97 @@
+{{template "head.html" .}}
+<div class="page">
+  {{template "sidebar.html" .}}
+  <div class="page-wrapper">
+    {{template "header.html" .}}
+    <main class="page-body">
+      <div class="container-wide">
+        {{template "admin_nav.html" .}}
+        <div class="page-header d-print-none">
+          <div class="row align-items-center">
+            <div class="col">
+              <h2 class="page-title">Admin: API Keys</h2>
+              <div class="text-secondary">All user API keys with usage. Set a per-key rate limit to override the default of {{ .DefaultRateLimit }} requests/minute; 0 or blank restores the default.</div>
+            </div>
+          </div>
+        </div>
+
+        {{if not .IsAuthenticated}}
+          <div class="alert alert-danger">You must be logged in.</div>
+        {{end}}
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h3 class="card-title">API keys ({{ len .Keys }})</h3>
+            <form method="get" action="/admin/api-keys" class="ms-auto d-flex gap-1">
+              <input type="text" class="form-control form-control-sm" name="q" value="{{ .Query }}" placeholder="Search user or label" style="width: 14rem;">
+              <button type="submit" class="btn btn-sm btn-outline-secondary">Search</button>
+              {{ if .Query }}<a href="/admin/api-keys" class="btn btn-sm btn-ghost-secondary">Clear</a>{{ end }}
+            </form>
+          </div>
+          <div class="table-responsive">
+            <table class="table card-table table-vcenter">
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Label</th>
+                  <th>Key</th>
+                  <th>Created</th>
+                  <th>Last used</th>
+                  <th class="text-end">24h</th>
+                  <th class="text-end">7d</th>
+                  <th class="text-end">Total</th>
+                  <th>Rate limit/min</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{range .Keys}}
+                <tr>
+                  <td>
+                    {{ if .Username }}<a href="/user/{{ .Username }}">{{ .Username }}</a>{{ else }}<span class="text-secondary">unknown</span>{{ end }}
+                  </td>
+                  <td>{{ if .Label }}{{ .Label }}{{ else }}<span class="text-secondary">—</span>{{ end }}</td>
+                  <td><code>…{{ .Last8 }}</code></td>
+                  <td class="text-secondary">{{ .Created }}</td>
+                  <td class="text-secondary">{{ if .LastUsed }}{{ .LastUsed }}{{ else }}never{{ end }}</td>
+                  <td class="text-end">{{ .Usage24h }}</td>
+                  <td class="text-end">{{ .Usage7d }}</td>
+                  <td class="text-end">
+                    {{ .UsageTotal }}
+                    {{ if .Endpoints }}
+                    <details>
+                      <summary class="text-secondary small" style="cursor:pointer;">by endpoint (30d)</summary>
+                      <div class="small text-start mt-1">
+                        {{ range .Endpoints }}
+                        <div class="d-flex justify-content-between gap-2">
+                          <code>{{ .Endpoint }}</code><span>{{ .Requests }}</span>
+                        </div>
+                        {{ end }}
+                      </div>
+                    </details>
+                    {{ end }}
+                  </td>
+                  <td>
+                    <form method="post" action="/admin/api-keys/{{ .ID }}/rate-limit" class="d-flex gap-1 align-items-center">
+                      <input type="hidden" name="q" value="{{ $.Query }}">
+                      <input type="number" class="form-control form-control-sm" name="rate_limit" min="0" max="1000000"
+                             value="{{ if .RateLimit }}{{ .RateLimit }}{{ end }}" placeholder="default" style="width: 6.5rem;">
+                      <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
+                    </form>
+                    {{ if .RateLimit }}<span class="badge bg-yellow-lt mt-1">custom</span>{{ end }}
+                  </td>
+                </tr>
+                {{else}}
+                <tr>
+                  <td colspan="9" class="text-secondary">{{ if .Query }}No API keys match "{{ .Query }}".{{ else }}No API keys have been created yet.{{ end }}</td>
+                </tr>
+                {{end}}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </main>
+    {{template "footer.html" .}}
+  </div>
+</div>
+{{template "foot.html" .}}

--- a/template/api_docs.html
+++ b/template/api_docs.html
@@ -109,7 +109,7 @@ Accept: application/json</pre>
               <div class="row-main">
                 <section class="apidocs-section" id="rate-limits">
                   <h2>{{ T .Language "Rate Limits" }} <a class="anchor" href="#rate-limits">#</a></h2>
-                  <p class="desc">{{ T .Language "Each API key is limited to" }} <strong>120 {{ T .Language "requests per minute" }}</strong>. {{ T .Language "Exceeding the limit returns" }} <code>429 Too Many Requests</code> {{ T .Language "with a" }} <code>Retry-After</code> {{ T .Language "header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle." }}</p>
+                  <p class="desc">{{ T .Language "Each API key is limited to" }} <strong>120 {{ T .Language "requests per minute" }}</strong> {{ T .Language "by default; a different limit may be assigned to your key" }}. {{ T .Language "Exceeding the limit returns" }} <code>429 Too Many Requests</code> {{ T .Language "with a" }} <code>Retry-After</code> {{ T .Language "header indicating seconds to wait. Every response includes rate-limit headers so you can self-throttle." }}</p>
                   <div class="code-card">
                     <div class="tabs"><span class="lang-tab active">{{ T .Language "Response Headers" }}</span><span class="tabs-spacer"></span><button class="copy-btn" data-copy><span>{{ T .Language "Copy" }}</span></button></div>
                     <pre data-lang="http">X-RateLimit-Limit: 120

--- a/template/include/admin_nav.html
+++ b/template/include/admin_nav.html
@@ -31,6 +31,9 @@
     <li class="nav-item">
       <a class="nav-link{{ if eq .AdminSection "api-secrets" }} active{{ end }}" href="/admin/api-secrets">API Secrets</a>
     </li>
+    <li class="nav-item">
+      <a class="nav-link{{ if eq .AdminSection "api-keys" }} active{{ end }}" href="/admin/api-keys">API Keys</a>
+    </li>
   </ul>
 </div>
 {{end}}


### PR DESCRIPTION
Adds /admin/api-keys where admins can see every user API key with its owner, label, last8 fragment, creation date, last use, request counts (24h / 7d / total), and a per-endpoint breakdown over the last 30 days, plus set a custom per-minute rate limit for individual keys (e.g. 1000 req/min). A limit of 0 (or blank) restores the endpoint default of 120 req/min. The list is searchable by username or label. Only the last8 display fragment is exposed — never the hash or full key (a test guards this).

- Migration 073: api_keys.rate_limit_per_minute + composite index on api_key_usage (api_key_id, created) for the usage aggregates
- API key auth helpers now return the full key row so the override rides along with the existing lookup (no extra query per request); effectiveRateLimit() applies it at every rate-limited endpoint
- Admin page follows the api-secrets pattern (isSuperAdmin guard, HX-aware redirects); nav entry added
- API docs note that a key may have a non-default limit