### PR TITLE
fix(search): stop the synchronized Meilisearch resync OOM cascade

### DIFF
--- a/internal/search/meili_engine.go
+++ b/internal/search/meili_engine.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/meilisearch/meilisearch-go"
 )
@@ -15,7 +16,29 @@ type MeiliEngine struct {
 	client   meilisearch.ServiceManager
 	indexUID string
 	svc      *Service // for suggest, trending scores, and filter index
-	resync   sync.Once
+
+	// Resync trigger state. The actual resync is a River job enqueued via
+	// resyncEnqueue so exactly ONE pod cluster-wide rebuilds the index —
+	// before 2026-07-24 every replica ran its own in-process full-corpus
+	// resync on the same 0-result signal, and the synchronized memory
+	// balloon OOMKilled the whole deployment.
+	resyncMu      sync.Mutex
+	resyncEnqueue func()
+	lastResync    time.Time
+}
+
+// resyncTriggerCooldown rate-limits how often a single pod may enqueue a
+// resync. The enqueue itself is further deduplicated cluster-wide by River
+// unique opts, so this only keeps a pod from hammering inserts while
+// Meilisearch is degraded.
+const resyncTriggerCooldown = 5 * time.Minute
+
+// SetResyncEnqueuer wires the callback used to enqueue an index rebuild job.
+// Called once the River job worker is running.
+func (m *MeiliEngine) SetResyncEnqueuer(fn func()) {
+	m.resyncMu.Lock()
+	defer m.resyncMu.Unlock()
+	m.resyncEnqueue = fn
 }
 
 // NewMeiliEngine creates a SearchEngine backed by Meilisearch.
@@ -35,6 +58,11 @@ func (m *MeiliEngine) Search(ctx context.Context, q SearchQuery) ([]string, erro
 		Limit:  5000,
 		Filter: filter,
 		Sort:   sort,
+		// Only the IDs are used — without this Meilisearch returns 5000 FULL
+		// documents (descriptions included) per broad query, which at ~30
+		// req/s of concurrent decodes was a large share of the pods' memory
+		// pressure in the 2026-07-24 OOM cascade.
+		AttributesToRetrieve: []string{"id"},
 	}
 
 	index := m.client.Index(m.indexUID)
@@ -68,8 +96,9 @@ func (m *MeiliEngine) SearchSimilar(ctx context.Context, schematicID string, tag
 	filter := fmt.Sprintf(`id != "%s"`, escapeMeiliString(schematicID))
 
 	searchReq := &meilisearch.SearchRequest{
-		Limit:  int64(limit),
-		Filter: filter,
+		Limit:                int64(limit),
+		Filter:               filter,
+		AttributesToRetrieve: []string{"id"},
 	}
 
 	index := m.client.Index(m.indexUID)
@@ -211,29 +240,30 @@ func (m *MeiliEngine) buildSort(order int) []string {
 	}
 }
 
-// triggerResyncIfEmpty kicks off a one-time background Meilisearch sync when a
-// broad query (empty term, no filters) returns 0 hits but the in-memory index
-// has documents. This covers the case where the pod started before Meilisearch
-// was reachable or before auth was configured.
+// triggerResyncIfEmpty enqueues a search index rebuild when a broad query
+// (empty term, no filters) returns 0 hits but the in-memory index has
+// documents. This covers the case where the pod started before Meilisearch
+// was reachable, or Meilisearch lost its index. The rebuild runs as a River
+// job (deduplicated cluster-wide with a cooldown), NOT in-process: one pod
+// does the work no matter how many replicas observe the same condition.
 func (m *MeiliEngine) triggerResyncIfEmpty(q SearchQuery, hitCount int) {
 	if hitCount > 0 || q.Term != "" || q.Category != "" && q.Category != "all" || len(q.Tags) > 0 {
 		return
 	}
-	idx := m.svc.GetIndex()
-	if len(idx) == 0 {
+	if len(m.svc.GetIndex()) == 0 {
 		return
 	}
-	m.resync.Do(func() {
-		go func() {
-			slog.Info("meili: 0-result broad query detected, triggering background resync", "index", m.indexUID, "docs", len(idx))
-			docs := MapToMeiliDocuments(idx, m.svc.trendingScores)
-			if err := SyncMeiliIndex(m.client, m.indexUID, docs); err != nil {
-				slog.Error("meili: background resync failed", "index", m.indexUID, "error", err)
-			} else {
-				slog.Info("meili: background resync complete", "index", m.indexUID, "docs", len(docs))
-			}
-		}()
-	})
+	m.resyncMu.Lock()
+	defer m.resyncMu.Unlock()
+	if m.resyncEnqueue == nil {
+		return
+	}
+	if time.Since(m.lastResync) < resyncTriggerCooldown {
+		return
+	}
+	m.lastResync = time.Now()
+	slog.Info("meili: 0-result broad query detected, enqueueing index rebuild", "index", m.indexUID)
+	m.resyncEnqueue()
 }
 
 // escapeMeiliString escapes double quotes in filter values.

--- a/internal/search/meili_setup.go
+++ b/internal/search/meili_setup.go
@@ -336,8 +336,10 @@ func SyncMeiliIndex(client meilisearch.ServiceManager, indexUID string, docs []M
 
 	index := client.Index(indexUID)
 
-	// Batch in groups of 1000.
-	const batchSize = 1000
+	// Small batches keep the transient JSON marshal buffers bounded — with
+	// large description fields a 1000-doc batch could balloon to hundreds of
+	// MB in flight during a rebuild.
+	const batchSize = 250
 	for start := 0; start < len(docs); start += batchSize {
 		end := start + batchSize
 		if end > len(docs) {

--- a/internal/search/resync_trigger_test.go
+++ b/internal/search/resync_trigger_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTriggerResyncIfEmpty(t *testing.T) {
+	svc := &Service{index: []schematicIndex{{ID: "a"}}}
+	m := &MeiliEngine{svc: svc}
+
+	// No enqueuer wired: must be a silent no-op.
+	m.triggerResyncIfEmpty(SearchQuery{}, 0)
+
+	var calls int
+	m.SetResyncEnqueuer(func() { calls++ })
+
+	// Non-broad queries and non-empty results never trigger.
+	m.triggerResyncIfEmpty(SearchQuery{Term: "windmill"}, 0)
+	m.triggerResyncIfEmpty(SearchQuery{Category: "automation"}, 0)
+	m.triggerResyncIfEmpty(SearchQuery{}, 3)
+	if calls != 0 {
+		t.Fatalf("expected no enqueues yet, got %d", calls)
+	}
+
+	// A broad 0-result query triggers exactly once...
+	m.triggerResyncIfEmpty(SearchQuery{}, 0)
+	if calls != 1 {
+		t.Fatalf("expected 1 enqueue, got %d", calls)
+	}
+
+	// ...and the per-pod cooldown swallows immediate repeats.
+	m.triggerResyncIfEmpty(SearchQuery{}, 0)
+	m.triggerResyncIfEmpty(SearchQuery{}, 0)
+	if calls != 1 {
+		t.Fatalf("cooldown violated: expected 1 enqueue, got %d", calls)
+	}
+
+	// Once the cooldown elapses it may trigger again.
+	m.lastResync = time.Now().Add(-resyncTriggerCooldown - time.Second)
+	m.triggerResyncIfEmpty(SearchQuery{}, 0)
+	if calls != 2 {
+		t.Fatalf("expected 2 enqueues after cooldown, got %d", calls)
+	}
+
+	// An empty in-memory index means there is nothing to resync from.
+	m.svc = &Service{}
+	m.lastResync = time.Time{}
+	m.triggerResyncIfEmpty(SearchQuery{}, 0)
+	if calls != 2 {
+		t.Fatalf("expected no enqueue with empty index, got %d", calls)
+	}
+}

--- a/k8s/createmod/prod/hpa.yaml
+++ b/k8s/createmod/prod/hpa.yaml
@@ -12,18 +12,17 @@ spec:
   minReplicas: 4
   maxReplicas: 16
   metrics:
+    # CPU only — deliberately no memory metric. Each pod carries the full
+    # in-memory search/similarity indexes, so per-pod memory does not go
+    # down when pods are added; memory-triggered scale-up during a balloon
+    # just creates more ballooning pods (2026-07-24 OOM cascade: HPA scaled
+    # 5 -> 9 and all 9 OOMed).
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: 70
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 85
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 900

--- a/server/start.go
+++ b/server/start.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/redis/go-redis/v9"
+	"github.com/riverqueue/river"
 	"log"
 	"log/slog"
 	"math/rand"
@@ -370,6 +371,26 @@ func (s *Server) Start() {
 		// handled by River periodic jobs with UniqueOpts deduplication, so
 		// only one pod executes each job even when running multiple replicas.
 		s.startJobWorker(trendingWindowDays)
+
+		// Wire the Meilisearch 0-result resync trigger to enqueue the
+		// existing rebuild job instead of resyncing in-process. River's
+		// unique opts make this a cluster-wide singleton with a cooldown:
+		// during a Meilisearch outage every replica sees the same 0-result
+		// condition, and before 2026-07-24 each ran its own full-corpus
+		// resync — five synchronized memory balloons OOMKilled the whole
+		// deployment at flat traffic.
+		if me, ok := searchEngine.(*search.MeiliEngine); ok && s.jobWorker != nil {
+			jw := s.jobWorker
+			me.SetResyncEnqueuer(func() {
+				err := jw.Insert(context.Background(), jobs.SearchIndexArgs{}, &river.InsertOpts{
+					Queue:      "search",
+					UniqueOpts: river.UniqueOpts{ByArgs: true, ByPeriod: 15 * time.Minute},
+				})
+				if err != nil {
+					slog.Warn("failed to enqueue meili resync rebuild", "error", err)
+				}
+			})
+		}
 	} else {
 		slog.Info("maintenance mode active — deferring background jobs until migration completes")
 	}


### PR DESCRIPTION
2026-07-24 00:13 UTC: one Meilisearch hiccup made broad queries return 0 results on every pod; each pod independently launched a full-corpus in-process resync (the sync.Once gate resets on restart), and the five synchronized memory balloons OOMKilled the deployment at flat traffic — restarted pods re-triggered until one resync finally won. The memory-metric HPA amplified it by adding four more pods that ballooned identically. Fixes, all within the existing 4Gi limit:

- The 0-result trigger now ENQUEUES the existing search_index_rebuild River job instead of resyncing in-process: unique opts (15 min period) make it a cluster-wide singleton with a built-in cooldown, and a 5-min per-pod cooldown keeps degraded pods from hammering inserts. One pod does one rebuild per incident, no matter how many replicas see the condition.

- Broad searches retrieve only the id attribute. Previously every broad query pulled 5000 FULL documents (descriptions included) from Meilisearch at ~1.2s each; concurrent decodes of those responses were a large share of the pods' memory pressure. SearchSimilar gets the same treatment.

- Meili sync batches shrink 1000 -> 250 documents to bound the transient JSON marshal buffers during rebuilds.

- The prod HPA drops its memory metric (CPU only): every pod carries the full in-memory index, so per-pod memory cannot go down when pods are added — memory-triggered scale-up during a balloon only creates more ballooning pods. Dev was already CPU-only.