### PR TITLE
fix(search): resolve category key to its display name when filtering

### DIFF
--- a/internal/jobs/search_index.go
+++ b/internal/jobs/search_index.go
@@ -54,6 +54,21 @@ func (w *SearchIndexWorker) Work(ctx context.Context, job *river.Job[SearchIndex
 		slog.Warn("search index rebuild: failed to load mod metadata", "error", err)
 	}
 
+	// Load the category taxonomy so category filters can resolve the URL key
+	// (e.g. "vehicles") to the display name the index stores (e.g.
+	// "Vehicles & Contraptions").
+	if cats, err := readStore.Categories.List(ctx); err == nil {
+		categoryNames := make(map[string]string, len(cats))
+		for _, c := range cats {
+			if c.Key != "" && c.Name != "" {
+				categoryNames[c.Key] = c.Name
+			}
+		}
+		w.deps.Search.SetCategoryNames(categoryNames)
+	} else {
+		slog.Warn("search index rebuild: failed to load categories", "error", err)
+	}
+
 	mapped := pages.MapStoreSchematicsNoCache(readStore, storeSchematics, w.deps.Cache)
 	w.deps.Search.BuildIndex(mapped, modDisplayNames)
 

--- a/internal/search/meili_engine.go
+++ b/internal/search/meili_engine.go
@@ -165,7 +165,17 @@ func (m *MeiliEngine) buildFilter(q SearchQuery) string {
 	}
 
 	if q.Category != "" && q.Category != "all" {
+		// The index stores category display NAMES; q.Category is the URL key.
+		// Resolve key->name against the current taxonomy. Keys are curated (not
+		// slugs of the names), so guessing the name from the key breaks whenever
+		// they diverge (e.g. key "vehicles" -> name "Vehicles & Contraptions").
+		// Fall back to the old hyphen->space guess only if the key is unknown.
 		cat := strings.ReplaceAll(q.Category, "-", " ")
+		if m != nil && m.svc != nil {
+			if name, ok := m.svc.CategoryNameByKey(q.Category); ok {
+				cat = name
+			}
+		}
 		// Meilisearch filter values need quoting.
 		parts = append(parts, fmt.Sprintf(`categories = "%s"`, escapeMeiliString(cat)))
 	}

--- a/internal/search/meili_engine_test.go
+++ b/internal/search/meili_engine_test.go
@@ -135,3 +135,28 @@ func TestMeiliEngine_BuildSort(t *testing.T) {
 		}
 	}
 }
+
+// buildFilter must resolve a category URL key to the display name the index
+// stores. Keys are curated (not slugs of the names), so a name that diverges
+// from the key — like "vehicles" -> "Vehicles & Contraptions" — only works via
+// the taxonomy lookup, not the hyphen->space guess.
+func TestMeiliEngine_BuildFilter_CategoryResolution(t *testing.T) {
+	svc := &Service{}
+	svc.SetCategoryNames(map[string]string{
+		"vehicles":  "Vehicles & Contraptions",
+		"mob-farms": "Mob Farms",
+	})
+	m := &MeiliEngine{svc: svc}
+
+	if got := m.buildFilter(SearchQuery{Category: "vehicles", Rating: -1}); got != `categories = "Vehicles & Contraptions"` {
+		t.Fatalf("known key not resolved to name: %q", got)
+	}
+	// Known key whose name matches the guess still resolves to the real name.
+	if got := m.buildFilter(SearchQuery{Category: "mob-farms", Rating: -1}); got != `categories = "Mob Farms"` {
+		t.Fatalf("mob-farms: %q", got)
+	}
+	// Unknown key falls back to the hyphen->space guess (no taxonomy entry).
+	if got := m.buildFilter(SearchQuery{Category: "unknown-cat", Rating: -1}); got != `categories = "unknown cat"` {
+		t.Fatalf("unknown key fallback: %q", got)
+	}
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/text/cases"
@@ -50,6 +51,31 @@ type Service struct {
 	index          []schematicIndex
 	storage        *storage.Service
 	trendingScores map[string]float64
+
+	// categoryNames maps a category key (the URL slug, e.g. "vehicles") to its
+	// display name (e.g. "Vehicles & Contraptions"), which is what the search
+	// index actually stores. Keys are curated, not slugs of the names, so the
+	// name cannot be reconstructed from the key — it must be looked up here.
+	// Refreshed by the search-index rebuild job.
+	catMu         sync.RWMutex
+	categoryNames map[string]string
+}
+
+// SetCategoryNames replaces the category key->name map. Called from the search
+// index rebuild so category filters resolve against the current taxonomy.
+func (s *Service) SetCategoryNames(m map[string]string) {
+	s.catMu.Lock()
+	s.categoryNames = m
+	s.catMu.Unlock()
+}
+
+// CategoryNameByKey returns the display name for a category key, and whether it
+// was found.
+func (s *Service) CategoryNameByKey(key string) (string, bool) {
+	s.catMu.RLock()
+	name, ok := s.categoryNames[key]
+	s.catMu.RUnlock()
+	return name, ok
 }
 
 type schematicIndex struct {


### PR DESCRIPTION
A blank search filtered by category returned no results for categories whose display name differs from the URL key — e.g. /search?category=vehicles (key "vehicles", name "Vehicles & Contraptions") showed 0 of 414 builds.

buildFilter guessed the indexed category name from the key by replacing hyphens with spaces, which only matches when the name equals the key-with-spaces (case-insensitively — Meilisearch filter equality is case-insensitive). It broke for every category whose curated name diverges from its key: vehicles, decoration, logistics, processing, storage, trains.

Resolve the key to the real name via the category taxonomy (loaded into the search Service during the index rebuild) and filter on that; fall back to the old guess only for unknown keys. No reindex needed — the index already stores names. Fixes the same bug on every category-filtered surface (search, mods, homepage sections, API), not just the search page.