### PR TITLE
fix(k8s): enable Meilisearch dumpless upgrades

### DIFF
--- a/k8s/meilisearch/dev/deployment.yaml
+++ b/k8s/meilisearch/dev/deployment.yaml
@@ -19,6 +19,12 @@ spec:
       containers:
         - name: meilisearch
           image: getmeili/meilisearch:v1.49
+          # Migrate the index database in place on version bumps instead of
+          # refusing to start ("database version X is incompatible with
+          # engine version Y" -> CrashLoopBackOff). No-op when versions
+          # already match, so it stays on permanently.
+          args:
+            - --experimental-dumpless-upgrade
           ports:
             - containerPort: 7700
               name: http

--- a/k8s/meilisearch/prod/statefulset.yaml
+++ b/k8s/meilisearch/prod/statefulset.yaml
@@ -20,6 +20,12 @@ spec:
       containers:
         - name: meilisearch
           image: getmeili/meilisearch:v1.49
+          # Migrate the index database in place on version bumps instead of
+          # refusing to start ("database version X is incompatible with
+          # engine version Y" -> CrashLoopBackOff). No-op when versions
+          # already match, so it stays on permanently.
+          args:
+            - --experimental-dumpless-upgrade
           ports:
             - containerPort: 7700
               name: http


### PR DESCRIPTION
Prod search is degraded: `meilisearch-0` has been in CrashLoopBackOff since the v1.49 image landed, refusing to start on a v1.48.2 database:

```
Error: Your database version (1.48.2) is incompatible with your current engine version (1.49.0).
```

**Fix:** `--experimental-dumpless-upgrade` on both prod and dev — Meilisearch migrates the database in place at boot instead of refusing to start. It's a no-op when versions match, so it stays on permanently and future image bumps self-heal. ArgoCD applies this on merge; the pod should migrate and go Ready within a couple of minutes.

If the in-place migration were ever to fail, the fallback is deleting the PVC data — the index is derived and rebuilds from PostgreSQL automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)