### PR TITLE
fix(k8s): dumpless upgrade via env var, not args

### DIFF
--- a/k8s/meilisearch/dev/deployment.yaml
+++ b/k8s/meilisearch/dev/deployment.yaml
@@ -19,12 +19,6 @@ spec:
       containers:
         - name: meilisearch
           image: getmeili/meilisearch:v1.49
-          # Migrate the index database in place on version bumps instead of
-          # refusing to start ("database version X is incompatible with
-          # engine version Y" -> CrashLoopBackOff). No-op when versions
-          # already match, so it stays on permanently.
-          args:
-            - --experimental-dumpless-upgrade
           ports:
             - containerPort: 7700
               name: http
@@ -34,6 +28,14 @@ spec:
                 secretKeyRef:
                   name: meilisearch-secret
                   key: MEILI_MASTER_KEY
+            # Migrate the index database in place on version bumps instead
+            # of refusing to start ("database version X is incompatible with
+            # engine version Y" -> CrashLoopBackOff). No-op when versions
+            # already match, so it stays on permanently. Env form because the
+            # image's entrypoint is tini and container args replace the CMD
+            # (tini would exec the flag as a program).
+            - name: MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE
+              value: "true"
             - name: MEILI_ENV
               value: "development"
           resources:

--- a/k8s/meilisearch/prod/statefulset.yaml
+++ b/k8s/meilisearch/prod/statefulset.yaml
@@ -20,12 +20,6 @@ spec:
       containers:
         - name: meilisearch
           image: getmeili/meilisearch:v1.49
-          # Migrate the index database in place on version bumps instead of
-          # refusing to start ("database version X is incompatible with
-          # engine version Y" -> CrashLoopBackOff). No-op when versions
-          # already match, so it stays on permanently.
-          args:
-            - --experimental-dumpless-upgrade
           ports:
             - containerPort: 7700
               name: http
@@ -35,6 +29,14 @@ spec:
                 secretKeyRef:
                   name: meilisearch-secret
                   key: MEILI_MASTER_KEY
+            # Migrate the index database in place on version bumps instead
+            # of refusing to start ("database version X is incompatible with
+            # engine version Y" -> CrashLoopBackOff). No-op when versions
+            # already match, so it stays on permanently. Env form because the
+            # image's entrypoint is tini and container args replace the CMD
+            # (tini would exec the flag as a program).
+            - name: MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE
+              value: "true"
             - name: MEILI_ENV
               value: "production"
           resources:


### PR DESCRIPTION
The meilisearch image's entrypoint is tini and container args replace the image CMD, so the flag from #1479 was exec'd as a program: '[FATAL tini (7)] exec --experimental-dumpless-upgrade failed: No such file or directory'. MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE=true is the equivalent configuration without touching the entrypoint.