### PR TITLE
fix(ui): style comment/description textareas before the editor loads

### DIFF
--- a/template/editschematic.html
+++ b/template/editschematic.html
@@ -22,7 +22,8 @@
                                         </div>
                                         <div class="mb-3">
                                             <label class="form-label required">Description</label>
-                                            <textarea id="tinymce-schematic"
+                                            <textarea id="tinymce-schematic" class="form-control"
+                                                      style="min-height: 300px;"
                                                       placeholder="Describe your schematic and include any details on how to get it running.">
                                                 {{ .Schematic.Content }}
                                             </textarea>

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -831,7 +831,8 @@
 >
                                     <div class="mb-12">
                                         <label id="leave-comment-label" class="form-label">{{ T .Language "Leave a comment" }}</label>
-                                        <textarea id="tinymce-comment" name="content"
+                                        <textarea id="tinymce-comment" name="content" class="form-control"
+                                                  style="min-height: 200px;"
                                                   placeholder="comment text goes here"></textarea>
                                     </div>
                                     <div class="mb-12">

--- a/template/upload_publish.html
+++ b/template/upload_publish.html
@@ -77,7 +77,8 @@
                                 </div>
                                 <div class="mb-3">
                                     <label class="form-label required">Description</label>
-                                    <textarea id="tinymce-schematic"
+                                    <textarea id="tinymce-schematic" class="form-control"
+                                              style="min-height: 300px;"
                                               placeholder="Describe your schematic and include any details on how to get it running."></textarea>
                                     <small class="form-hint mt-2 d-block text-secondary">Please describe your schematic — explain what it is. Is it a blue train, or does it have passenger carriages? A good description helps your schematic appear in search results.</small>
                                 </div>


### PR DESCRIPTION
The comment field on schematic pages rendered as a bare browser-default textarea until clicked: the rich-text editor is lazy-loaded on focus (to defer a ~140 KB bundle), and the raw <textarea> had no class, so it showed unstyled until the editor initialized. Every other editor textarea already carries class="form-control"; the comment field (and the two schematic description editors, which briefly flash unstyled while the bundle loads on page open) were simply missing it.

Add form-control plus a min-height matching each editor's configured minHeight (comment 200px, schematic 300px) so the placeholder textarea looks like a proper field and doesn't shift layout when the editor mounts. form-control uses the same design tokens (--cm-bg-forms, --cm-border-color) as the editor wrapper, so the two visually match. editor.js hides the textarea once the editor mounts, so there is no double box.