### PR TITLE
fix(ci): buildx cache export failures must not fail the build

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,47 @@
+name: Cache cleanup
+
+# The Actions cache quota is 10 GB; each dependency PR mints its own ~0.8 GB
+# Go cache (go.sum changes produce a new key per PR ref), so the quota pegs
+# and buildx cache reservations start failing. This prunes caches whose PR is
+# closed — open PRs and branch caches are untouched and everything deleted
+# regenerates on the next run.
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  pull-requests: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches belonging to closed PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          deleted=0
+          gh api --paginate "repos/$GH_REPO/actions/caches?per_page=100" \
+            --jq '.actions_caches[] | [.id, .ref] | @tsv' > caches.tsv
+          while IFS=$'\t' read -r id ref; do
+            case "$ref" in
+              refs/pull/*/merge)
+                pr=${ref#refs/pull/}
+                pr=${pr%/merge}
+                case "$pr" in *[!0-9]*) continue ;; esac
+                state=$(gh api "repos/$GH_REPO/pulls/$pr" --jq .state 2>/dev/null || echo unknown)
+                if [ "$state" = "closed" ]; then
+                  if gh api -X DELETE "repos/$GH_REPO/actions/caches/$id" >/dev/null 2>&1; then
+                    deleted=$((deleted + 1))
+                  fi
+                fi
+                ;;
+            esac
+          done < caches.tsv
+          usage=$(gh api "repos/$GH_REPO/actions/cache/usage" --jq '.active_caches_size_in_bytes')
+          echo "deleted $deleted closed-PR caches; usage now $((usage / 1024 / 1024)) MB"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           build-args: |
             BUILD_VERSION=${{ github.sha }}
           cache-from: type=gha,scope=createmod
-          cache-to: type=gha,mode=max,scope=createmod
+          cache-to: type=gha,mode=max,scope=createmod,ignore-error=true
           platforms: linux/amd64
 
       - name: Build and start app
@@ -190,7 +190,7 @@ jobs:
           build-args: |
             BUILD_VERSION=${{ github.sha }}
           cache-from: ${{ github.event.inputs.no-cache == 'true' && '' || 'type=gha,scope=createmod' }}
-          cache-to: type=gha,mode=max,scope=createmod
+          cache-to: type=gha,mode=max,scope=createmod,ignore-error=true
           no-cache: ${{ github.event.inputs.no-cache == 'true' }}
           platforms: linux/amd64
 


### PR DESCRIPTION
Deploy/build jobs are failing with `error writing layer blob: failed to reserve cache` (e.g. [run 28980345906](https://github.com/uberswe/createmod.com/actions/runs/28980345906)).

**Root cause:** the repo's Actions cache was 12.6 GB against GitHub's 10 GB quota — each dependency PR mints its own ~0.8 GB Go cache (go.sum changes the key per PR ref), so the quota stays pegged and cache evictions race buildx's blob reservations.

**Fixes:**
1. `ignore-error=true` on both `cache-to` lines — the GHA cache is an optimization, never a build input, so export failures become warnings instead of build failures.
2. **New scheduled workflow `cache-cleanup.yml`** (daily + manual dispatch): deletes caches belonging to closed PRs. Open PRs and branch caches are untouched; anything deleted regenerates on the next run. PR numbers parsed from cache refs are validated numeric before API use.

**Immediate relief already applied:** ran the same cleanup manually — usage dropped 12.60 GB → 6.15 GB, which unblocks in-flight builds before this even merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)