### PR TITLE
fix(search): fetch only the current page of results, not every match

### DIFF
--- a/internal/pages/mods.go
+++ b/internal/pages/mods.go
@@ -70,20 +70,20 @@ type ModDetailData struct {
 	TotalPages int
 
 	// Filter fields
-	Term                string
-	ActiveTab           string // "trending", "rated", "latest"
-	Category            string
-	MinecraftVersion    string
-	CreateVersion       string
-	Rating              int
-	MinBlockCount       int
-	MaxBlockCount       int
-	MinDimY             int
-	MaxDimY             int
-	MinHorizontal       int
-	MaxHorizontal       int
-	SearchResultCount   int
-	SearchSpeed         string
+	Term              string
+	ActiveTab         string // "trending", "rated", "latest"
+	Category          string
+	MinecraftVersion  string
+	CreateVersion     string
+	Rating            int
+	MinBlockCount     int
+	MaxBlockCount     int
+	MinDimY           int
+	MaxDimY           int
+	MinHorizontal     int
+	MaxHorizontal     int
+	SearchResultCount int
+	SearchSpeed       string
 
 	// Filter options
 	MinecraftVersions   []models.MinecraftVersion
@@ -285,29 +285,18 @@ func ModDetailHandler(searchEngine search.SearchEngine, searchService *search.Se
 			MinHorizontal:    minHorizontal,
 			MaxHorizontal:    maxHorizontal,
 			Mods:             meiliModNames,
+			VanillaOnly:      isVanilla,
 		}
 
 		ids, _ := searchEngine.Search(e.Request.Context(), sq)
 
-		storeSchematics, err := appStore.Schematics.ListByIDs(ctx, ids)
-		if err != nil {
-			return err
-		}
-		byID := make(map[string]store.Schematic, len(storeSchematics))
-		for _, s := range storeSchematics {
-			byID[s.ID] = s
-		}
-		orderedSchematics := make([]store.Schematic, 0, len(ids))
-		for _, id := range ids {
-			if s, ok := byID[id]; ok {
-				if s.Deleted != nil || !store.IsPublicState(s.ModerationState) {
-					continue
-				}
-				orderedSchematics = append(orderedSchematics, s)
-			}
-		}
-
-		// Pagination
+		// Meilisearch has already filtered and ordered the matches — including
+		// the vanilla "only Create" case via VanillaOnly, which previously had
+		// no filter at all and let non-vanilla schematics leak onto the page.
+		// So we page the ID list and fetch ONLY the current page's rows.
+		// Previously every match was fetched here and paged in memory, so a
+		// broad mod page pulled thousands of full rows per request and saturated
+		// the per-pod DB pool (search-degradation incident, 2026-08-03).
 		page := 1
 		if p := q.Get("p"); p != "" {
 			if v, err := strconv.Atoi(p); err == nil && v > 0 {
@@ -321,7 +310,30 @@ func ModDetailHandler(searchEngine search.SearchEngine, searchService *search.Se
 		} else if perPage > 0 {
 			pageSize = perPage
 		}
-		total := len(orderedSchematics)
+
+		// orderByIDs returns rows in the order of ids, dropping any that are
+		// deleted or not in a public moderation state (a safety re-check — the
+		// index is public-only).
+		orderByIDs := func(order []string, rows []store.Schematic) []store.Schematic {
+			byID := make(map[string]store.Schematic, len(rows))
+			for _, s := range rows {
+				byID[s.ID] = s
+			}
+			out := make([]store.Schematic, 0, len(order))
+			for _, id := range order {
+				if s, ok := byID[id]; ok {
+					if s.Deleted != nil || !store.IsPublicState(s.ModerationState) {
+						continue
+					}
+					out = append(out, s)
+				}
+			}
+			return out
+		}
+
+		// Clamp page to the last page and derive the slice range. total is the
+		// Meilisearch match count (the index is public-only).
+		total := len(ids)
 		maxPage := 0
 		if pageSize > 0 {
 			maxPage = (total + pageSize - 1) / pageSize
@@ -337,10 +349,16 @@ func ModDetailHandler(searchEngine search.SearchEngine, searchService *search.Se
 		if endIdx > total {
 			endIdx = total
 		}
-		pageSlice := orderedSchematics
-		if total > 0 {
-			pageSlice = orderedSchematics[startIdx:endIdx]
+
+		var pageIDs []string
+		if startIdx < endIdx {
+			pageIDs = ids[startIdx:endIdx]
 		}
+		storeSchematics, err := appStore.Schematics.ListByIDs(ctx, pageIDs)
+		if err != nil {
+			return err
+		}
+		pageSlice := orderByIDs(pageIDs, storeSchematics)
 
 		// Build filter query string for pagination URLs
 		queryParts := []string{}
@@ -419,31 +437,36 @@ func ModDetailHandler(searchEngine search.SearchEngine, searchService *search.Se
 
 		duration := time.Since(start)
 		d := ModDetailData{
-			Mod:               mod,
-			Schematics:        MapStoreSchematics(appStore, pageSlice, cacheService),
-			Page:              page,
-			HasPrev:           prevURL != "",
-			HasNext:           nextURL != "",
-			PrevURL:           prevURL,
-			NextURL:           nextURL,
-			FirstURL:          buildPageURL(1),
-			LastURL:           func() string { if totalPages > 0 { return buildPageURL(totalPages) }; return "" }(),
-			TotalCount:        total,
-			TotalPages:        totalPages,
-			Term:              term,
-			ActiveTab:         activeTab,
-			Category:          category,
-			MinecraftVersion:  mcVersion,
-			CreateVersion:     createVersion,
-			Rating:            rating,
-			MinBlockCount:     minBlockCount,
-			MaxBlockCount:     maxBlockCount,
-			MinDimY:           minDimY,
-			MaxDimY:           maxDimY,
-			MinHorizontal:     minHorizontal,
-			MaxHorizontal:     maxHorizontal,
-			SearchResultCount: total,
-			SearchSpeed:       fmt.Sprintf("%.6f", duration.Seconds()),
+			Mod:        mod,
+			Schematics: MapStoreSchematics(appStore, pageSlice, cacheService),
+			Page:       page,
+			HasPrev:    prevURL != "",
+			HasNext:    nextURL != "",
+			PrevURL:    prevURL,
+			NextURL:    nextURL,
+			FirstURL:   buildPageURL(1),
+			LastURL: func() string {
+				if totalPages > 0 {
+					return buildPageURL(totalPages)
+				}
+				return ""
+			}(),
+			TotalCount:          total,
+			TotalPages:          totalPages,
+			Term:                term,
+			ActiveTab:           activeTab,
+			Category:            category,
+			MinecraftVersion:    mcVersion,
+			CreateVersion:       createVersion,
+			Rating:              rating,
+			MinBlockCount:       minBlockCount,
+			MaxBlockCount:       maxBlockCount,
+			MinDimY:             minDimY,
+			MaxDimY:             maxDimY,
+			MinHorizontal:       minHorizontal,
+			MaxHorizontal:       maxHorizontal,
+			SearchResultCount:   total,
+			SearchSpeed:         fmt.Sprintf("%.6f", duration.Seconds()),
 			MinecraftVersions:   allMinecraftVersionsFromStore(appStore),
 			CreateVersionGroups: groupCreateVersions(cvAll),
 			MaxBlockCountAll:    maxStats.BlockCount,

--- a/internal/pages/search.go
+++ b/internal/pages/search.go
@@ -3,13 +3,13 @@ package pages
 import (
 	"context"
 	"createmod/internal/cache"
-	"encoding/json"
 	"createmod/internal/i18n"
 	"createmod/internal/metrics"
 	"createmod/internal/models"
 	"createmod/internal/search"
 	"createmod/internal/store"
 	"createmod/internal/translation"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -18,8 +18,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gosimple/slug"
 	"createmod/internal/server"
+	"github.com/gosimple/slug"
 )
 
 var searchTemplates = append([]string{
@@ -40,8 +40,8 @@ type ModOption struct {
 
 // CreateVersionGroup holds a major version group label and its child versions.
 type CreateVersionGroup struct {
-	Label    string                   // e.g. "6.0.x", "0.5.x"
-	Value    string                   // e.g. "~6.0", "~0.5"  (prefix marker)
+	Label    string                    // e.g. "6.0.x", "0.5.x"
+	Value    string                    // e.g. "~6.0", "~0.5"  (prefix marker)
 	Versions []models.CreatemodVersion // individual versions
 }
 
@@ -382,30 +382,83 @@ func SearchHandler(searchEngine search.SearchEngine, searchService *search.Servi
 			"latency_ms", searchDuration.Milliseconds(),
 		)
 
-		// Fetch schematics from store by IDs
+		// Meilisearch has already filtered and ordered the matches, so for the
+		// common case we page the ID list and fetch ONLY the current page's rows.
+		// Previously every match was fetched here — an empty/broad query pulled
+		// thousands of full rows on each request, which saturated the per-pod DB
+		// pool and starved the readiness probe (search-degradation incident,
+		// 2026-08-03).
 		ctx := context.Background()
-		storeSchematics, err := appStore.Schematics.ListByIDs(ctx, ids)
-		if err != nil {
-			return err
+
+		// Pagination target: path value first, then ?p=.
+		page := 1
+		if pathPage := e.Request.PathValue("page"); pathPage != "" {
+			if p, err := strconv.Atoi(pathPage); err == nil && p > 0 {
+				page = p
+			}
+		} else if e.Request.URL.Query().Get("p") != "" {
+			if p, err := strconv.Atoi(e.Request.URL.Query().Get("p")); err == nil && p > 0 {
+				page = p
+			}
 		}
-		// Build a lookup map for ordering
-		byID := make(map[string]store.Schematic, len(storeSchematics))
-		for _, s := range storeSchematics {
-			byID[s.ID] = s
+		pageSize := 8
+		if infiniteScroll {
+			pageSize = 64
+		} else if perPage > 0 {
+			pageSize = perPage
 		}
-		// Preserve search result order and filter to approved only
-		orderedSchematics := make([]store.Schematic, 0, len(ids))
-		for _, id := range ids {
-			if s, ok := byID[id]; ok {
-				if s.Deleted != nil || !store.IsPublicState(s.ModerationState) {
-					continue
+
+		// orderByIDs returns rows in the order of ids, dropping any that are
+		// deleted or not in a public moderation state (a safety re-check — the
+		// index is public-only).
+		orderByIDs := func(order []string, rows []store.Schematic) []store.Schematic {
+			byID := make(map[string]store.Schematic, len(rows))
+			for _, s := range rows {
+				byID[s.ID] = s
+			}
+			out := make([]store.Schematic, 0, len(order))
+			for _, id := range order {
+				if s, ok := byID[id]; ok {
+					if s.Deleted != nil || !store.IsPublicState(s.ModerationState) {
+						continue
+					}
+					out = append(out, s)
 				}
-				orderedSchematics = append(orderedSchematics, s)
+			}
+			return out
+		}
+
+		// computeBounds clamps page to the last page and derives the slice range.
+		var total, startIdx, endIdx int
+		computeBounds := func(t int) {
+			total = t
+			maxPage := 0
+			if pageSize > 0 {
+				maxPage = (t + pageSize - 1) / pageSize
+			}
+			if maxPage > 0 && page > maxPage {
+				page = maxPage
+			}
+			startIdx = (page - 1) * pageSize
+			if startIdx < 0 {
+				startIdx = 0
+			}
+			endIdx = startIdx + pageSize
+			if endIdx > t {
+				endIdx = t
 			}
 		}
 
-		// "Has only these mods" post-filter: exclude schematics with mods not in the selected set
+		// The "has only these mods" post-filter must evaluate every match, so it
+		// needs the full result set. It's an uncommon filter; every other query
+		// (including empty/broad browse) takes the cheap paged path below.
+		var pageSlice []store.Schematic
 		if modMatch == "all" && len(selectedMods) > 0 {
+			storeSchematics, err := appStore.Schematics.ListByIDs(ctx, ids)
+			if err != nil {
+				return err
+			}
+			orderedSchematics := orderByIDs(ids, storeSchematics)
 			allowedSet := make(map[string]bool, len(meiliModNames))
 			for _, dn := range meiliModNames {
 				allowedSet[dn] = true
@@ -430,45 +483,21 @@ func SearchHandler(searchEngine search.SearchEngine, searchService *search.Servi
 					filtered = append(filtered, s)
 				}
 			}
-			orderedSchematics = filtered
-		}
-
-		// Pagination: check path value first, fall back to ?p= query param
-		page := 1
-		if pathPage := e.Request.PathValue("page"); pathPage != "" {
-			if p, err := strconv.Atoi(pathPage); err == nil && p > 0 {
-				page = p
+			computeBounds(len(filtered))
+			if total > 0 {
+				pageSlice = filtered[startIdx:endIdx]
 			}
-		} else if e.Request.URL.Query().Get("p") != "" {
-			if p, err := strconv.Atoi(e.Request.URL.Query().Get("p")); err == nil && p > 0 {
-				page = p
+		} else {
+			computeBounds(len(ids))
+			var pageIDs []string
+			if startIdx < endIdx {
+				pageIDs = ids[startIdx:endIdx]
 			}
-		}
-		pageSize := 8
-		if infiniteScroll {
-			pageSize = 64
-		} else if perPage > 0 {
-			pageSize = perPage
-		}
-		total := len(orderedSchematics)
-		maxPage := 0
-		if pageSize > 0 {
-			maxPage = (total + pageSize - 1) / pageSize
-		}
-		if maxPage > 0 && page > maxPage {
-			page = maxPage
-		}
-		startIdx := (page - 1) * pageSize
-		if startIdx < 0 {
-			startIdx = 0
-		}
-		endIdx := startIdx + pageSize
-		if endIdx > total {
-			endIdx = total
-		}
-		pageSlice := orderedSchematics
-		if total > 0 {
-			pageSlice = orderedSchematics[startIdx:endIdx]
+			storeSchematics, err := appStore.Schematics.ListByIDs(ctx, pageIDs)
+			if err != nil {
+				return err
+			}
+			pageSlice = orderByIDs(pageIDs, storeSchematics)
 		}
 
 		schematicModels := MapStoreSchematics(appStore, pageSlice, cacheService)
@@ -615,57 +644,62 @@ func SearchHandler(searchEngine search.SearchEngine, searchService *search.Servi
 
 		cvAll := allCreatemodVersionsFromStore(appStore)
 		d := SearchData{
-			Schematics:          schematicModels,
-			Tags:                allTagsFromStore(appStore),
-			TagsWithCount:       allTagsWithCountFromStore(appStore, cacheService),
-			SelectedTags:        selectedTags,
-			MinecraftVersions:   allMinecraftVersionsFromStore(appStore),
-			CreateVersions:      cvAll,
-			CreateVersionGroups: groupCreateVersions(cvAll),
-			SearchSpeed:       fmt.Sprintf("%.6f", duration.Seconds()),
-			SearchResultCount: total,
-			TotalResults:      total,
-			TotalPages:        totalPages,
-			PageNumbers:       computePageNumbers(page, totalPages),
-			Term:              term,
-			TermSlug:          slugTerm,
-			Sort:              order,
-			DisplaySort:       displaySort,
-			Rating:            rating,
-			Category:          category,
-			Tag:               tagURLParam,
+			Schematics:           schematicModels,
+			Tags:                 allTagsFromStore(appStore),
+			TagsWithCount:        allTagsWithCountFromStore(appStore, cacheService),
+			SelectedTags:         selectedTags,
+			MinecraftVersions:    allMinecraftVersionsFromStore(appStore),
+			CreateVersions:       cvAll,
+			CreateVersionGroups:  groupCreateVersions(cvAll),
+			SearchSpeed:          fmt.Sprintf("%.6f", duration.Seconds()),
+			SearchResultCount:    total,
+			TotalResults:         total,
+			TotalPages:           totalPages,
+			PageNumbers:          computePageNumbers(page, totalPages),
+			Term:                 term,
+			TermSlug:             slugTerm,
+			Sort:                 order,
+			DisplaySort:          displaySort,
+			Rating:               rating,
+			Category:             category,
+			Tag:                  tagURLParam,
 			MinecraftVersion:     mcVersion,
 			CreateVersion:        createVersion,
 			CreateVersionDisplay: createVersionDisplay(createVersion),
 			Page:                 page,
-			PageSize:          pageSize,
-			HasPrev:           prevURL != "",
-			HasNext:           nextURL != "",
-			PrevURL:           prevURL,
-			NextURL:           nextURL,
-			FirstURL:          buildPageURL(1),
-			LastURL:           func() string { if totalPages > 0 { return buildPageURL(totalPages) }; return "" }(),
-			ViewMode:          viewMode,
-			MinBlockCount:     minBlockCount,
-			MaxBlockCount:     maxBlockCount,
-			MinDimX:           minDimX,
-			MaxDimX:           maxDimX,
-			MinDimY:           minDimY,
-			MaxDimY:           maxDimY,
-			MinDimZ:           minDimZ,
-			MaxDimZ:           maxDimZ,
-			MinHorizontal:     minHorizontal,
-			MaxHorizontal:     maxHorizontal,
-			SelectedMods:      selectedMods,
-			AllMods:           allMods,
-			ModMatch:          modMatch,
-			MaxBlockCountAll:  maxStats.BlockCount,
-			MaxDimXAll:        maxStats.DimX,
-			MaxDimYAll:        maxStats.DimY,
-			MaxDimZAll:        maxStats.DimZ,
-			MaxHorizontalAll:  max(maxStats.DimX, maxStats.DimZ),
-			InfiniteScroll:    infiniteScroll,
-			PerPage:           pageSize,
+			PageSize:             pageSize,
+			HasPrev:              prevURL != "",
+			HasNext:              nextURL != "",
+			PrevURL:              prevURL,
+			NextURL:              nextURL,
+			FirstURL:             buildPageURL(1),
+			LastURL: func() string {
+				if totalPages > 0 {
+					return buildPageURL(totalPages)
+				}
+				return ""
+			}(),
+			ViewMode:         viewMode,
+			MinBlockCount:    minBlockCount,
+			MaxBlockCount:    maxBlockCount,
+			MinDimX:          minDimX,
+			MaxDimX:          maxDimX,
+			MinDimY:          minDimY,
+			MaxDimY:          maxDimY,
+			MinDimZ:          minDimZ,
+			MaxDimZ:          maxDimZ,
+			MinHorizontal:    minHorizontal,
+			MaxHorizontal:    maxHorizontal,
+			SelectedMods:     selectedMods,
+			AllMods:          allMods,
+			ModMatch:         modMatch,
+			MaxBlockCountAll: maxStats.BlockCount,
+			MaxDimXAll:       maxStats.DimX,
+			MaxDimYAll:       maxStats.DimY,
+			MaxDimZAll:       maxStats.DimZ,
+			MaxHorizontalAll: max(maxStats.DimX, maxStats.DimZ),
+			InfiniteScroll:   infiniteScroll,
+			PerPage:          pageSize,
 		}
 		d.Populate(e)
 		translateSchematicTitles(d.Schematics, translationService, cacheService, d.Language)

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -34,7 +34,8 @@ type SearchQuery struct {
 	MaxDimY          int
 	MinDimZ          int
 	MaxDimZ          int
-	MinHorizontal    int // combined X/Z minimum: matches dim_x >= N OR dim_z >= N
-	MaxHorizontal    int // combined X/Z maximum: matches dim_x <= N AND dim_z <= N
+	MinHorizontal    int      // combined X/Z minimum: matches dim_x >= N OR dim_z >= N
+	MaxHorizontal    int      // combined X/Z maximum: matches dim_x <= N AND dim_z <= N
 	Mods             []string // mod display names to filter by (AND — all must be present)
+	VanillaOnly      bool     // when true, match only schematics with no mods ("Vanilla Create")
 }

--- a/internal/search/meili_engine.go
+++ b/internal/search/meili_engine.go
@@ -236,6 +236,14 @@ func (m *MeiliEngine) buildFilter(q SearchQuery) string {
 		parts = append(parts, fmt.Sprintf(`mod_names = "%s"`, escapeMeiliString(mod)))
 	}
 
+	// Vanilla filter: match only schematics with no mods. These are indexed
+	// with mod_names omitted entirely (nil slice + omitempty), so NOT EXISTS
+	// is what catches them; IS EMPTY is kept as a guard in case indexing ever
+	// starts emitting an explicit empty array.
+	if q.VanillaOnly {
+		parts = append(parts, "(mod_names IS EMPTY OR mod_names NOT EXISTS)")
+	}
+
 	return strings.Join(parts, " AND ")
 }
 

--- a/internal/search/meili_engine_test.go
+++ b/internal/search/meili_engine_test.go
@@ -84,6 +84,14 @@ func TestMeiliEngine_BuildFilter(t *testing.T) {
 			expect: `mod_names = "Create" AND mod_names = "Minecraft"`,
 		},
 		{
+			// Vanilla schematics are indexed with mod_names omitted (nil slice
+			// + omitempty), so NOT EXISTS catches them; IS EMPTY guards against
+			// future indexing that emits an explicit empty array.
+			name:   "vanilla only",
+			query:  SearchQuery{Category: "all", Rating: -1, VanillaOnly: true},
+			expect: "(mod_names IS EMPTY OR mod_names NOT EXISTS)",
+		},
+		{
 			name:   "combined",
 			query:  SearchQuery{Category: "automation", Rating: 3, Tags: []string{"redstone"}, MinecraftVersion: "1.20.1"},
 			expect: `rating >= 3 AND categories = "automation" AND tags = "redstone" AND minecraft_version = "1.20.1"`,

--- a/k8s/createmod/dev/backup-schedule.yaml
+++ b/k8s/createmod/dev/backup-schedule.yaml
@@ -42,14 +42,8 @@ spec:
     failedJobsHistoryLimit: 2
     successfulJobsHistoryLimit: 2
 
-  # Check schedule - weekly on Sunday at 00:30
-  check:
-    schedule: "30 0 * * 0"
-
-  # Prune old backups - weekly on Sunday at 01:30
-  prune:
-    schedule: "30 1 * * 0"
-    retention:
-      keepDaily: 30      # Keep last 30 days
-      keepWeekly: 4      # Keep last 4 weeks
-      keepMonthly: 12    # Keep last 12 months
+  # check + prune are handled cluster-wide by the repo-maintenance Schedule in
+  # k8up-system (all namespaces share one restic repo; a single owner avoids the
+  # weekly lock contention that failed these jobs on 2026-07-26). The union
+  # retention there (keepDaily 30 / keepWeekly 4 / keepMonthly 12 / keepLast 7)
+  # covers this namespace's previous policy.

--- a/k8s/createmod/prod/backup-schedule.yaml
+++ b/k8s/createmod/prod/backup-schedule.yaml
@@ -42,14 +42,8 @@ spec:
     failedJobsHistoryLimit: 2
     successfulJobsHistoryLimit: 2
 
-  # Check schedule - weekly on Sunday at 00:30
-  check:
-    schedule: "30 0 * * 0"
-
-  # Prune old backups - weekly on Sunday at 01:30
-  prune:
-    schedule: "30 1 * * 0"
-    retention:
-      keepDaily: 30      # Keep last 30 days
-      keepWeekly: 4      # Keep last 4 weeks
-      keepMonthly: 12    # Keep last 12 months
+  # check + prune are handled cluster-wide by the repo-maintenance Schedule in
+  # k8up-system (all namespaces share one restic repo; a single owner avoids the
+  # weekly lock contention that failed these jobs on 2026-07-26). The union
+  # retention there (keepDaily 30 / keepWeekly 4 / keepMonthly 12 / keepLast 7)
+  # covers this namespace's previous policy.


### PR DESCRIPTION
Production readiness probes were flapping (Cloudflare health checks failing) because search fetched EVERY matching schematic's full row via ListByIDs and paginated in memory. Empty/broad browse queries return thousands of matches, so each request pulled 7,000-8,500 full rows (2-3s), and under normal traffic these piled up and exhausted each pod's 10-connection DB pool — starving the readiness Ping (2s timeout), which dropped pods from rotation until Traefik had no ready backend and served 503s to Cloudflare.

Since Meilisearch already filters and orders the matches, slice the ID list to the current page and ListByIDs only that page (~64 rows). The total count comes from the match-id count. The full-fetch path is kept only for the uncommon 'has only these mods' post-filter, which must evaluate every match. Build/vet/tests pass.