### PR TITLE
fix(k8s): use MEILI_UPGRADE_DB so Meili version bumps don't crashloop

### DIFF
--- a/k8s/meilisearch/dev/deployment.yaml
+++ b/k8s/meilisearch/dev/deployment.yaml
@@ -28,12 +28,19 @@ spec:
                 secretKeyRef:
                   name: meilisearch-secret
                   key: MEILI_MASTER_KEY
-            # Migrate the index database in place on version bumps instead
-            # of refusing to start ("database version X is incompatible with
-            # engine version Y" -> CrashLoopBackOff). No-op when versions
-            # already match, so it stays on permanently. Env form because the
-            # image's entrypoint is tini and container args replace the CMD
-            # (tini would exec the flag as a program).
+            # Migrate the index database in place on version bumps instead of
+            # refusing to start ("database version X is incompatible with
+            # engine version Y" -> CrashLoopBackOff, which took prod search
+            # down on the v1.50 -> v1.51 bump, 2026-07-29). Meili RENAMED this
+            # flag in v1.51 (MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE ->
+            # MEILI_UPGRADE_DB) and silently ignores the old name, so set BOTH:
+            # whichever the running engine version honors triggers the in-place
+            # upgrade, the other is ignored. No-op when versions already match,
+            # so they stay on permanently. Env form because the image's
+            # entrypoint is tini and container args replace the CMD (tini would
+            # exec the flag as a program).
+            - name: MEILI_UPGRADE_DB
+              value: "true"
             - name: MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE
               value: "true"
             - name: MEILI_ENV

--- a/k8s/meilisearch/prod/statefulset.yaml
+++ b/k8s/meilisearch/prod/statefulset.yaml
@@ -29,12 +29,19 @@ spec:
                 secretKeyRef:
                   name: meilisearch-secret
                   key: MEILI_MASTER_KEY
-            # Migrate the index database in place on version bumps instead
-            # of refusing to start ("database version X is incompatible with
-            # engine version Y" -> CrashLoopBackOff). No-op when versions
-            # already match, so it stays on permanently. Env form because the
-            # image's entrypoint is tini and container args replace the CMD
-            # (tini would exec the flag as a program).
+            # Migrate the index database in place on version bumps instead of
+            # refusing to start ("database version X is incompatible with
+            # engine version Y" -> CrashLoopBackOff, which took prod search
+            # down on the v1.50 -> v1.51 bump, 2026-07-29). Meili RENAMED this
+            # flag in v1.51 (MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE ->
+            # MEILI_UPGRADE_DB) and silently ignores the old name, so set BOTH:
+            # whichever the running engine version honors triggers the in-place
+            # upgrade, the other is ignored. No-op when versions already match,
+            # so they stay on permanently. Env form because the image's
+            # entrypoint is tini and container args replace the CMD (tini would
+            # exec the flag as a program).
+            - name: MEILI_UPGRADE_DB
+              value: "true"
             - name: MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE
               value: "true"
             - name: MEILI_ENV


### PR DESCRIPTION
Renovate bumped Meilisearch v1.50 -> v1.51 (#1575). v1.51 refuses to start against a v1.50 on-disk database unless told to migrate, and it RENAMED the auto-migrate flag from MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE to MEILI_UPGRADE_DB, silently ignoring the old name we had set. Result: meilisearch-0 CrashLoopBackOff and prod search returning 0 results for everything (the app degrades to empty results when Meili is unreachable), 2026-07-29.

Set BOTH env var names in prod and dev so whichever the running engine version honors triggers the in-place upgrade and the other is ignored — this keeps future Renovate image bumps from taking search down again.

Recovery already applied live (MEILI_UPGRADE_DB patched onto the running statefulset, which migrated the DB to 1.51; app rolled to refresh stale Meili connections). This commit makes the fix durable in git so ArgoCD holds it.