### PR TITLE
feat(admin): blocked URLs section for DMCA takedowns

### DIFF
--- a/internal/blockedurls/blockedurls.go
+++ b/internal/blockedurls/blockedurls.go
@@ -1,0 +1,79 @@
+// Package blockedurls normalizes and matches admin-managed blocked URLs
+// (e.g. DMCA takedown targets) against incoming request URLs.
+package blockedurls
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// Normalize converts an admin-supplied value (a full URL or an absolute path)
+// into the canonical stored form: path plus optional query string, e.g.
+// "/es/search?p=17&q=term". Scheme and host are discarded.
+func Normalize(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("URL is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	if !strings.HasPrefix(u.Path, "/") {
+		return "", fmt.Errorf("URL must be a full URL (https://...) or an absolute path starting with /")
+	}
+	normalized := u.EscapedPath()
+	if u.RawQuery != "" {
+		normalized += "?" + u.RawQuery
+	}
+	return normalized, nil
+}
+
+// Matches reports whether reqURL matches any of the stored entries. An entry
+// matches when its path equals the request path and its query parameters
+// equal the request's query parameters (order-insensitive).
+func Matches(entries []string, reqURL *url.URL) bool {
+	if reqURL == nil {
+		return false
+	}
+	reqQuery := reqURL.Query()
+	for _, entry := range entries {
+		eu, err := url.Parse(entry)
+		if err != nil {
+			continue
+		}
+		if eu.Path != reqURL.Path {
+			continue
+		}
+		if queryValuesEqual(eu.Query(), reqQuery) {
+			return true
+		}
+	}
+	return false
+}
+
+// queryValuesEqual reports whether two query parameter sets contain the same
+// keys and values, ignoring parameter order.
+func queryValuesEqual(a, b url.Values) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, av := range a {
+		bv, ok := b[key]
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		as := append([]string(nil), av...)
+		bs := append([]string(nil), bv...)
+		sort.Strings(as)
+		sort.Strings(bs)
+		for i := range as {
+			if as[i] != bs[i] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/blockedurls/blockedurls_test.go
+++ b/internal/blockedurls/blockedurls_test.go
@@ -1,0 +1,85 @@
+package blockedurls
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"full url with query", "https://createmod.com/es/search?p=17&q=canva-premium-mod-for-pc", "/es/search?p=17&q=canva-premium-mod-for-pc", false},
+		{"absolute path with query", "/es/search?q=foo", "/es/search?q=foo", false},
+		{"path only", "/schematics/some-slug", "/schematics/some-slug", false},
+		{"surrounding whitespace", "  https://createmod.com/foo?a=1  ", "/foo?a=1", false},
+		{"empty", "", "", true},
+		{"whitespace only", "   ", "", true},
+		{"relative path", "search?q=foo", "", true},
+		{"bare domain no path", "https://createmod.com", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Normalize(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Normalize(%q) = %q, want error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Normalize(%q) unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatches(t *testing.T) {
+	entries := []string{
+		"/es/search?p=17&q=canva-premium-mod-for-pc",
+		"/schematics/blocked-build",
+	}
+	tests := []struct {
+		name string
+		req  string
+		want bool
+	}{
+		{"exact match", "/es/search?p=17&q=canva-premium-mod-for-pc", true},
+		{"query order swapped", "/es/search?q=canva-premium-mod-for-pc&p=17", true},
+		{"different page param", "/es/search?p=18&q=canva-premium-mod-for-pc", false},
+		{"missing param", "/es/search?q=canva-premium-mod-for-pc", false},
+		{"extra param", "/es/search?p=17&q=canva-premium-mod-for-pc&x=1", false},
+		{"different path", "/search?p=17&q=canva-premium-mod-for-pc", false},
+		{"path-only entry match", "/schematics/blocked-build", true},
+		{"path-only entry with query", "/schematics/blocked-build?utm=1", false},
+		{"unrelated path", "/schematics/other-build", false},
+		{"search page without query", "/es/search", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := Matches(entries, u); got != tt.want {
+				t.Fatalf("Matches(%q) = %v, want %v", tt.req, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesEntryWithHost(t *testing.T) {
+	// Entries stored as full URLs (pre-normalization data) still match on
+	// path + query.
+	entries := []string{"https://createmod.com/es/search?q=foo"}
+	u, _ := url.Parse("/es/search?q=foo")
+	if !Matches(entries, u) {
+		t.Fatal("expected full-URL entry to match on path + query")
+	}
+}

--- a/internal/cache/service.go
+++ b/internal/cache/service.go
@@ -24,6 +24,7 @@ const (
 	LatestHasNextKey          = "LatestHasNext"
 	HighestRatedHasNextKey    = "HighestRatedHasNext"
 	TrendingHasNextKey        = "TrendingHasNext"
+	BlockedURLsKey            = "BlockedURLs"
 
 	keyPrefix    = "cm:"
 	defaultTTL   = 30 * time.Minute

--- a/internal/database/migrations/080_blocked_urls.down.sql
+++ b/internal/database/migrations/080_blocked_urls.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS blocked_urls;

--- a/internal/database/migrations/080_blocked_urls.up.sql
+++ b/internal/database/migrations/080_blocked_urls.up.sql
@@ -1,0 +1,12 @@
+-- Admin-managed blocked URLs. Requests whose path + query exactly match an
+-- entry are served a 404, e.g. to honor DMCA takedown notices without
+-- removing unrelated content.
+CREATE TABLE IF NOT EXISTS blocked_urls (
+    id         TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    url        TEXT NOT NULL,
+    note       TEXT NOT NULL DEFAULT '',
+    created_by TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_blocked_urls_url ON blocked_urls (url);

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -4087,6 +4087,7 @@ func NewStoreFromPool(pool *pgxpool.Pool) *store.Store {
 		Security:            &SecurityStoreImpl{q: q, pool: pool},
 		AdClicks:            &AdClickStoreImpl{q: q},
 		ModSecrets:          &ModSecretStoreImpl{pool: pool},
+		BlockedURLs:         &BlockedURLStoreImpl{pool: pool},
 	}
 }
 
@@ -4145,6 +4146,60 @@ func (m *ModSecretStoreImpl) SetActive(ctx context.Context, id string, active bo
 
 func (m *ModSecretStoreImpl) Delete(ctx context.Context, id string) error {
 	_, err := m.pool.Exec(ctx, `DELETE FROM mod_secrets WHERE id = $1`, id)
+	return err
+}
+
+// BlockedURLStoreImpl implements store.BlockedURLStore over raw pgx.
+type BlockedURLStoreImpl struct{ pool *pgxpool.Pool }
+
+func (b *BlockedURLStoreImpl) ListURLs(ctx context.Context) ([]string, error) {
+	rows, err := b.pool.Query(ctx, `SELECT url FROM blocked_urls ORDER BY created_at`)
+	if err != nil {
+		return nil, fmt.Errorf("listing blocked urls: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var u string
+		if err := rows.Scan(&u); err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+func (b *BlockedURLStoreImpl) List(ctx context.Context) ([]store.BlockedURL, error) {
+	rows, err := b.pool.Query(ctx, `
+		SELECT id, url, note, created_by, created_at
+		FROM blocked_urls ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("listing blocked urls: %w", err)
+	}
+	defer rows.Close()
+	var out []store.BlockedURL
+	for rows.Next() {
+		var u store.BlockedURL
+		if err := rows.Scan(&u.ID, &u.URL, &u.Note, &u.CreatedBy, &u.Created); err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+func (b *BlockedURLStoreImpl) Create(ctx context.Context, u *store.BlockedURL) error {
+	return b.pool.QueryRow(ctx, `
+		INSERT INTO blocked_urls (url, note, created_by)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (url) DO UPDATE SET note = EXCLUDED.note
+		RETURNING id, created_at`,
+		u.URL, u.Note, u.CreatedBy,
+	).Scan(&u.ID, &u.Created)
+}
+
+func (b *BlockedURLStoreImpl) Delete(ctx context.Context, id string) error {
+	_, err := b.pool.Exec(ctx, `DELETE FROM blocked_urls WHERE id = $1`, id)
 	return err
 }
 
@@ -4733,6 +4788,7 @@ var (
 	_ store.ZeroResultStore     = (*ZeroResultStoreImpl)(nil)
 	_ store.AdClickStore        = (*AdClickStoreImpl)(nil)
 	_ store.ModSecretStore      = (*ModSecretStoreImpl)(nil)
+	_ store.BlockedURLStore     = (*BlockedURLStoreImpl)(nil)
 )
 
 // --------------------------------------------------------------------------

--- a/internal/pages/admin_blocked_urls.go
+++ b/internal/pages/admin_blocked_urls.go
@@ -1,0 +1,143 @@
+package pages
+
+import (
+	"context"
+	"createmod/internal/blockedurls"
+	"createmod/internal/cache"
+	"createmod/internal/i18n"
+	"createmod/internal/server"
+	"createmod/internal/store"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var adminBlockedURLsTemplates = append([]string{
+	"./template/admin_blocked_urls.html",
+}, commonTemplates...)
+
+// AdminBlockedURLRow is one blocked URL shown in the admin list.
+type AdminBlockedURLRow struct {
+	ID      string
+	URL     string
+	Note    string
+	Created string
+}
+
+type AdminBlockedURLsData struct {
+	DefaultData
+	BlockedURLs []AdminBlockedURLRow
+	FormError   string
+}
+
+// AdminBlockedURLsHandler renders the admin page for managing blocked URLs
+// (e.g. DMCA takedown targets that must return a 404).
+func AdminBlockedURLsHandler(registry *server.Registry, cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+
+		list, err := appStore.BlockedURLs.List(context.Background())
+		if err != nil {
+			return e.String(http.StatusInternalServerError, "failed to list blocked URLs")
+		}
+		rows := make([]AdminBlockedURLRow, len(list))
+		for i, b := range list {
+			rows[i] = AdminBlockedURLRow{
+				ID:      b.ID,
+				URL:     b.URL,
+				Note:    b.Note,
+				Created: b.Created.Format("2006-01-02 15:04"),
+			}
+		}
+
+		d := AdminBlockedURLsData{
+			BlockedURLs: rows,
+			FormError:   e.Request.URL.Query().Get("error"),
+		}
+		d.Populate(e)
+		d.AdminSection = "blocked-urls"
+		d.Breadcrumbs = NewBreadcrumbs(d.Language, i18n.T(d.Language, "Admin"), "/admin", i18n.T(d.Language, "Blocked URLs"))
+		d.Title = i18n.T(d.Language, "Admin: Blocked URLs")
+		d.SubCategory = "Admin"
+		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
+
+		html, err := registry.LoadFiles(adminBlockedURLsTemplates...).Render(d)
+		if err != nil {
+			return err
+		}
+		return e.HTML(http.StatusOK, html)
+	}
+}
+
+// AdminBlockedURLCreateHandler adds a blocked URL. The submitted value may be
+// a full URL or an absolute path; it is normalized to path + query.
+func AdminBlockedURLCreateHandler(cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		if err := e.Request.ParseForm(); err != nil {
+			return e.String(http.StatusBadRequest, "invalid form")
+		}
+		normalized, err := blockedurls.Normalize(e.Request.FormValue("url"))
+		if err != nil {
+			return adminBlockedURLsRedirect(e, err.Error())
+		}
+		if strings.HasPrefix(normalized, "/admin") {
+			return adminBlockedURLsRedirect(e, "refusing to block admin pages")
+		}
+
+		b := &store.BlockedURL{
+			URL:       normalized,
+			Note:      strings.TrimSpace(e.Request.FormValue("note")),
+			CreatedBy: authenticatedUserID(e),
+		}
+		if err := appStore.BlockedURLs.Create(context.Background(), b); err != nil {
+			return e.String(http.StatusInternalServerError, "failed to create blocked URL")
+		}
+		invalidateBlockedURLsCache(cacheService)
+		return adminBlockedURLsRedirect(e, "")
+	}
+}
+
+// AdminBlockedURLDeleteHandler removes a blocked URL so it is served normally
+// again.
+func AdminBlockedURLDeleteHandler(cacheService *cache.Service, appStore *store.Store) func(e *server.RequestEvent) error {
+	return func(e *server.RequestEvent) error {
+		if !isSuperAdmin(e) {
+			return e.String(http.StatusForbidden, "forbidden")
+		}
+		id := e.Request.PathValue("id")
+		if id == "" {
+			return e.String(http.StatusBadRequest, "missing id")
+		}
+		if err := appStore.BlockedURLs.Delete(context.Background(), id); err != nil {
+			return e.String(http.StatusInternalServerError, "failed to delete blocked URL")
+		}
+		invalidateBlockedURLsCache(cacheService)
+		return adminBlockedURLsRedirect(e, "")
+	}
+}
+
+// invalidateBlockedURLsCache clears the cached blocklist so changes take
+// effect immediately on this pod and, via Redis pub/sub, on all other pods.
+func invalidateBlockedURLsCache(cacheService *cache.Service) {
+	if cacheService != nil {
+		cacheService.Delete(cache.BlockedURLsKey)
+	}
+}
+
+func adminBlockedURLsRedirect(e *server.RequestEvent, formError string) error {
+	target := "/admin/blocked-urls"
+	if formError != "" {
+		target = fmt.Sprintf("%s?error=%s", target, url.QueryEscape(formError))
+	}
+	if e.Request.Header.Get("HX-Request") != "" {
+		e.Response.Header().Set("HX-Redirect", LangRedirectURL(e, target))
+		return e.HTML(http.StatusNoContent, "")
+	}
+	return e.Redirect(http.StatusSeeOther, LangRedirectURL(e, target))
+}

--- a/internal/pages/admin_blocked_urls_template_test.go
+++ b/internal/pages/admin_blocked_urls_template_test.go
@@ -1,0 +1,44 @@
+package pages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func Test_AdminBlockedURLs_Template_Has_Expected_Elements(t *testing.T) {
+	path := filepath.Join("..", "..", "template", "admin_blocked_urls.html")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	s := string(b)
+	must := []string{
+		"Admin: Blocked URLs",
+		"Block a URL",
+		`name="url"`,
+		`name="note"`,
+		`action="/admin/blocked-urls"`,
+		"/admin/blocked-urls/{{ .ID }}/delete",
+		"Unblock",
+		"No blocked URLs.",
+		"admin_nav.html",
+	}
+	for _, m := range must {
+		if !strings.Contains(s, m) {
+			t.Fatalf("admin_blocked_urls.html missing: %s", m)
+		}
+	}
+}
+
+func Test_AdminNav_Has_BlockedURLs_Link(t *testing.T) {
+	path := filepath.Join("..", "..", "template", "include", "admin_nav.html")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(b), `href="/admin/blocked-urls"`) {
+		t.Fatal("admin_nav.html missing blocked URLs link")
+	}
+}

--- a/internal/router/blocked_urls.go
+++ b/internal/router/blocked_urls.go
@@ -1,0 +1,79 @@
+package router
+
+import (
+	"context"
+	"createmod/internal/blockedurls"
+	"createmod/internal/cache"
+	"createmod/internal/pages"
+	"createmod/internal/store"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// blockedURLMiddleware serves a 404 for requests whose path + query match an
+// admin-managed blocked URL (e.g. DMCA takedown targets). It runs before the
+// legacy-compat rewrites so the exact reported URL is blocked, not its
+// redirect target. The blocklist is cached per-pod; admin changes invalidate
+// the cache on all pods via Redis pub/sub.
+func blockedURLMiddleware(appStore *store.Store, cacheService *cache.Service, notFound http.HandlerFunc) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			entries := blockedURLList(appStore, cacheService)
+			if len(entries) > 0 && blockedurls.Matches(entries, effectiveRequestURL(req)) {
+				notFound(w, req)
+				return
+			}
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+// effectiveRequestURL returns the URL as the visitor requested it.
+// LangPrefixHandler strips the language prefix (e.g. /es) at the transport
+// level before this middleware runs, so blocked entries stored with a
+// language prefix would never match without restoring it here.
+func effectiveRequestURL(req *http.Request) *url.URL {
+	lang := req.Header.Get("X-Createmod-Lang")
+	if lang == "" {
+		return req.URL
+	}
+	prefix, ok := pages.LangToPrefix[lang]
+	if !ok || prefix == "" {
+		return req.URL
+	}
+	u := *req.URL
+	u.Path = "/" + prefix + u.Path
+	return &u
+}
+
+// blockedURLList returns the blocked URL entries, from cache when possible.
+// On store errors it fails open (returns nil) so a database hiccup never
+// takes down regular traffic.
+func blockedURLList(appStore *store.Store, cacheService *cache.Service) []string {
+	if cacheService != nil {
+		if v, ok := cacheService.Get(cache.BlockedURLsKey); ok {
+			if entries, ok := v.([]string); ok {
+				return entries
+			}
+		}
+	}
+	if appStore == nil || appStore.BlockedURLs == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	entries, err := appStore.BlockedURLs.ListURLs(ctx)
+	if err != nil {
+		slog.Error("blocked urls: failed to list", "error", err)
+		return nil
+	}
+	if entries == nil {
+		entries = []string{}
+	}
+	if cacheService != nil {
+		cacheService.Set(cache.BlockedURLsKey, entries)
+	}
+	return entries
+}

--- a/internal/router/blocked_urls_test.go
+++ b/internal/router/blocked_urls_test.go
@@ -1,0 +1,35 @@
+package router
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// LangPrefixHandler strips the language prefix before this middleware runs,
+// so effectiveRequestURL must restore it for blocked entries stored with a
+// prefix (e.g. /es/search?q=foo) to ever match.
+func Test_effectiveRequestURL(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		lang string
+		want string
+	}{
+		{"no lang header", "/search?q=foo", "", "/search?q=foo"},
+		{"es prefix restored", "/search?p=17&q=canva", "es", "/es/search?p=17&q=canva"},
+		{"unknown lang left alone", "/search?q=foo", "xx", "/search?q=foo"},
+		{"pt-BR prefix restored", "/schematics/some-build", "pt-BR", "/pt-br/schematics/some-build"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			if tt.lang != "" {
+				req.Header.Set("X-Createmod-Lang", tt.lang)
+			}
+			got := effectiveRequestURL(req)
+			if got.RequestURI() != tt.want {
+				t.Fatalf("effectiveRequestURL(%q, lang=%q) = %q, want %q", tt.path, tt.lang, got.RequestURI(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -276,6 +276,9 @@ func Register(p RegisterParams) chi.Router {
 	r.Use(requestLogger)
 	r.Use(securityHeaders)
 	r.Use(maintenanceModeMiddleware(maintenanceFlag))
+	// Admin-managed blocked URLs (DMCA takedowns) return a 404. Runs before
+	// the legacy-compat rewrites so the exact reported URL is what's blocked.
+	r.Use(blockedURLMiddleware(p.AppStore, p.CacheService, Adapt(pages.FourOhFourHandler(registry, p.AppStore))))
 	r.Use(legacyFileCompat)
 	r.Use(legacySearchCompat)
 	r.Use(legacyCategoryCompat)
@@ -562,6 +565,9 @@ func Register(p RegisterParams) chi.Router {
 		r.Post("/admin/api-secrets", Adapt(pages.AdminModSecretCreateHandler(p.CacheService, p.AppStore)))
 		r.Post("/admin/api-secrets/{id}/active", Adapt(pages.AdminModSecretActiveHandler(p.CacheService, p.AppStore)))
 		r.Post("/admin/api-secrets/{id}/delete", Adapt(pages.AdminModSecretDeleteHandler(p.CacheService, p.AppStore)))
+		r.Get("/admin/blocked-urls", Adapt(pages.AdminBlockedURLsHandler(registry, p.CacheService, p.AppStore)))
+		r.Post("/admin/blocked-urls", Adapt(pages.AdminBlockedURLCreateHandler(p.CacheService, p.AppStore)))
+		r.Post("/admin/blocked-urls/{id}/delete", Adapt(pages.AdminBlockedURLDeleteHandler(p.CacheService, p.AppStore)))
 		r.Get("/admin/api-keys", Adapt(pages.AdminAPIKeysHandler(registry, p.CacheService, p.AppStore)))
 		r.Post("/admin/api-keys/{id}/rate-limit", Adapt(pages.AdminAPIKeyRateLimitHandler(p.AppStore)))
 		r.Get("/admin/mods", Adapt(pages.AdminModsHandler(registry, p.CacheService, p.AppStore)))

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1547,6 +1547,27 @@ type ModSecretStore interface {
 	Delete(ctx context.Context, id string) error
 }
 
+// BlockedURL is an admin-managed URL (path + optional query string) that is
+// served a 404, e.g. to honor DMCA takedown notices without removing
+// unrelated content.
+type BlockedURL struct {
+	ID        string
+	URL       string // path + optional query, e.g. /es/search?q=foo
+	Note      string // free text, e.g. the takedown notice reference
+	CreatedBy string
+	Created   time.Time
+}
+
+// BlockedURLStore manages admin-defined blocked URLs.
+type BlockedURLStore interface {
+	// ListURLs returns just the URL strings of all entries (hot path).
+	ListURLs(ctx context.Context) ([]string, error)
+	// List returns all entries (for the admin UI), newest first.
+	List(ctx context.Context) ([]BlockedURL, error)
+	Create(ctx context.Context, b *BlockedURL) error
+	Delete(ctx context.Context, id string) error
+}
+
 type Store struct {
 	Users               UserStore
 	Sessions            SessionStore
@@ -1593,4 +1614,5 @@ type Store struct {
 	Security            SecurityStore
 	AdClicks            AdClickStore
 	ModSecrets          ModSecretStore
+	BlockedURLs         BlockedURLStore
 }

--- a/template/admin_blocked_urls.html
+++ b/template/admin_blocked_urls.html
@@ -1,0 +1,89 @@
+{{template "head.html" .}}
+<div class="page">
+  {{template "sidebar.html" .}}
+  <div class="page-wrapper">
+    {{template "header.html" .}}
+    <main class="page-body">
+      <div class="container-wide">
+        {{template "admin_nav.html" .}}
+        <div class="page-header d-print-none">
+          <div class="row align-items-center">
+            <div class="col">
+              <h2 class="page-title">Admin: Blocked URLs</h2>
+              <div class="text-secondary">URLs listed here return a 404 to every visitor. Use this to honor DMCA takedown notices without removing unrelated content. Matching is exact on path and query parameters (parameter order does not matter).</div>
+            </div>
+          </div>
+        </div>
+
+        {{if not .IsAuthenticated}}
+          <div class="alert alert-danger">You must be logged in.</div>
+        {{end}}
+
+        {{if .FormError}}
+          <div class="alert alert-danger">{{ .FormError }}</div>
+        {{end}}
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h3 class="card-title">Block a URL</h3>
+          </div>
+          <div class="card-body">
+            <form method="post" action="/admin/blocked-urls">
+              <div class="row g-2">
+                <div class="col-md-7">
+                  <label class="form-label">URL</label>
+                  <input type="text" class="form-control" name="url" required placeholder="https://createmod.com/es/search?p=17&amp;q=term or /es/search?q=term">
+                </div>
+                <div class="col-md-5">
+                  <label class="form-label">Note</label>
+                  <input type="text" class="form-control" name="note" placeholder="e.g. DMCA notice reference">
+                </div>
+              </div>
+              <div class="mt-3">
+                <button type="submit" class="btn btn-primary">Block URL</button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h3 class="card-title">Blocked URLs</h3>
+          </div>
+          <div class="table-responsive">
+            <table class="table card-table table-vcenter">
+              <thead>
+                <tr>
+                  <th>URL</th>
+                  <th>Note</th>
+                  <th>Created</th>
+                  <th class="w-1">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{range .BlockedURLs}}
+                <tr>
+                  <td><code style="word-break:break-all;">{{ .URL }}</code></td>
+                  <td>{{ if .Note }}{{ .Note }}{{ else }}<span class="text-secondary">—</span>{{ end }}</td>
+                  <td class="text-secondary">{{ .Created }}</td>
+                  <td>
+                    <form method="post" action="/admin/blocked-urls/{{ .ID }}/delete" style="display:inline" onsubmit="return confirm('Unblock this URL? It will be served normally again.');">
+                      <button type="submit" class="btn btn-sm btn-danger">Unblock</button>
+                    </form>
+                  </td>
+                </tr>
+                {{else}}
+                <tr>
+                  <td colspan="4" class="text-secondary">No blocked URLs.</td>
+                </tr>
+                {{end}}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </main>
+    {{template "footer.html" .}}
+  </div>
+</div>
+{{template "foot.html" .}}

--- a/template/include/admin_nav.html
+++ b/template/include/admin_nav.html
@@ -34,6 +34,9 @@
     <li class="nav-item">
       <a class="nav-link{{ if eq .AdminSection "api-keys" }} active{{ end }}" href="/admin/api-keys">API Keys</a>
     </li>
+    <li class="nav-item">
+      <a class="nav-link{{ if eq .AdminSection "blocked-urls" }} active{{ end }}" href="/admin/blocked-urls">Blocked URLs</a>
+    </li>
   </ul>
 </div>
 {{end}}


### PR DESCRIPTION
Admin-managed list of URLs (path + query) that return a 404 to every visitor. Matching is exact on path and query parameters (parameter order-insensitive) so a takedown target like
/es/search?p=17&q=some-term can be blocked without affecting other searches, pages, or languages.

- migration 080: blocked_urls table (unique on url)
- internal/blockedurls: normalization + matching helpers
- /admin/blocked-urls: list, add (full URL or absolute path), unblock
- router middleware serves the localized 404 before legacy-compat rewrites; restores the language prefix that LangPrefixHandler strips at the transport level
- blocklist cached per pod, invalidated across pods via Redis pub/sub