### PR TITLE
feat: index and fix schematic NBT-data and similar pages

### DIFF
--- a/internal/pages/nbt_viewer.go
+++ b/internal/pages/nbt_viewer.go
@@ -154,7 +154,6 @@ func SchematicNBTDataHandler(registry *server.Registry, cacheService *cache.Serv
 		d := nbtDataPageData{}
 		d.Populate(e)
 		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
-		d.NoIndex = true // raw data view; the schematic page carries the SEO
 		d.Title = fmt.Sprintf(i18n.T(d.Language, "NBT Data: %s"), s.Title)
 		d.Description = i18n.T(d.Language, "Browse the raw NBT structure of this schematic.")
 		d.Slug = "/schematics/" + name + "/nbt-data"

--- a/internal/pages/similar.go
+++ b/internal/pages/similar.go
@@ -124,8 +124,7 @@ func SimilarSchematicsHandler(registry *server.Registry, cacheService *cache.Ser
 		d := similarPageData{}
 		d.Populate(e)
 		d.Categories = allCategoriesFromStoreOnly(appStore, cacheService)
-		d.NoIndex = true // dynamic thin content; the tool page carries the SEO
-		d.Title = fmt.Sprintf(i18n.T(d.Language, "Schematics similar to %s"), s.Title)
+		d.Title = fmt.Sprintf(i18n.T(d.Language, "Schematics Similar to “%s”"), s.Title)
 		d.Description = i18n.T(d.Language, "Builds with a similar structure, shape and materials.")
 		d.Slug = "/schematics/" + name + "/similar"
 		d.Breadcrumbs = NewBreadcrumbs(d.Language, i18n.T(d.Language, "Schematics"), "/schematics", s.Title, "/schematics/"+name, i18n.T(d.Language, "Similar"))

--- a/internal/sitemap/service.go
+++ b/internal/sitemap/service.go
@@ -124,6 +124,41 @@ func (s *Service) Generate(appStore *store.Store) {
 		}
 	}
 
+	// Per-schematic sub-pages: similar-schematics search and the raw NBT data
+	// view. Chunked at 500 schematics per file (two locs each = 1000 locs).
+	schematicPagesSmCount := 1
+	smSchematicPages := smi.NewSitemap()
+	smSchematicPages.SetName(fmt.Sprintf("schematic-pages-%d", schematicPagesSmCount))
+	smSchematicPages.SetOutputPath(tmpDir + "/")
+	smSchematicPages.SetLastMod(&now)
+
+	for i := range schematics {
+		if i != 0 && i%500 == 0 {
+			schematicPagesSmCount++
+			smSchematicPages = smi.NewSitemap()
+			smSchematicPages.SetName(fmt.Sprintf("schematic-pages-%d", schematicPagesSmCount))
+			smSchematicPages.SetOutputPath(tmpDir + "/")
+			smSchematicPages.SetLastMod(&now)
+		}
+		lastMod := schematics[i].Updated
+		for _, sub := range []struct {
+			path     string
+			priority float32
+		}{
+			{"similar", 0.4},
+			{"nbt-data", 0.3},
+		} {
+			if err := smSchematicPages.Add(&smg.SitemapLoc{
+				Loc:        fmt.Sprintf("/schematics/%s/%s", schematics[i].Name, sub.path),
+				LastMod:    &lastMod,
+				ChangeFreq: smg.Weekly,
+				Priority:   sub.priority,
+			}); err != nil {
+				slog.Error("Unable to add schematic sub-page SitemapLoc:", "error", err)
+			}
+		}
+	}
+
 	userSmCount := 1
 	smUsers := smi.NewSitemap()
 	smUsers.SetName(fmt.Sprintf("users-%d", userSmCount))

--- a/template/nbt_data.html
+++ b/template/nbt_data.html
@@ -4,7 +4,10 @@
     <div class="page-wrapper">
         {{template "header.html" .}}
         <main class="page-body">
-            <div class="container-wide" style="max-width: 1100px;">
+            <div class="container-wide">
+                <div class="d-flex gap-3">
+                <div class="flex-grow-1 min-width-0">
+                <div style="max-width: 1100px; margin: 0 auto;">
                 <div class="mb-3">
                     <h1 class="h2 mb-1">{{ T .Language "NBT Data" }}: {{ .SourceTitle }}</h1>
                     <p class="cm-page-sub mb-2">{{ T .Language "The raw NBT structure of this schematic, with SNBT view, key search and copy-path." }}</p>
@@ -19,6 +22,10 @@
                         <div id="nbt-data-tree"></div>
                     </div>
                 </div>
+                </div><!-- /max-width -->
+                </div><!-- /flex-grow-1 -->
+                <div class="cm-side-rail d-none d-xl-block" data-cm-adrail data-prefix="nbt-data" data-kw="minecraft,create-mod,schematic,nbt" data-page="nbt-data"></div>
+                </div><!-- /d-flex -->
             </div>
         </main>
         {{ template "footer.html" . }}

--- a/template/nbt_viewer.html
+++ b/template/nbt_viewer.html
@@ -7,7 +7,7 @@
             <div class="container-wide">
                 <div class="d-flex gap-3">
                 <div class="flex-grow-1 min-width-0">
-                <div style="max-width: 1020px;">
+                <div style="max-width: 1100px; margin: 0 auto;">
                 <div class="mb-3">
                     <h1 class="h2 mb-1">{{ T .Language "NBT Viewer" }}</h1>
                     <p class="cm-page-sub">{{ T .Language "Open any Minecraft NBT or schematic file in a browsable tree, with SNBT view, key search and copy-path. The file stays in your browser session and is parsed per request, never stored." }}</p>

--- a/template/similar.html
+++ b/template/similar.html
@@ -6,7 +6,7 @@
         <main class="page-body">
             <div class="container-wide">
                 <div class="mb-3">
-                    <h1 class="h2 mb-1">{{ T .Language "Similar to" }} “{{ .Source.Title }}”</h1>
+                    <h1 class="h2 mb-1">{{ T .Language "Schematics Similar to" }} “{{ .Source.Title }}”</h1>
                     <div class="text-secondary">{{ T .Language "Ranked by structure: shape, materials, Create components, proportions and palette." }}</div>
                 </div>
                 <div class="d-flex gap-3">


### PR DESCRIPTION
- Retitle the similar page to 'Schematics Similar to "<title>"' (page title and on-page heading)
- Drop the noindex flag from the nbt-data and similar pages and add both to the sitemap as chunked schematic-pages-N files (500 schematics per file, similar at 0.4, nbt-data at 0.3)