### PR TITLE
fix(editor): carry the external-viewer preview token in the path, not…

### DIFF
--- a/internal/pages/editor_token.go
+++ b/internal/pages/editor_token.go
@@ -92,11 +92,19 @@ func editorTokenAllows(id, tok, need string, now time.Time) bool {
 	return true
 }
 
-// editorTokenFromRequest reads the token from the X-Editor-Token header (the
-// editor client's edit token) or the ?t= query param (view tokens on download
-// links and external-viewer URLs, which cannot set headers).
+// editorTokenFromRequest reads the token from, in order: the X-Editor-Token
+// header (the editor client's edit token), the {token} path segment, or the ?t=
+// query param.
+//
+// The path segment exists because external viewers (Bloxelizer, Shulkr) fetch
+// the preview URL we hand them but STRIP its query string, which would drop a
+// ?t= token. Carrying the view token as a path segment survives that, while the
+// URL still ends in .nbt so the viewer recognizes the format.
 func editorTokenFromRequest(e *server.RequestEvent) string {
 	if t := e.Request.Header.Get("X-Editor-Token"); t != "" {
+		return t
+	}
+	if t := e.Request.PathValue("token"); t != "" {
 		return t
 	}
 	return e.Request.URL.Query().Get("t")

--- a/internal/pages/editor_token_test.go
+++ b/internal/pages/editor_token_test.go
@@ -1,9 +1,51 @@
 package pages
 
 import (
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"createmod/internal/server"
 )
+
+func TestEditorTokenFromRequest_Sources(t *testing.T) {
+	// Header wins over path and query.
+	req := httptest.NewRequest("GET", "/api/editor/id/tok-path/preview.nbt?t=tok-query", nil)
+	req.Header.Set("X-Editor-Token", "tok-header")
+	req.SetPathValue("token", "tok-path")
+	if got := editorTokenFromRequest(&server.RequestEvent{Request: req}); got != "tok-header" {
+		t.Fatalf("header precedence: got %q, want tok-header", got)
+	}
+
+	// Path segment is used when there is no header — this is the external-viewer
+	// path form whose query would otherwise be stripped by the viewer.
+	req = httptest.NewRequest("GET", "/api/editor/id/tok-path/preview.nbt?t=tok-query", nil)
+	req.SetPathValue("token", "tok-path")
+	if got := editorTokenFromRequest(&server.RequestEvent{Request: req}); got != "tok-path" {
+		t.Fatalf("path precedence over query: got %q, want tok-path", got)
+	}
+
+	// Query is the last resort (download links).
+	req = httptest.NewRequest("GET", "/api/editor/id/preview.nbt?t=tok-query", nil)
+	if got := editorTokenFromRequest(&server.RequestEvent{Request: req}); got != "tok-query" {
+		t.Fatalf("query fallback: got %q, want tok-query", got)
+	}
+}
+
+// A view token carried in the path authorizes a view-scope read, just like one
+// in the query — this is what keeps Bloxelizer/Shulkr working.
+func TestEditorTokenFromRequest_PathViewToken(t *testing.T) {
+	const id = "abcdef01-2345-6789-abcd-ef0123456789"
+	now := time.Unix(1_700_000_000, 0)
+	view := mintEditorToken(id, editorScopeView, now)
+
+	req := httptest.NewRequest("GET", "/api/editor/"+id+"/"+view+"/preview.nbt", nil)
+	req.SetPathValue("token", view)
+	got := editorTokenFromRequest(&server.RequestEvent{Request: req})
+	if !editorTokenAllows(id, got, editorScopeView, now) {
+		t.Fatal("path-carried view token failed view-scope validation")
+	}
+}
 
 func TestEditorToken_MintAndAllow(t *testing.T) {
 	const id = "11111111-2222-3333-4444-555555555555"

--- a/internal/router/editor_preview_route_test.go
+++ b/internal/router/editor_preview_route_test.go
@@ -1,0 +1,49 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// The plain preview.nbt route and the token-in-path variant must coexist: a
+// 2-segment request hits the plain route, a 3-segment request hits the path
+// variant and exposes both {id} and {token}. This guards the external-viewer
+// fix against a chi routing ambiguity.
+func TestEditorPreviewRoutes_Coexist(t *testing.T) {
+	r := chi.NewRouter()
+	r.Get("/api/editor/{id}/preview.nbt", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Route", "plain")
+		w.Header().Set("X-Id", chi.URLParam(req, "id"))
+	})
+	r.Get("/api/editor/{id}/{token}/preview.nbt", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Route", "path-token")
+		w.Header().Set("X-Id", chi.URLParam(req, "id"))
+		w.Header().Set("X-Token", chi.URLParam(req, "token"))
+	})
+
+	do := func(path string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		return rec
+	}
+
+	plain := do("/api/editor/sess-1/preview.nbt")
+	if plain.Header().Get("X-Route") != "plain" || plain.Header().Get("X-Id") != "sess-1" {
+		t.Fatalf("plain route: got route=%q id=%q", plain.Header().Get("X-Route"), plain.Header().Get("X-Id"))
+	}
+
+	// Token segment carries dots (scope.exp.sig); it must be captured whole.
+	pathTok := do("/api/editor/sess-1/v.68abc123.deadbeefdeadbeef/preview.nbt")
+	if pathTok.Header().Get("X-Route") != "path-token" {
+		t.Fatalf("path-token route not matched: got %q", pathTok.Header().Get("X-Route"))
+	}
+	if pathTok.Header().Get("X-Id") != "sess-1" {
+		t.Fatalf("path-token id: got %q, want sess-1", pathTok.Header().Get("X-Id"))
+	}
+	if got := pathTok.Header().Get("X-Token"); got != "v.68abc123.deadbeefdeadbeef" {
+		t.Fatalf("path-token token: got %q", got)
+	}
+}

--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -774,6 +774,11 @@ func Register(p RegisterParams) chi.Router {
 	r.With(rateLimitMiddlewareNew(p.RateLimiter, 60, time.Minute)).Post("/api/editor/{id}/undo", Adapt(pages.EditorUndoRedoHandler(p.AppStore, p.StorageService, false)))
 	r.With(rateLimitMiddlewareNew(p.RateLimiter, 60, time.Minute)).Post("/api/editor/{id}/redo", Adapt(pages.EditorUndoRedoHandler(p.AppStore, p.StorageService, true)))
 	r.With(editorDump).Get("/api/editor/{id}/preview.nbt", Adapt(pages.EditorPreviewNBTHandler(p.AppStore, p.StorageService)))
+	// Same preview, with the view token carried as a path segment (…/{token}/preview.nbt)
+	// instead of ?t=. External viewers (Bloxelizer, Shulkr) strip the query when
+	// they re-fetch the URL we hand them, so the query form loses the token; the
+	// path form survives and the URL still ends in .nbt.
+	r.With(editorDump).Get("/api/editor/{id}/{token}/preview.nbt", Adapt(pages.EditorPreviewNBTHandler(p.AppStore, p.StorageService)))
 	r.With(editorDump).Get("/api/editor/{id}/download", Adapt(pages.EditorDownloadHandler(p.AppStore, p.StorageService)))
 	r.With(editorDump).Get("/api/editor/{id}/preview.json", Adapt(pages.EditorPreviewJSONHandler(p.AppStore, p.StorageService)))
 	// NBT viewer

--- a/template/editor.html
+++ b/template/editor.html
@@ -324,7 +324,12 @@
     document.querySelectorAll('.ed-dl').forEach(function (a) {
       a.href = tok('/api/editor/' + sessionID + '/download?format=' + a.getAttribute('data-format'));
     });
-    var previewURL = tok(location.origin + '/api/editor/' + sessionID + '/preview.nbt');
+    // External viewers strip the query string when they re-fetch the URL, so
+    // carry the view token as a path segment (…/{token}/preview.nbt) rather than
+    // ?t=. The URL still ends in .nbt so the viewer recognizes the format.
+    var previewURL = sessionViewToken
+      ? location.origin + '/api/editor/' + sessionID + '/' + encodeURIComponent(sessionViewToken) + '/preview.nbt'
+      : location.origin + '/api/editor/' + sessionID + '/preview.nbt';
     document.getElementById('ed-bloxelizer').href = 'https://bloxelizer.com/viewer?url=' + encodeURIComponent(previewURL);
     document.getElementById('ed-shulkr').href = 'https://www.shulkr.com/?url=' + encodeURIComponent(previewURL);
     setError('');


### PR DESCRIPTION
… the query

External 3D viewers (Bloxelizer, Shulkr) strip the query string when they re-fetch the preview URL we hand them, so the ?t= view token was dropped and the preview 404'd — breaking the "open in viewer" integration.

Serve the same preview.nbt from an additional route that takes the view token as a path segment (…/{token}/preview.nbt); the URL still ends in .nbt so the viewer recognizes the format. editorTokenFromRequest now also reads the {token} path value (header > path > query). Download links are same-origin navigations that preserve the query, so they keep using ?t= and are unchanged.

Build/vet/tests pass.