### PR TITLE
fix(search): stop the loading bar getting stuck; upgrade htmx to 2.0.10

### DIFF
--- a/template/include/head.html
+++ b/template/include/head.html
@@ -75,7 +75,7 @@ window.setTheme=function(theme){
 
 
     <!-- HTMX (via jsdelivr to share CDN connection) -->
-    <script src="https://cdn.jsdelivr.net/npm/htmx.org@1.9.12/dist/htmx.min.js" defer crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.10/dist/htmx.min.js" integrity="sha384-H5SrcfygHmAuTDZphMHqBJLc3FhssKjG7w/CeCpFReSfwBWDTKpkzPP8c+cLsK+V" defer crossorigin="anonymous"></script>
     <!-- DOMPurify – client-side HTML sanitization for defense-in-depth -->
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js" defer crossorigin="anonymous"></script>
     <!-- Framework JS (dropdown, modal, collapse, tabs) — in <head> to prevent re-execution on HTMX body swaps -->
@@ -272,3 +272,33 @@ window.setTheme=function(theme){
   })();
 </script>
 <div id="htmx-indicator" class="htmx-indicator"></div>
+<script>
+  // Safety net for the shared loading bar. htmx can leak the htmx-request
+  // class on #htmx-indicator when a response's target was removed by a
+  // concurrent swap (htmx:swapError) or the request was aborted (hx-sync),
+  // leaving the bar animating forever. Track in-flight XHRs and clear the
+  // bar whenever none remain.
+  (function () {
+    var inflight = new Set();
+    function sweep() {
+      inflight.forEach(function (x) {
+        if (x.readyState === 4 || x.readyState === 0) inflight.delete(x);
+      });
+      if (inflight.size === 0) {
+        var el = document.getElementById('htmx-indicator');
+        if (el) el.classList.remove('htmx-request');
+      }
+    }
+    document.addEventListener('htmx:beforeRequest', function (e) {
+      if (e.detail && e.detail.xhr) inflight.add(e.detail.xhr);
+    });
+    ['htmx:afterRequest', 'htmx:sendError', 'htmx:responseError', 'htmx:swapError',
+     'htmx:targetError', 'htmx:timeout', 'htmx:abort'].forEach(function (ev) {
+      document.addEventListener(ev, function (e) {
+        if (e.detail && e.detail.xhr) inflight.delete(e.detail.xhr);
+        setTimeout(sweep, 0);
+      });
+    });
+    setInterval(sweep, 2000);
+  })();
+</script>

--- a/template/include/search_filters.html
+++ b/template/include/search_filters.html
@@ -2,7 +2,7 @@
 <div id="search-filters">
     <form id="advanced-search-form" method="get" action="/search" autocomplete="off"
           hx-get="/search" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML" hx-push-url="true"
-          hx-trigger="change">
+          hx-trigger="change" hx-sync="this:replace">
         <div class="search-filter-bar">
             <div class="search-filter-row">
                 <div class="search-filter-input input-icon">
@@ -12,7 +12,7 @@
                     <input id="search-hero-input" type="text" value="{{ .Term }}" name="q" class="form-control" placeholder="{{ T .Language "Search schematics, creators, tags..." }}"
                            aria-label="Search CreateMod.com" autocomplete="off"
                            hx-get="/search" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"
-                           hx-trigger="keyup changed delay:800ms, search" hx-include="closest form">
+                           hx-trigger="keyup changed delay:800ms, search" hx-include="closest form" hx-sync="closest form:replace">
                 </div>
                 <div class="search-filter-item">
                     <span class="filter-label">{{ T .Language "Sort" }}:</span>

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -1516,7 +1516,7 @@ function copyMaterialsAsMarkdown() {
             headers: { 'HX-Request': 'true' }
         }).then(function(resp) {
             if (resp.ok) {
-                htmx.ajax('GET', '/schematics/{{ .Schematic.Name }}/comments', {target:'#comments-list', swap:'outerHTML'});
+                htmx.ajax('GET', '/schematics/{{ .Schematic.Name }}/comments', {target:'#comments-list', swap:'outerHTML'}).catch(function(){});
             }
         });
     });
@@ -1544,7 +1544,7 @@ document.addEventListener('htmx:afterRequest', function(evt) {
       var status = evt.detail && evt.detail.xhr ? evt.detail.xhr.status : 0;
       if (status >= 200 && status < 300) {
         gtag('event', 'comment_post', { 'schematic_id': '{{ .Schematic.ID }}' });
-        htmx.ajax('GET','/schematics/{{ .Schematic.Name }}/comments', {target:'#comments-list', swap:'outerHTML'});
+        htmx.ajax('GET','/schematics/{{ .Schematic.Name }}/comments', {target:'#comments-list', swap:'outerHTML'}).catch(function(){});
         var s = document.getElementById('comment-success'); if (s) { s.style.display = 'block'; }
         if (window._cmCommentEditor) { window._cmCommentEditor.commands.clearContent(); }
         var p = document.getElementById('parent-comment'); if (p) { p.value = ''; }

--- a/template/search.html
+++ b/template/search.html
@@ -153,14 +153,14 @@
                                     <ul class="pagination mb-0">
                                         {{ if gt .Page 1 }}
                                         <li class="page-item">
-                                            <a class="page-link page-link-arrow" href="{{ .FirstURL }}" hx-get="{{ .FirstURL }}" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M11 7l-5 5l5 5"/><path d="M17 7l-5 5l5 5"/></svg></a>
+                                            <a class="page-link page-link-arrow" href="{{ .FirstURL }}" hx-get="{{ .FirstURL }}" hx-sync="#advanced-search-form:replace" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M11 7l-5 5l5 5"/><path d="M17 7l-5 5l5 5"/></svg></a>
                                         </li>
                                         {{ else }}
                                         <li class="page-item disabled"><span class="page-link page-link-arrow"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M11 7l-5 5l5 5"/><path d="M17 7l-5 5l5 5"/></svg></span></li>
                                         {{ end }}
                                         {{ if .HasPrev }}
                                         <li class="page-item">
-                                            <a class="page-link page-link-arrow" href="{{ .PrevURL }}" hx-get="{{ .PrevURL }}" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6l6 6"/></svg></a>
+                                            <a class="page-link page-link-arrow" href="{{ .PrevURL }}" hx-get="{{ .PrevURL }}" hx-sync="#advanced-search-form:replace" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6l6 6"/></svg></a>
                                         </li>
                                         {{ else }}
                                         <li class="page-item disabled"><span class="page-link page-link-arrow"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6l6 6"/></svg></span></li>
@@ -168,14 +168,14 @@
                                         <li class="page-item"><span class="page-link page-link-info page-jump-trigger" data-page-jump data-current-page="{{ .Page }}" data-total-pages="{{ .TotalPages }}" data-page-param="p">{{ T .Language "Page" }} {{ .Page }}/{{ .TotalPages }}</span></li>
                                         {{ if .HasNext }}
                                         <li class="page-item">
-                                            <a class="page-link page-link-arrow" href="{{ .NextURL }}" hx-get="{{ .NextURL }}" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6l-6 6"/></svg></a>
+                                            <a class="page-link page-link-arrow" href="{{ .NextURL }}" hx-get="{{ .NextURL }}" hx-sync="#advanced-search-form:replace" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6l-6 6"/></svg></a>
                                         </li>
                                         {{ else }}
                                         <li class="page-item disabled"><span class="page-link page-link-arrow"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6l-6 6"/></svg></span></li>
                                         {{ end }}
                                         {{ if and (gt .TotalPages 0) (lt .Page .TotalPages) }}
                                         <li class="page-item">
-                                            <a class="page-link page-link-arrow" href="{{ .LastURL }}" hx-get="{{ .LastURL }}" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M7 7l5 5l-5 5"/><path d="M13 7l5 5l-5 5"/></svg></a>
+                                            <a class="page-link page-link-arrow" href="{{ .LastURL }}" hx-get="{{ .LastURL }}" hx-sync="#advanced-search-form:replace" hx-target="#search-results" hx-select="#search-results" hx-swap="outerHTML scroll:top" hx-push-url="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M7 7l5 5l-5 5"/><path d="M13 7l5 5l-5 5"/></svg></a>
                                         </li>
                                         {{ else }}
                                         <li class="page-item disabled"><span class="page-link page-link-arrow"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M7 7l5 5l-5 5"/><path d="M13 7l5 5l-5 5"/></svg></span></li>


### PR DESCRIPTION
The global loading bar (#htmx-indicator) could animate forever when two HTMX requests overlapped on the search page: the live-search input (800ms debounce) and the filter form both swap #search-results with outerHTML, and under htmx 1.9.12 the second response hit a detached target, threw htmx:swapError, and never released the indicator class. Slow responses on dev made the overlap easy to hit; prod rarely did.

- upgrade htmx 1.9.12 -> 2.0.10 (with SRI hash); 2.x handles the detached-target swap gracefully. 4.0 is still beta (beta5) and is a major rewrite, so not adopted. Audited 1->2 breaking changes: no hx-on/hx-sse/hx-ws/hx-vars usage; all hx-delete handlers read only path params so the DELETE param encoding change is safe
- hx-sync on the search input, filter form, and pagination links so a new request aborts the in-flight one instead of racing it (also prevents a slow older response overwriting newer results)
- safety-net script beside #htmx-indicator that tracks in-flight XHRs and clears the bar whenever none remain, covering any remaining swapError/abort/timeout leak site-wide (e.g. the notification badge load racing a boosted navigation)
- .catch() on the two htmx.ajax comment-refresh calls: in 2.x the returned promise rejects on abort, which logged unhandled rejections