### PR TITLE
fix: stop NBT tree API from OOMing pods under crawler load

### DIFF
--- a/internal/pages/nbt_viewer.go
+++ b/internal/pages/nbt_viewer.go
@@ -1,11 +1,13 @@
 package pages
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"createmod/internal/cache"
 	"createmod/internal/i18n"
@@ -15,9 +17,35 @@ import (
 	"createmod/internal/store"
 )
 
+// nbtTreeSem caps concurrent NBT decompress+parse work per pod. A single
+// request can hold MaxDecompressedSize (100MB) of decompressed NBT plus parse
+// overhead, so a crawler fetching several large schematics at once can spike
+// the pod past its 4Gi memory limit (OOMKilled wave, 2026-07-22). Requests
+// wait briefly for a slot, then get a 429 with Retry-After so well-behaved
+// bots back off.
+var nbtTreeSem = make(chan struct{}, 2)
+
+// acquireNBTTreeSlot reserves a decompress+parse slot. It returns a release
+// function, or writes a 429 and returns false if none frees up in time.
+func acquireNBTTreeSlot(e *server.RequestEvent) (func(), bool) {
+	select {
+	case nbtTreeSem <- struct{}{}:
+		return func() { <-nbtTreeSem }, true
+	case <-time.After(2 * time.Second):
+		e.Response.Header().Set("Retry-After", "5")
+		_ = writeJSON(e, http.StatusTooManyRequests, map[string]string{"error": "server busy, retry shortly"})
+		return nil, false
+	}
+}
+
 // nbtTreeRespond serves tree/SNBT/search views over raw schematic bytes.
 // Shared by the library endpoint and the stateless upload endpoint.
 func nbtTreeRespond(e *server.RequestEvent, data []byte) error {
+	release, ok := acquireNBTTreeSlot(e)
+	if !ok {
+		return nil
+	}
+	defer release()
 	raw, err := schematic.DecompressForTree(data)
 	if err != nil {
 		return writeJSON(e, http.StatusUnprocessableEntity, map[string]string{"error": convertUserError(err)})
@@ -54,9 +82,13 @@ func nbtTreeRespond(e *server.RequestEvent, data []byte) error {
 	return writeJSON(e, http.StatusOK, page)
 }
 
+// nbtTreeCacheMaxEntry bounds cached default-page JSON so a crawler sweep
+// can't balloon the per-pod cache (worst case ≈ sweep rate × TTL × this).
+const nbtTreeCacheMaxEntry = 256 * 1024
+
 // SchematicNBTTreeHandler serves the NBT tree for a library schematic.
 // GET /api/schematics/{name}/nbt-tree
-func SchematicNBTTreeHandler(appStore *store.Store, storageSvc *storage.Service) func(e *server.RequestEvent) error {
+func SchematicNBTTreeHandler(appStore *store.Store, cacheService *cache.Service, storageSvc *storage.Service) func(e *server.RequestEvent) error {
 	return func(e *server.RequestEvent) error {
 		if storageSvc == nil {
 			return writeJSON(e, http.StatusServiceUnavailable, map[string]string{"error": "file storage unavailable"})
@@ -70,6 +102,38 @@ func SchematicNBTTreeHandler(appStore *store.Store, storageSvc *storage.Service)
 		if primary == "" {
 			return writeJSON(e, http.StatusNotFound, map[string]string{"error": "schematic has no file"})
 		}
+
+		// The root page (no path/search/snbt, offset 0) is what every first
+		// page load — and every crawler rendering /schematics/{name}/nbt-data
+		// — asks for, and it is the same few-hundred-node response every
+		// time. Serve it from cache so bot sweeps don't pay the full
+		// decompress+parse (up to 100MB in memory per request; caused the
+		// 2026-07-22 OOM wave). Deeper navigation (path/offset/snbt/search)
+		// stays uncached but is bounded by the nbtTreeSem concurrency cap.
+		q := e.Request.URL.Query()
+		qInt := func(key string, def int) int {
+			if v, err := strconv.Atoi(q.Get(key)); err == nil {
+				return v
+			}
+			return def
+		}
+		depth := qInt("depth", 2)
+		limit := qInt("limit", 200)
+		isDefaultPage := strings.TrimSpace(q.Get("q")) == "" && q.Get("snbt") != "1" &&
+			q.Get("path") == "" && qInt("offset", 0) == 0
+		cacheKey := fmt.Sprintf("nbt_tree_p1_%s_%s_%d_%d", s.ID, primary, depth, limit)
+		if isDefaultPage && cacheService != nil {
+			if v, ok := cacheService.Get(cacheKey); ok {
+				if body, ok2 := v.([]byte); ok2 {
+					setPublicCacheControl(e, 300)
+					e.Response.Header().Set("Content-Type", "application/json")
+					e.Response.WriteHeader(http.StatusOK)
+					_, _ = e.Response.Write(body)
+					return nil
+				}
+			}
+		}
+
 		reader, err := storageSvc.Download(e.Request.Context(), storage.CollectionPrefix("schematics"), s.ID, primary)
 		if err != nil {
 			return writeJSON(e, http.StatusNotFound, map[string]string{"error": "schematic file not found"})
@@ -79,6 +143,35 @@ func SchematicNBTTreeHandler(appStore *store.Store, storageSvc *storage.Service)
 		if err != nil {
 			return writeJSON(e, http.StatusInternalServerError, map[string]string{"error": "failed to read schematic"})
 		}
+
+		if isDefaultPage {
+			release, ok := acquireNBTTreeSlot(e)
+			if !ok {
+				return nil
+			}
+			defer release()
+			raw, err := schematic.DecompressForTree(data)
+			if err != nil {
+				return writeJSON(e, http.StatusUnprocessableEntity, map[string]string{"error": convertUserError(err)})
+			}
+			page, err := schematic.NBTTreePage(raw, "", depth, 0, limit)
+			if err != nil {
+				return writeJSON(e, http.StatusUnprocessableEntity, map[string]string{"error": convertUserError(err)})
+			}
+			body, err := json.Marshal(page)
+			if err != nil {
+				return writeJSON(e, http.StatusInternalServerError, map[string]string{"error": "failed to encode tree"})
+			}
+			if cacheService != nil && len(body) <= nbtTreeCacheMaxEntry {
+				cacheService.SetWithTTL(cacheKey, body, 10*time.Minute)
+			}
+			setPublicCacheControl(e, 300)
+			e.Response.Header().Set("Content-Type", "application/json")
+			e.Response.WriteHeader(http.StatusOK)
+			_, _ = e.Response.Write(body)
+			return nil
+		}
+
 		// Tree responses vary only with the stored file; cache briefly.
 		setPublicCacheControl(e, 300)
 		return nbtTreeRespond(e, data)

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -774,7 +774,7 @@ func Register(p RegisterParams) chi.Router {
 	r.Get("/api/editor/{id}/preview.json", Adapt(pages.EditorPreviewJSONHandler(p.AppStore, p.StorageService)))
 	// NBT viewer
 	r.Get("/tools/nbt-viewer", Adapt(pages.NBTViewerToolHandler(registry, p.CacheService, p.AppStore)))
-	r.With(rateLimitMiddlewareNew(p.RateLimiter, 60, time.Minute)).Get("/api/schematics/{name}/nbt-tree", Adapt(pages.SchematicNBTTreeHandler(p.AppStore, p.StorageService)))
+	r.With(rateLimitMiddlewareNew(p.RateLimiter, 60, time.Minute)).Get("/api/schematics/{name}/nbt-tree", Adapt(pages.SchematicNBTTreeHandler(p.AppStore, p.CacheService, p.StorageService)))
 	r.With(rateLimitMiddlewareNew(p.RateLimiter, 60, time.Minute)).Post("/api/nbt-tree", Adapt(pages.NBTTreeUploadHandler()))
 	// Similarity search
 	r.Get("/schematics/{name}/similar", Adapt(pages.SimilarSchematicsHandler(registry, p.CacheService, p.AppStore, p.SimilarityService)))

--- a/internal/sitemap/service.go
+++ b/internal/sitemap/service.go
@@ -126,6 +126,9 @@ func (s *Service) Generate(appStore *store.Store) {
 
 	// Per-schematic sub-pages: similar-schematics search and the raw NBT data
 	// view. Chunked at 500 schematics per file (two locs each = 1000 locs).
+	// Note: nbt-data renders are only safe to invite crawlers to because the
+	// tree API caches its root page and caps decompress concurrency (see
+	// SchematicNBTTreeHandler) — uncapped, this caused the 2026-07-22 OOMs.
 	schematicPagesSmCount := 1
 	smSchematicPages := smi.NewSitemap()
 	smSchematicPages.SetName(fmt.Sprintf("schematic-pages-%d", schematicPagesSmCount))


### PR DESCRIPTION
The 2026-07-22 OOMKilled wave started ~45 min after the sitemap began listing /schematics/{name}/nbt-data (#1544): crawlers rendering those pages hit /api/schematics/{name}/nbt-tree, and every request decompressed the full schematic (up to MaxDecompressedSize, 100MB) plus NBT parse overhead with no concurrency bound - a few concurrent large fetches spiked pods past the 4Gi limit.

Keep the pages indexed and in the sitemap, but make the endpoint safe:

- Cache the root tree page (the only thing first loads and crawler renders request) in go-cache for 10 min, entries capped at 256KB
- Cap concurrent decompress+parse at 2 per pod via semaphore; waiters get 2s, then 429 + Retry-After so bots back off
- Both guards cover the upload variant (/api/nbt-tree) too