### PR TITLE
fix(db): cap the connection pool at 10 per pod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,7 @@ MEILISEARCH_KEY=localdev
 
 # Logging (debug, info, warn, error)
 LOG_LEVEL=info
+
+# Max PostgreSQL connections per pod (default 10; shared DB has 200 slots
+# across all apps and pods)
+DB_MAX_CONNS=10

--- a/internal/database/conn.go
+++ b/internal/database/conn.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"os"
+	"strconv"
 	"log/slog"
 	"time"
 
@@ -26,12 +28,25 @@ type Config struct {
 	MaxConnLifetime time.Duration
 }
 
-// DefaultConfig returns a Config with sensible defaults for PgBouncer.
+// DefaultConfig returns a Config with pool sizing appropriate for a shared
+// PostgreSQL. The shared cluster instance has 200 connection slots serving
+// ~10 applications; this app runs 2-6 pods (HPA) and rolling updates surge
+// pods, so per-pod appetite multiplies: 25/pod peaked past the global limit
+// during a deploy and starved other tenants (authentik outage, 2026-07-09).
+// Observed steady-state usage is ~8 connections per pod; 10 gives headroom
+// while capping the worst case (6 pods + surge) near 90. Override with
+// DB_MAX_CONNS if a dedicated database ever warrants more.
 func DefaultConfig(databaseURL string) Config {
+	maxConns := int32(10)
+	if v := os.Getenv("DB_MAX_CONNS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 2 && n <= 100 {
+			maxConns = int32(n)
+		}
+	}
 	return Config{
 		DatabaseURL:     databaseURL,
-		MaxConns:        25,
-		MinConns:        5,
+		MaxConns:        maxConns,
+		MinConns:        2,
 		MaxConnLifetime: time.Hour,
 	}
 }


### PR DESCRIPTION
During today's dependency deploy, the shared PostgreSQL (200 slots, ~10 tenant apps) ran out of connection slots: authentik lost its connections (`FATAL: remaining connection slots are reserved for SUPERUSER`), taking down auth.9m.se and ArgoCD logins until the post-deploy churn settled.

**Why:** this app allowed **25 connections per pod**. HPA runs 2–6 pods and rolling updates surge old+new pods simultaneously — worst case well past the entire global limit, and today's rollout (4 pods) crossed it.

**Fix:** default `MaxConns` 25 → 10 (observed steady-state is ~8/pod; 34 idle across 4 pods at incident time), `MinConns` 5 → 2, and a `DB_MAX_CONNS` env override documented in `.env.example` for if the app ever gets a dedicated database.

Worst case after this: 6 pods + surge ≈ 90 connections, leaving half the global budget for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)