### PR TITLE
chore(k8s): drop replicas from deployments — the HPA owns scale

### DIFF
--- a/k8s/createmod/dev/deployment.yaml
+++ b/k8s/createmod/dev/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
     app: createmod
     environment: dev
 spec:
-  replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/k8s/createmod/prod/deployment.yaml
+++ b/k8s/createmod/prod/deployment.yaml
@@ -8,7 +8,6 @@ metadata:
     app: createmod
     environment: prod
 spec:
-  replicas: 4
   revisionHistoryLimit: 3
   selector:
     matchLabels:


### PR DESCRIPTION
ArgoCD now ignores /spec/replicas (RespectIgnoreDifferences), so this field was inert and only misleading: it implied a fixed scale while the HPA (prod 4-16, dev 1-3) actually decides. Removing it also keeps any future tooling from re-applying a stale count. Fresh creations briefly default to 1 replica until the HPA reconciles to its minimum.