### PR TITLE
fix(jobs): stop the backfill recompute loop

### DIFF
--- a/internal/database/gen/schematic_fingerprints.sql.go
+++ b/internal/database/gen/schematic_fingerprints.sql.go
@@ -70,9 +70,9 @@ func (q *Queries) ListAllFingerprints(ctx context.Context, version int32) ([]Lis
 const listSchematicsNeedingFingerprint = `-- name: ListSchematicsNeedingFingerprint :many
 SELECT s.id FROM schematics s
 LEFT JOIN schematic_fingerprints sf ON sf.schematic_id = s.id
-WHERE (sf.schematic_id IS NULL OR sf.version < $1 OR s.updated > sf.computed_at)
+WHERE (sf.schematic_id IS NULL OR sf.version < $1 OR COALESCE(s.modified, s.created) > sf.computed_at)
   AND s.deleted IS NULL
-ORDER BY s.created DESC
+ORDER BY (sf.schematic_id IS NULL) DESC, s.created DESC
 LIMIT $2
 `
 

--- a/internal/database/gen/schematic_safety.sql.go
+++ b/internal/database/gen/schematic_safety.sql.go
@@ -40,9 +40,9 @@ func (q *Queries) GetSchematicSafety(ctx context.Context, schematicID string) (S
 const listSchematicsNeedingSafetyScan = `-- name: ListSchematicsNeedingSafetyScan :many
 SELECT s.id FROM schematics s
 LEFT JOIN schematic_safety ss ON ss.schematic_id = s.id
-WHERE (ss.schematic_id IS NULL OR ss.pipeline_version < $1 OR s.updated > ss.scanned_at)
+WHERE (ss.schematic_id IS NULL OR ss.pipeline_version < $1 OR COALESCE(s.modified, s.created) > ss.scanned_at)
   AND s.deleted IS NULL
-ORDER BY s.created DESC
+ORDER BY (ss.schematic_id IS NULL) DESC, s.created DESC
 LIMIT $2
 `
 

--- a/internal/database/gen/schematics.sql.go
+++ b/internal/database/gen/schematics.sql.go
@@ -1907,7 +1907,8 @@ UPDATE schematics SET
     schematic_file = COALESCE($27, schematic_file),
     short_code = COALESCE($28, short_code),
     created = COALESCE($29, created),
-    rotation_disabled = COALESCE($30, rotation_disabled)
+    rotation_disabled = COALESCE($30, rotation_disabled),
+    modified = NOW()
 WHERE id = $1
 RETURNING id, author_id, name, title, description, excerpt, content, postdate, modified, detected_language, featured_image, gallery, schematic_file, video, has_dependencies, dependencies, createmod_version_id, minecraft_version_id, views, downloads, block_count, dim_x, dim_y, dim_z, materials, mods, paid, featured, ai_description, moderation_reason, scheduled_at, deleted, deleted_at, old_id, status, type, created, updated, external_url, trending_score, avg_rating, rating_count, moderation_state, rotation_images, short_code, rotation_disabled
 `

--- a/internal/database/queries/schematic_fingerprints.sql
+++ b/internal/database/queries/schematic_fingerprints.sql
@@ -12,9 +12,9 @@ SELECT * FROM schematic_fingerprints WHERE schematic_id = $1;
 -- name: ListSchematicsNeedingFingerprint :many
 SELECT s.id FROM schematics s
 LEFT JOIN schematic_fingerprints sf ON sf.schematic_id = s.id
-WHERE (sf.schematic_id IS NULL OR sf.version < $1 OR s.updated > sf.computed_at)
+WHERE (sf.schematic_id IS NULL OR sf.version < $1 OR COALESCE(s.modified, s.created) > sf.computed_at)
   AND s.deleted IS NULL
-ORDER BY s.created DESC
+ORDER BY (sf.schematic_id IS NULL) DESC, s.created DESC
 LIMIT $2;
 
 -- name: ListAllFingerprints :many

--- a/internal/database/queries/schematic_safety.sql
+++ b/internal/database/queries/schematic_safety.sql
@@ -14,9 +14,9 @@ SELECT * FROM schematic_safety WHERE schematic_id = $1;
 -- name: ListSchematicsNeedingSafetyScan :many
 SELECT s.id FROM schematics s
 LEFT JOIN schematic_safety ss ON ss.schematic_id = s.id
-WHERE (ss.schematic_id IS NULL OR ss.pipeline_version < $1 OR s.updated > ss.scanned_at)
+WHERE (ss.schematic_id IS NULL OR ss.pipeline_version < $1 OR COALESCE(s.modified, s.created) > ss.scanned_at)
   AND s.deleted IS NULL
-ORDER BY s.created DESC
+ORDER BY (ss.schematic_id IS NULL) DESC, s.created DESC
 LIMIT $2;
 
 -- name: DeleteSchematicSafety :exec

--- a/internal/database/queries/schematics.sql
+++ b/internal/database/queries/schematics.sql
@@ -114,7 +114,8 @@ UPDATE schematics SET
     schematic_file = COALESCE(sqlc.narg('schematic_file'), schematic_file),
     short_code = COALESCE(sqlc.narg('short_code'), short_code),
     created = COALESCE(sqlc.narg('created'), created),
-    rotation_disabled = COALESCE(sqlc.narg('rotation_disabled'), rotation_disabled)
+    rotation_disabled = COALESCE(sqlc.narg('rotation_disabled'), rotation_disabled),
+    modified = NOW()
 WHERE id = $1
 RETURNING *;
 

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/riverqueue/river/rivertype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/riverqueue/river"
@@ -57,25 +56,21 @@ type Config struct {
 // chainBackfill re-enqueues a backfill job immediately when the current run
 // processed a full batch, so a large backlog (a fresh table after a
 // migration, or a version bump) drains continuously instead of one batch
-// per 15-minute periodic sweep. The unique states deliberately exclude
-// "running" so the follow-up can be inserted from inside the current run,
-// while still deduping against an already-queued follow-up.
+// per 15-minute periodic sweep.
+//
+// The insert is deliberately NOT unique: River requires unique jobs to
+// dedupe against the "running" state, which would always match the very
+// job doing the chaining and silently drop the follow-up (this happened in
+// production — the drain never chained). A plain insert can briefly allow
+// a second lineage when the periodic sweep overlaps a chained run; both
+// stop as soon as a batch comes back short, and the work itself is
+// idempotent upserts.
 func chainBackfill(ctx context.Context, args river.JobArgs) {
 	client, err := river.ClientFromContextSafely[pgx.Tx](ctx)
 	if err != nil {
 		return
 	}
-	if _, err := client.Insert(ctx, args, &river.InsertOpts{
-		UniqueOpts: river.UniqueOpts{
-			ByArgs: true,
-			ByState: []rivertype.JobState{
-				rivertype.JobStateAvailable,
-				rivertype.JobStatePending,
-				rivertype.JobStateRetryable,
-				rivertype.JobStateScheduled,
-			},
-		},
-	}); err != nil {
+	if _, err := client.Insert(ctx, args, nil); err != nil {
 		slog.Warn("backfill chain: insert failed", "kind", args.Kind(), "error", err)
 	}
 }


### PR DESCRIPTION
Two production bugs kept the fingerprint/safety backfills stuck (the similar index froze at ~950 of the catalog while re-downloading the same 200 newest schematics from S3 every 15 minutes, forever):

1. The needing-work queries compared computed_at against s.updated, but a trigger bumps updated on EVERY schematics write — view counters, download counters, trending scores — so the newest 200 were permanently 'stale' and, ordered by created DESC, crowded out everything never computed. The queries now compare against COALESCE(s.modified, s.created) (real content edits only) and process never-computed rows first. UpdateSchematic now sets modified = NOW() so edits keep triggering recompute.

2. chainBackfill inserted with UniqueOpts.ByState excluding 'running', which River rejects ('ByState must contain all required states'); the follow-up insert failed every time and the drain never chained. The chain is now a plain insert — a brief second lineage when the periodic sweep overlaps is possible and harmless (idempotent upserts), and every lineage stops on the first short batch.

Verified against a migrated database: counter churn no longer re-queues a fingerprinted schematic, a real edit does, and never-computed rows sort ahead of re-queued ones.