### PR TITLE
feat(ads): recover ad-block-hidden rail inventory without popups

### DIFF
--- a/template/collections.html
+++ b/template/collections.html
@@ -85,10 +85,10 @@
             <div id="collections-mobile" class="d-lg-none mt-3 text-center"></div>
           </div>
           <!-- Ad Rails -->
-          <div class="ad-rail-sm d-none d-lg-block d-xl-none">
+          <div class="cm-side-rail-sm d-none d-lg-block d-xl-none">
             <div id="collections-sticky-adrail-lg" class="mb-3"></div>
           </div>
-          <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="collections" data-kw="minecraft,create-mod,collections" data-page="collections"></div>
+          <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="collections" data-kw="minecraft,create-mod,collections" data-page="collections"></div>
           </div>
         </div>
       </div>

--- a/template/collections_show.html
+++ b/template/collections_show.html
@@ -135,10 +135,10 @@
           </div>
 
           <!-- Ad Rails -->
-          <div class="ad-rail-sm d-none d-lg-block d-xl-none">
+          <div class="cm-side-rail-sm d-none d-lg-block d-xl-none">
             <div id="collshow-sticky-adrail-lg" class="mb-3"></div>
           </div>
-          <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="collshow" data-kw="minecraft,create-mod,collection" data-page="collection"></div>
+          <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="collshow" data-kw="minecraft,create-mod,collection" data-page="collection"></div>
           </div>
         </div><!-- /d-flex -->
       </div>

--- a/template/convert.html
+++ b/template/convert.html
@@ -92,7 +92,7 @@
                 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Minecraft Schematic Converter","applicationCategory":"UtilitiesApplication","operatingSystem":"Web","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://createmod.com/tools/convert"}</script>
                 </div><!-- /max-width -->
                 </div><!-- /flex-grow-1 -->
-                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="convert" data-kw="minecraft,create-mod,schematic,converter" data-page="convert"></div>
+                <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="convert" data-kw="minecraft,create-mod,schematic,converter" data-page="convert"></div>
                 </div><!-- /d-flex -->
             </div>
         </main>

--- a/template/download_interstitial.html
+++ b/template/download_interstitial.html
@@ -7,7 +7,7 @@
       <div class="container-wide">
         <div class="d-flex gap-3 justify-content-center">
           <!-- Left Ad Rail (desktop only) -->
-          <div class="ad-rail d-none d-xl-block">
+          <div class="cm-side-rail d-none d-xl-block">
             <div id="dlinterstitial-sticky-adrail-left" class="mb-3"></div>
           </div>
           <div style="max-width:540px; width:100%; padding:2rem 0;">
@@ -28,7 +28,7 @@
             </div>
           </div>
           <!-- Right Ad Rail (desktop only) -->
-          <div class="ad-rail d-none d-xl-block">
+          <div class="cm-side-rail d-none d-xl-block">
             <div id="dlinterstitial-sticky-adrail-right" class="mb-3"></div>
           </div>
         </div>

--- a/template/explore.html
+++ b/template/explore.html
@@ -59,7 +59,7 @@
                 </div>
 
                 <!-- Ad Rail (desktop only) -->
-                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="explore" data-kw="minecraft,create-mod,schematics,explore,discover" data-page="explore"></div>
+                <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="explore" data-kw="minecraft,create-mod,schematics,explore,discover" data-page="explore"></div>
                 </div>
             </div>
         </main>

--- a/template/external_interstitial.html
+++ b/template/external_interstitial.html
@@ -7,7 +7,7 @@
       <div class="container-wide">
         <div class="d-flex gap-3 justify-content-center">
           <!-- Left Ad Rail (desktop only) -->
-          <div class="ad-rail d-none d-xl-block">
+          <div class="cm-side-rail d-none d-xl-block">
             <div id="extinterstitial-sticky-adrail-left" class="mb-3"></div>
           </div>
           <div style="max-width:540px; width:100%; padding:2rem 0;">
@@ -25,7 +25,7 @@
             </div>
           </div>
           <!-- Right Ad Rail (desktop only) -->
-          <div class="ad-rail d-none d-xl-block">
+          <div class="cm-side-rail d-none d-xl-block">
             <div id="extinterstitial-sticky-adrail-right" class="mb-3"></div>
           </div>
         </div>

--- a/template/generators.html
+++ b/template/generators.html
@@ -63,7 +63,7 @@
                 </div>
                     </div>
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="generators" data-kw="minecraft,create-mod,generators,schematics" data-page="generators"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="generators" data-kw="minecraft,create-mod,generators,schematics" data-page="generators"></div>
                     </div>
                 </div>
             </div>

--- a/template/guides.html
+++ b/template/guides.html
@@ -58,7 +58,7 @@
 
         <!-- Ad Rail (desktop only) -->
         {{if not .IsContributor}}
-        <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="guides" data-kw="minecraft,create-mod,guide,tutorial" data-page="guides"></div>
+        <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="guides" data-kw="minecraft,create-mod,guide,tutorial" data-page="guides"></div>
         </div>
         {{end}}
         </div><!-- /d-flex -->

--- a/template/guides_show.html
+++ b/template/guides_show.html
@@ -86,7 +86,7 @@
 
         <!-- Ad Rail (desktop only) -->
         {{if not .IsContributor}}
-        <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="guideshow" data-kw="minecraft,create-mod,guide,tutorial" data-page="guide"></div>
+        <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="guideshow" data-kw="minecraft,create-mod,guide,tutorial" data-page="guide"></div>
         </div>
         {{end}}
         </div><!-- /d-flex -->

--- a/template/highest_scores.html
+++ b/template/highest_scores.html
@@ -33,7 +33,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="highscores" data-kw="minecraft,create-mod,schematics,highest-scores" data-page="highest-scores"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="highscores" data-kw="minecraft,create-mod,schematics,highest-scores" data-page="highest-scores"></div>
                     </div>
 
                 </div>

--- a/template/index.html
+++ b/template/index.html
@@ -106,7 +106,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="index" data-kw="minecraft,create-mod,schematics,home" data-page="index"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="index" data-kw="minecraft,create-mod,schematics,home" data-page="index"></div>
                     </div>
 
                 </div>

--- a/template/modify.html
+++ b/template/modify.html
@@ -169,11 +169,11 @@
 
                     <!-- Ad Rails -->
                     <!-- Narrow 160px rail for lg (992-1199px) -->
-                    <div class="ad-rail-sm d-none d-lg-block d-xl-none">
+                    <div class="cm-side-rail-sm d-none d-lg-block d-xl-none">
                         <div id="modify-sticky-adrail-lg" class="mb-3"></div>
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="modify" data-kw="minecraft,create-mod,modify,blocks" data-page="modify"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="modify" data-kw="minecraft,create-mod,modify,blocks" data-page="modify"></div>
                     </div>
                 </div><!-- /d-flex -->
             </div>

--- a/template/mods.html
+++ b/template/mods.html
@@ -55,7 +55,7 @@
         {{ end }}
           </div>
           <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-          <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="mods" data-kw="minecraft,create-mod,mods,addons" data-page="mods"></div>
+          <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="mods" data-kw="minecraft,create-mod,mods,addons" data-page="mods"></div>
         </div>
       </div>
     </main>

--- a/template/nbt_viewer.html
+++ b/template/nbt_viewer.html
@@ -38,7 +38,7 @@
                 </div>
                 </div><!-- /max-width -->
                 </div><!-- /flex-grow-1 -->
-                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="nbt-viewer" data-kw="minecraft,create-mod,schematic,nbt" data-page="nbt-viewer"></div>
+                <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="nbt-viewer" data-kw="minecraft,create-mod,schematic,nbt" data-page="nbt-viewer"></div>
                 </div><!-- /d-flex -->
             </div>
         </main>

--- a/template/profile.html
+++ b/template/profile.html
@@ -147,7 +147,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only) -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="profile" data-kw="minecraft,create-mod,profile,builder" data-page="profile"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="profile" data-kw="minecraft,create-mod,profile,builder" data-page="profile"></div>
                     </div>
                 </div>
             </div>

--- a/template/safety_check.html
+++ b/template/safety_check.html
@@ -89,7 +89,7 @@
                 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Can a Minecraft schematic contain a virus?","acceptedAnswer":{"@type":"Answer","text":"A schematic is a data file describing blocks and positions. It contains no executable code and Minecraft never executes it, so it cannot install anything on your computer the way a malicious mod jar could. The realistic concerns are in-world: command blocks, spawners, or sign click-commands included in the build. CreateMod.com inspects every published schematic and shows a transparency manifest of exactly those contents."}},{"@type":"Question","name":"What does the Validated badge on CreateMod.com mean?","acceptedAnswer":{"@type":"Answer","text":"Validated means the file parsed as well-formed schematic data, passed hardening checks (size, decompression and nesting limits), and a content inspection found no command blocks, spawners, or click commands. If the inspection finds any, the badge states what was found instead, with details available."}}]}</script>
 
                 </div><!-- /flex-grow-1 -->
-                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="safety-check" data-kw="minecraft,create-mod,schematic,safety" data-page="safety-check"></div>
+                <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="safety-check" data-kw="minecraft,create-mod,schematic,safety" data-page="safety-check"></div>
                 </div><!-- /d-flex -->
             </div>
         </main>

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -1178,11 +1178,11 @@
 
                     <!-- Column 3: Ad Rails -->
                     <!-- Narrow 160px rail for lg (992-1199px) -->
-                    <div class="ad-rail-sm d-none d-lg-block d-xl-none">
+                    <div class="cm-side-rail-sm d-none d-lg-block d-xl-none">
                         <div id="schematic-sticky-adrail-lg" class="mb-3"></div>
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+): video ad (scrolls away) above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="schematic" data-kw="minecraft,create-mod,schematic" data-page="schematic"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="schematic" data-kw="minecraft,create-mod,schematic" data-page="schematic"></div>
                 </div><!-- /d-flex -->
 
             </div>

--- a/template/schematics.html
+++ b/template/schematics.html
@@ -54,7 +54,7 @@
                 </div>
                 </div>
                 <!-- Ad Rail (desktop only) -->
-                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="schematics" data-kw="minecraft,create-mod,schematics,browse" data-page="schematics"></div>
+                <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="schematics" data-kw="minecraft,create-mod,schematics,browse" data-page="schematics"></div>
                 </div>
                 </div>
             </div>

--- a/template/similar.html
+++ b/template/similar.html
@@ -46,7 +46,7 @@
                 </div></div>
                 {{ end }}
                 </div><!-- /flex-grow-1 -->
-                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="similar" data-kw="minecraft,create-mod,schematic,similar" data-page="similar"></div>
+                <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="similar" data-kw="minecraft,create-mod,schematic,similar" data-page="similar"></div>
                 </div><!-- /d-flex -->
             </div>
         </main>

--- a/template/similar_tool.html
+++ b/template/similar_tool.html
@@ -43,7 +43,7 @@
 
                 <div class="row row-cards" id="sim-results"></div>
                 </div><!-- /flex-grow-1 -->
-                <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="similar-tool" data-kw="minecraft,create-mod,schematic,similar" data-page="similar-tool"></div>
+                <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="similar-tool" data-kw="minecraft,create-mod,schematic,similar" data-page="similar-tool"></div>
                 </div><!-- /d-flex -->
             </div>
         </main>

--- a/template/static/adrail.js
+++ b/template/static/adrail.js
@@ -1,7 +1,7 @@
 // Desktop right-rail ads.
 //
 // Each page declares its rail with a container element:
-//   <div class="ad-rail d-none d-xl-block" data-cm-adrail
+//   <div class="cm-side-rail d-none d-xl-block" data-cm-adrail
 //        data-prefix="mods" data-kw="minecraft,..." data-page="mods"></div>
 // (search / mod_detail use .search-ad-rail-wide; the data-cm-adrail attribute
 // is what matters.)
@@ -67,6 +67,52 @@
       );
     }
   }
+
+  // ---- Blocked-ads fallback ----
+  // Most blockers stop the NitroPay loader at the network level, which would
+  // leave the rail as a blank gutter. Instead of a popup or blocking content,
+  // fill it with a quiet first-party support note. Signals: the loader's
+  // onerror flag (_nitroBlocked, set in head.html), NitroPay's own abp flag,
+  // and the np.detect event dispatched by the detection script in foot.html.
+  function renderSupportNote(rail) {
+    if (rail.querySelector(".cm-support-note")) return;
+    // The empty unit holder spans the full column; hide it so the note
+    // isn't pushed below the fold.
+    var holders = rail.querySelectorAll('[id$="_sticky"]');
+    for (var i = 0; i < holders.length; i++) holders[i].style.display = "none";
+
+    var note = document.createElement("div");
+    note.className = "cm-support-note";
+    var head = document.createElement("strong");
+    head.textContent = "Enjoying CreateMod?";
+    var body = document.createElement("p");
+    body.textContent =
+      "CreateMod.com is a free community project funded by the ads that " +
+      "would normally appear here. If the site is useful to you, please " +
+      "consider allowlisting createmod.com in your ad blocker.";
+    note.appendChild(head);
+    note.appendChild(body);
+    rail.appendChild(note);
+  }
+
+  function blockedFallback() {
+    var rails = document.querySelectorAll("[data-cm-adrail]");
+    for (var i = 0; i < rails.length; i++) renderSupportNote(rails[i]);
+  }
+
+  function checkBlocked() {
+    if (window._nitroBlocked || (window.nitroAds && window.nitroAds.abp === true)) {
+      blockedFallback();
+    }
+  }
+
+  document.addEventListener("np.detect", function (e) {
+    if (e && e.detail && e.detail.blocking) blockedFallback();
+  });
+  setTimeout(checkBlocked, 6000);
+  document.addEventListener("htmx:afterSettle", function () {
+    setTimeout(checkBlocked, 1500);
+  });
 
   if (document.readyState !== "loading") {
     initAdRails();

--- a/template/static/app.css
+++ b/template/static/app.css
@@ -426,7 +426,7 @@ a:hover {
   We only set width and flex so the column stretches to full
   content height — required for sticky-stack placement calc.
 ***************/
-.ad-rail {
+.cm-side-rail {
   width: 300px;
   min-width: 300px;
   flex-shrink: 0;
@@ -436,10 +436,32 @@ a:hover {
    adrail.js) must span the full column so NitroPay can place pinned ads down
    the whole page height — the holder has no content of its own and would
    otherwise collapse. NitroPay handles the per-ad sticky positioning. */
-.ad-rail > [id$="_sticky"],
-.ad-rail > [id*="sticky-adrail"],
+.cm-side-rail > [id$="_sticky"],
+.cm-side-rail > [id*="sticky-adrail"],
 .search-ad-rail-wide > [id$="_sticky"] {
   height: 100%;
+}
+/* First-party support note shown in the rail when an ad blocker keeps ads
+   from loading (see the blocked-ads fallback in adrail.js). Deliberately
+   quiet: lives in the empty rail space, no overlay, no content blocking. */
+.cm-support-note {
+  position: sticky;
+  top: 8px;
+  border: 1px dashed rgba(191, 144, 69, 0.4);
+  border-radius: 8px;
+  padding: 16px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--cm-secondary, #8a9099);
+  background: rgba(191, 144, 69, 0.05);
+}
+.cm-support-note strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--cm-primary, #bf9045);
+}
+.cm-support-note p {
+  margin: 0;
 }
 /* When the mobile/tablet anchor ad is showing, lift the floating outstream
    player above it — both are fixed to the bottom edge otherwise. The
@@ -560,7 +582,7 @@ html.cm-anchor-open [id*="outstream-player"] {
 /***************
   Narrow ad rail (160px, for lg breakpoint)
 ***************/
-.ad-rail-sm {
+.cm-side-rail-sm {
   width: 160px;
   min-width: 160px;
   flex-shrink: 0;
@@ -568,7 +590,7 @@ html.cm-anchor-open [id*="outstream-player"] {
 }
 /* Full column height so the NitroPay sticky-stack can place pinned ads down
    the whole page as the user scrolls (NitroPay handles the stickiness). */
-.ad-rail-sm > [id*="sticky-adrail"] {
+.cm-side-rail-sm > [id*="sticky-adrail"] {
   height: 100%;
 }
 

--- a/template/static/dev-ads.js
+++ b/template/static/dev-ads.js
@@ -119,7 +119,7 @@
   }
 
   function renderStickyStack(container, id) {
-    var isNarrow = !!(container.closest('.ad-rail-sm') ||
+    var isNarrow = !!(container.closest('.cm-side-rail-sm') ||
                       container.closest('.generator-ad-rail-sm'));
     var w = isNarrow ? 160 : 300;
     var h = isNarrow ? 600 : 800;

--- a/template/tools.html
+++ b/template/tools.html
@@ -94,7 +94,7 @@
                     </div>
                 </div>
                     </div>
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="tools" data-kw="minecraft,create-mod,tools,schematics" data-page="tools"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="tools" data-kw="minecraft,create-mod,tools,schematics" data-page="tools"></div>
                 </div>
             </div>
         </main>

--- a/template/top-creators.html
+++ b/template/top-creators.html
@@ -150,7 +150,7 @@
             </div>
             </div>
             <!-- Ad Rail (desktop only) -->
-            <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="topcreators" data-kw="minecraft,create-mod,leaderboard,creators" data-page="top-creators"></div>
+            <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="topcreators" data-kw="minecraft,create-mod,leaderboard,creators" data-page="top-creators"></div>
             </div>
             </div>
             {{ else }}

--- a/template/trending.html
+++ b/template/trending.html
@@ -33,7 +33,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only): video ad above two stacked 300x600 sticky ads -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="trending" data-kw="minecraft,create-mod,schematics,trending" data-page="trending"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="trending" data-kw="minecraft,create-mod,schematics,trending" data-page="trending"></div>
                     </div>
 
                 </div>

--- a/template/upload_modify.html
+++ b/template/upload_modify.html
@@ -113,11 +113,11 @@
 
                     <!-- Ad Rails -->
                     <!-- Narrow 160px rail for lg (992-1199px) -->
-                    <div class="ad-rail-sm d-none d-lg-block d-xl-none">
+                    <div class="cm-side-rail-sm d-none d-lg-block d-xl-none">
                         <div id="upload-modify-sticky-adrail-lg" class="mb-3"></div>
                     </div>
                     <!-- Wide 300px rail for xl+ (1200px+) -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="upload-modify" data-kw="minecraft,create-mod,modify,blocks,upload" data-page="modify"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="upload-modify" data-kw="minecraft,create-mod,modify,blocks,upload" data-page="modify"></div>
                     </div>
                 </div><!-- /d-flex -->
                 <!-- Mobile ad (below content on smaller screens) -->

--- a/template/upload_preview.html
+++ b/template/upload_preview.html
@@ -391,7 +391,7 @@
                     </div>
 
                     <!-- Ad Rail (desktop only) -->
-                    <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="upload-preview" data-kw="minecraft,create-mod,upload,preview" data-page="upload-preview"></div>
+                    <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="upload-preview" data-kw="minecraft,create-mod,upload,preview" data-page="upload-preview"></div>
                     </div>
                 </div>
             </div>

--- a/template/videos.html
+++ b/template/videos.html
@@ -52,7 +52,7 @@
         </div><!-- /flex-grow-1 -->
 
         <!-- Ad Rail (desktop only) -->
-        <div class="ad-rail d-none d-xl-block" data-cm-adrail data-prefix="videos" data-kw="minecraft,create-mod,videos" data-page="videos"></div>
+        <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="videos" data-kw="minecraft,create-mod,videos" data-page="videos"></div>
         </div>
         </div><!-- /d-flex -->
         <!-- Mobile ad (below content on smaller screens) -->

--- a/tests/e2e/specs/ad_sticky.spec.ts
+++ b/tests/e2e/specs/ad_sticky.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 // The desktop right rail is built client-side by adrail.js: each page has a
-// <div class="ad-rail ..." data-cm-adrail ...> container, and the helper
+// <div class="cm-side-rail ..." data-cm-adrail ...> container, and the helper
 // appends a single NitroPay sticky-stack unit whose id ends "_sticky". The
 // holder itself is NOT sticky — NitroPay pins individual ads inside it — but
 // it must span the full rail column (height: 100%) so ads can be placed down
-// the whole page height. Uses /explore because it always renders an .ad-rail.
+// the whole page height. Uses /explore because it always renders an .cm-side-rail.
 // In CI no real ad scripts load, but the helper still builds the DOM (it only
 // needs the nitroAds stub), so we can verify the computed styles.
 
@@ -16,12 +16,12 @@ test.describe('Ad rail', () => {
     const url = baseURL ?? 'http://localhost:8080';
     await page.goto(url + '/explore', { waitUntil: 'domcontentloaded' });
 
-    const adRail = page.locator('.ad-rail[data-cm-adrail]').first();
+    const adRail = page.locator('.cm-side-rail[data-cm-adrail]').first();
     await expect(adRail).toBeAttached({ timeout: 10000 });
 
     // adrail.js builds the rail on load — wait for the unit holder to appear.
     await page.waitForFunction(() => {
-      const r = document.querySelector('.ad-rail[data-cm-adrail]');
+      const r = document.querySelector('.cm-side-rail[data-cm-adrail]');
       return !!(r && r.querySelector(':scope > [id$="_sticky"]'));
     }, { timeout: 10000 });
 
@@ -53,7 +53,7 @@ test.describe('Ad rail', () => {
     const url = baseURL ?? 'http://localhost:8080';
     await page.goto(url + '/explore', { waitUntil: 'domcontentloaded' });
 
-    const adRail = page.locator('.ad-rail').first();
+    const adRail = page.locator('.cm-side-rail').first();
     await expect(adRail).toBeAttached({ timeout: 10000 });
 
     const outerStyles = await adRail.evaluate((el) => {


### PR DESCRIPTION
EasyList carries a generic cosmetic rule '##.ad-rail' that hides any element with that class on every site, while NitroPay's loader is generically allowlisted by the Acceptable Ads exception list (on by default for AdBlock Plus / AdBlock users). Those users could be served AA-compliant ads, but our container class name was getting the rail hidden anyway.

- Rename the .ad-rail / .ad-rail-sm classes to .cm-side-rail / .cm-side-rail-sm (search-ad-rail-wide, generator-ad-rail and guide-ad-rail are not on any list and keep their names)
- When a blocker does stop ads (loader onerror, nitroAds.abp, or the np.detect event), fill the now-unhidden empty rail with a quiet first-party support note instead of leaving a blank gutter - no popup, no content blocking