### PR TITLE
fix(settings): account deletion never fired since the Tabler removal

### DIFF
--- a/template/static/framework.js
+++ b/template/static/framework.js
@@ -218,7 +218,10 @@
 
     var dismiss = e.target.closest('[data-cm-dismiss="modal"]');
     if (dismiss) {
-      e.preventDefault();
+      // A submit button may both submit its form (e.g. the delete-account
+      // hx-delete form) and dismiss the modal; preventDefault would swallow
+      // the submission entirely.
+      if (!(dismiss.type === 'submit' && dismiss.form)) e.preventDefault();
       var modal = dismiss.closest('.modal');
       if (modal) hideModal(modal);
       return;

--- a/template/user-settings.html
+++ b/template/user-settings.html
@@ -340,7 +340,7 @@
             // After successful deletion via HTMX, clear cookie and redirect
             document.addEventListener('htmx:afterRequest', function(evt) {
               var form = document.getElementById('delete-account-form');
-              if (evt.target === form) {
+              if (evt.target === form && evt.detail && evt.detail.successful) {
                 try {
                   deleteCookie('create-mod-auth');
                 } catch (e) {}


### PR DESCRIPTION
The custom modal handler preventDefault()s every data-cm-dismiss click. The "Yes, delete my account" button is a submit button inside the hx-delete form AND dismisses the modal, so the form submission was swallowed: the modal closed and no DELETE was ever sent. Let submit buttons submit their form while still dismissing the modal, and only clear the session cookie / redirect when the request succeeded.