### PR TITLE
perf(ads): defer the NitroPay loader to post-load idle

### DIFF
--- a/template/include/head.html
+++ b/template/include/head.html
@@ -85,7 +85,29 @@ window.setTheme=function(theme){
     {{ if .IsDev }}
     <script src="/assets/x/dev-ads.js?v={{ AssetVer }}" defer></script>
     {{ else }}
-    <script data-cfasync="false" async src="https://s.nitropay.com/ads-2143.js" onerror="window._nitroBlocked=true"></script>
+    <script data-cfasync="false">
+    // Defer the NitroPay loader until the page has loaded and the main
+    // thread is idle: its initial evaluation is a ~1.4s main-thread task
+    // (the site's dominant INP contributor on mobile), and running it during
+    // the critical window makes early taps wait behind it. The queue shim
+    // above buffers createAd calls until the real script arrives.
+    (function () {
+      function loadNitro() {
+        var s = document.createElement('script');
+        s.setAttribute('data-cfasync', 'false');
+        s.async = true;
+        s.src = 'https://s.nitropay.com/ads-2143.js';
+        s.onerror = function () { window._nitroBlocked = true; };
+        document.head.appendChild(s);
+      }
+      function whenIdle() {
+        if (window.requestIdleCallback) requestIdleCallback(loadNitro, { timeout: 4000 });
+        else setTimeout(loadNitro, 1500);
+      }
+      if (document.readyState === 'complete') whenIdle();
+      else window.addEventListener('load', whenIdle, { once: true });
+    })();
+    </script>
     {{ end }}
     <script src="/assets/x/adrail.js?v={{ AssetVer }}" defer></script>
     <!-- WebMCP: expose curated site tools to browser AI agents -->


### PR DESCRIPTION
Lighthouse on production mobile shows ads-2143.js evaluating in a single ~1.4s main-thread task — the dominant INP contributor in the Search Console Core Web Vitals report (all 66k mobile URLs sit in the 200-500ms 'needs improvement' band; nothing else on the page comes within 10x of it). Loading it after window.load + idle keeps that task out of the critical window so early taps stop queueing behind it. The existing nitroAds queue shim buffers createAd calls until the script arrives, and ad refresh settings are unchanged.