### PR TITLE
fix(seo): stop placeholder SVGs from being indexed as page thumbnails

### DIFF
--- a/internal/pages/schematic_card_eager_template_test.go
+++ b/internal/pages/schematic_card_eager_template_test.go
@@ -56,13 +56,14 @@ func Test_Schematic_Card_Eager_Image_Loading(t *testing.T) {
 	if got := strings.Count(out, `fetchpriority="high"`); got != 12 {
 		t.Fatalf("expected 12 fetchpriority=high thumbnails, got %d", got)
 	}
-	// Each eager card has two eager imgs (placeholder + thumbnail).
-	if got := strings.Count(out, `loading="eager"`); got != 24 {
-		t.Fatalf("expected 24 eager-loading imgs, got %d", got)
+	// Placeholders are now CSS backgrounds (not indexable <img>), so each card
+	// renders a single thumbnail <img>: 12 eager for the above-the-fold cards.
+	if got := strings.Count(out, `loading="eager"`); got != 12 {
+		t.Fatalf("expected 12 eager-loading imgs, got %d", got)
 	}
-	// The remaining 2 cards stay lazy (2 imgs each).
-	if got := strings.Count(out, `loading="lazy"`); got != 4 {
-		t.Fatalf("expected 4 lazy-loading imgs, got %d", got)
+	// The remaining 2 cards stay lazy (one img each).
+	if got := strings.Count(out, `loading="lazy"`); got != 2 {
+		t.Fatalf("expected 2 lazy-loading imgs, got %d", got)
 	}
 }
 

--- a/template/include/head.html
+++ b/template/include/head.html
@@ -33,8 +33,8 @@ window.setTheme=function(theme){
     <meta property="og:image" content="{{ .Thumbnail }}">
     {{ else }}
     <meta property="og:image" content="https://createmod.com/assets/x/logo_sq_lg.png">
-    <meta property="og:image:width" content="709">
-    <meta property="og:image:height" content="360">
+    <meta property="og:image:width" content="1280">
+    <meta property="og:image:height" content="720">
     {{ end }}
     <meta name="twitter:site" content="@uberswe">
     <meta name="twitter:title" content="{{ .Title }} - CreateMod.com">

--- a/template/include/schematic_card.html
+++ b/template/include/schematic_card.html
@@ -1,8 +1,7 @@
 {{define "schematic_card.html"}}
 <a href="{{ LangURL .Language "/schematics" }}/{{ .Name }}" class="d-block text-decoration-none">
   <div class="card card-sm card-hover-lift overflow-hidden">
-    <div class="card-body-borderless ratio ratio-16x9">
-      <img loading="{{ if .EagerImage }}eager{{ else }}lazy{{ end }}" src="{{ PlaceholderImg .ID }}" alt="" class="object-fit-cover" width="640" height="360" style="z-index:0;">
+    <div class="card-body-borderless ratio ratio-16x9" style="background-image:url('{{ PlaceholderImg .ID }}');background-size:cover;background-position:center;">
       {{ if ne .FeaturedImage "" }}
       <img loading="{{ if .EagerImage }}eager{{ else }}lazy{{ end }}"{{ if .EagerImage }} fetchpriority="high"{{ end }} src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180&v=2"
            srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180&v=2 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360&v=2 640w"

--- a/template/include/schematic_card_featured.html
+++ b/template/include/schematic_card_featured.html
@@ -2,8 +2,7 @@
 <div class="col-md-4 col-12 mb-3">
   <a href="{{ LangURL .Language "/schematics" }}/{{ .Name }}" class="d-block text-decoration-none">
     <div class="card card-featured card-hover-lift overflow-hidden">
-      <div class="ratio ratio-16x9">
-        <img loading="lazy" src="{{ PlaceholderImg .ID }}" alt="" class="object-fit-cover" width="640" height="360" style="z-index:0;">
+      <div class="ratio ratio-16x9" style="background-image:url('{{ PlaceholderImg .ID }}');background-size:cover;background-position:center;">
         {{ if ne .FeaturedImage "" }}
         <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180&v=2"
              srcset="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=320x180&v=2 320w, /api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=640x360&v=2 640w"

--- a/template/include/schematic_card_list.html
+++ b/template/include/schematic_card_list.html
@@ -1,7 +1,6 @@
 {{define "schematic_card_list.html"}}
 <a href="{{ LangURL .Language "/schematics" }}/{{ .Name }}" class="search-list-item d-flex text-decoration-none">
-  <div class="flex-shrink-0" style="width: 120px; height: 68px; position:relative;">
-    <img loading="lazy" src="{{ PlaceholderImg .ID }}" alt="" class="object-fit-cover" width="120" height="68" style="position:absolute;inset:0;width:120px;height:68px;border-radius:.4rem;z-index:0;">
+  <div class="flex-shrink-0" style="width: 120px; height: 68px; position:relative;background-image:url('{{ PlaceholderImg .ID }}');background-size:cover;background-position:center;border-radius:.4rem;">
     {{ if ne .FeaturedImage "" }}
     <img loading="lazy" src="/api/files/schematics/{{ .ID }}/{{ urlPathEscape .FeaturedImage }}?thumb=240x136&v=2"
          alt="Featured image of {{ .Title }}" class="object-fit-cover" width="120" height="68" style="position:absolute;inset:0;width:120px;height:68px;border-radius:.4rem;z-index:1;"

--- a/template/schematic.html
+++ b/template/schematic.html
@@ -341,8 +341,7 @@
                             {{ else if ne .Schematic.FeaturedImage "" }}
                             <a data-fslightbox="gallery" hx-boost="false"
                                href="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}">
-                                <div class="ratio ratio-16x9">
-                                <img src="{{ PlaceholderImg .Schematic.ID }}" alt="" class="object-fit-cover" width="1920" height="1080" style="z-index:0;">
+                                <div class="ratio ratio-16x9" style="background-image:url('{{ PlaceholderImg .Schematic.ID }}');background-size:cover;background-position:center;">
                                 <img
                                         src="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540&v=2"
                                         srcset="/api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=640x360&v=2 640w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=960x540&v=2 960w, /api/files/schematics/{{ .Schematic.ID }}/{{ urlPathEscape .Schematic.FeaturedImage }}?thumb=1920x1080&v=2 1920w"
@@ -352,9 +351,7 @@
                                 </div>
                             </a>
                             {{ else }}
-                            <div class="ratio ratio-16x9">
-                                <img src="{{ PlaceholderImg .Schematic.ID }}" class="object-fit-cover" width="1920" height="1080" alt="">
-                            </div>
+                            <div class="ratio ratio-16x9" style="background-image:url('{{ PlaceholderImg .Schematic.ID }}');background-size:cover;background-position:center;"></div>
                             {{ end }}
                             <div class="card-body">
                                 {{/* Gallery thumbnails — horizontally scrollable strip */}}


### PR DESCRIPTION
Google Search Console was showing the schematic placeholder image as the thumbnail for listing pages (home, /mods, /mods/<mod>) instead of the logo or a real schematic image. Cause: every schematic card rendered the placeholder as a real <img src> layered behind the real thumbnail, so each listing page carried dozens-to-hundreds of placeholder <img> elements that Googlebot indexes and can pick as the page's preview image.

Render the placeholder as a CSS background-image on the image container instead of an <img> (card + featured + list card templates, and the schematic detail hero, including the imageless case). Visually identical — it's still the loading backdrop, imageless fallback, and broken-image fallback (the real <img> keeps its onerror hide) — but placeholders are no longer crawlable content images, so Google is left with real schematic images and the og:image logo to choose from.

Also correct the logo og:image dimensions (declared 709x360; the file is 1280x720). Update the eager-loading card test for the single-<img> markup.