### PR TITLE
feat(agents): serve /auth.md documenting the human-mediated auth model

### DIFF
--- a/internal/pages/agent_discovery.go
+++ b/internal/pages/agent_discovery.go
@@ -86,7 +86,8 @@ When a user wants a schematic, give them the schematic page URL
 4. **Autocomplete**: GET https://createmod.com/api/search/suggest?q={terms}
    returns JSON suggestions.
 5. **Authenticated JSON API**: https://createmod.com/api (docs) — requires
-   an API key created by a user account.
+   an API key created by a user account. See https://createmod.com/auth.md
+   for how authentication works and how to obtain a key.
 `,
 	},
 	{
@@ -129,6 +130,65 @@ To build a configuration for a user:
 More agent tools will be exposed this way over time.
 `,
 	},
+}
+
+// authMD is the agent-facing authentication guide served at /auth.md.
+// CreateMod.com is deliberately not an OAuth authorization server: API keys
+// are provisioned by humans only, which keeps every credential traceable to
+// an account the site can oversee and rate limit.
+const authMD = `# Authentication on CreateMod.com
+
+This document tells AI agents how authentication works on CreateMod.com
+and what to do when an endpoint requires credentials.
+
+## Summary
+
+- Most agent-relevant functionality requires **no authentication** (see below).
+- The JSON API (https://createmod.com/api) requires an **API key** sent as an
+  ` + "`X-API-Key`" + ` header.
+- There is **no autonomous agent registration**: no OAuth authorization
+  server, no dynamic client registration, no token endpoint. API keys are
+  created manually by a signed-in human.
+
+## No authentication required
+
+- MCP server: POST https://createmod.com/api/mcp (see
+  /.well-known/mcp/server-card.json)
+- Markdown content negotiation: request the home page or any schematic page
+  with "Accept: text/markdown"
+- Search suggestions: GET https://createmod.com/api/search/suggest?q={terms}
+- Search and browse pages, sitemaps, and all /.well-known/ discovery files
+
+## Getting an API key (requires a human)
+
+1. Ask your user to create an account at https://createmod.com/register
+   (or sign in at https://createmod.com/login).
+2. The user creates an API key at https://createmod.com/settings/api-keys.
+3. The user gives the key to you; send it as the ` + "`X-API-Key`" + ` header.
+
+Agents must not create accounts or fill in registration forms on a user's
+behalf.
+
+## Rate limits
+
+API keys default to 120 requests/minute; a different limit may be assigned
+to individual keys. 429 responses include a Retry-After header. The
+unauthenticated MCP endpoint is limited to 60 requests/minute per IP.
+
+## Hard policy
+
+Never download schematic (.nbt) files or call download endpoints, with or
+without credentials. Schematic files are for players: send users to the
+schematic page (https://createmod.com/schematics/{slug}) or to a generator
+(https://createmod.com/generators/) to download builds themselves.
+`
+
+// AuthMDHandler serves /auth.md.
+func AuthMDHandler() func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		e.Response.Header().Set("Cache-Control", "public, max-age=3600")
+		return e.Blob(http.StatusOK, "text/markdown; charset=utf-8", []byte(authMD))
+	}
 }
 
 // AgentSkillsIndexHandler serves /.well-known/agent-skills/index.json.

--- a/internal/pages/api_catalog.go
+++ b/internal/pages/api_catalog.go
@@ -9,7 +9,7 @@ import (
 
 // agentDiscoveryLinkHeader advertises API discovery resources to agents via
 // an RFC 8288 Link header. Served on the homepage and the API docs page.
-const agentDiscoveryLinkHeader = `</.well-known/api-catalog>; rel="api-catalog", </api>; rel="service-doc", </api/openapi.json>; rel="service-desc"`
+const agentDiscoveryLinkHeader = `</.well-known/api-catalog>; rel="api-catalog", </api>; rel="service-doc", </api/openapi.json>; rel="service-desc", </auth.md>; rel="help"`
 
 // SetAgentDiscoveryLinkHeader adds the agent-discovery Link header to a response.
 func SetAgentDiscoveryLinkHeader(e *server.RequestEvent) {

--- a/internal/pages/mcp_test.go
+++ b/internal/pages/mcp_test.go
@@ -168,3 +168,30 @@ func Test_AgentSkills_Index_And_Digests(t *testing.T) {
 		t.Errorf("unknown skill should 404, got %d", nrec.Code)
 	}
 }
+
+func Test_AuthMD(t *testing.T) {
+	req := httptest.NewRequest("GET", "/auth.md", nil)
+	rec := httptest.NewRecorder()
+	if err := AuthMDHandler()(server.NewRequestEvent(rec, req)); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/markdown") {
+		t.Errorf("expected text/markdown, got %s", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"X-API-Key",
+		"/settings/api-keys",
+		"no autonomous agent registration",
+		"must not create accounts",
+		"Never download schematic (.nbt) files",
+		"120 requests/minute",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("auth.md missing %q", want)
+		}
+	}
+}

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -515,6 +515,8 @@ func Register(p RegisterParams) chi.Router {
 	// Agent skills discovery (Agent Skills Discovery RFC)
 	r.Get("/.well-known/agent-skills/index.json", Adapt(pages.AgentSkillsIndexHandler()))
 	r.Get("/.well-known/agent-skills/{name}/SKILL.md", Adapt(pages.AgentSkillHandler()))
+	// Agent-facing authentication guide (auth.md convention)
+	r.Get("/auth.md", Adapt(pages.AuthMDHandler()))
 	// Public JSON API (beta) — supports both X-API-Key and HMAC authentication
 	r.Get("/api/home", Adapt(pages.APIHomeHandler(p.SearchEngine, p.RateLimiter, p.CacheService, p.AppStore)))
 	r.Get("/api/schematics", Adapt(pages.APISchematicsListHandler(p.SearchEngine, p.RateLimiter, p.CacheService, p.AppStore)))


### PR DESCRIPTION
Agents discovering the API get explicit authentication guidance instead of dead-ending on the login form: what needs no auth (MCP, markdown negotiation, suggest API, discovery files), that the JSON API uses X-API-Key, and that keys are created manually by a signed-in human at /settings/api-keys — there is deliberately no OAuth authorization server or dynamic agent registration, so every credential stays traceable to an account that can be overseen and rate-limited from the admin panel. States the NBT policy and rate limits; agents are told not to create accounts on a user's behalf.

Referenced from the homepage Link header (rel="help") and the find-schematics agent skill.