### PR TITLE
fix(upload): raise request-body cap for publish/edit so image uploads

### DIFF
--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -1630,7 +1630,10 @@ func deriveOAuthSigningSecret() string {
 }
 
 func maxBodyMiddleware(maxBytes int64) func(http.Handler) http.Handler {
-	const uploadMax int64 = 50 << 20
+	// Publish/edit requests bundle the .nbt plus several multi-MB screenshots, so
+	// they need the same headroom the make-public form parser and its error
+	// message already assume (100 MB). Per-file caps are enforced in the handlers.
+	const uploadMax int64 = 100 << 20
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Body != nil {
@@ -1650,7 +1653,20 @@ func isUploadRoute(path string) bool {
 	case "/upload/nbt", "/api/schematics/upload", "/api/schematics/upload-anonymous", "/api/images/upload":
 		return true
 	}
-	return strings.HasSuffix(path, "/add-file")
+	// Publishing (/u/{token}/make-public) and editing a schematic
+	// (/schematics/{id}/update, /admin/schematics/{id}) POST the .nbt plus
+	// inline screenshots in one multipart body, which easily exceeds the default
+	// 10 MB cap. add-file appends an extra .nbt variation.
+	if strings.HasSuffix(path, "/add-file") || strings.HasSuffix(path, "/make-public") {
+		return true
+	}
+	if strings.HasPrefix(path, "/schematics/") && strings.HasSuffix(path, "/update") {
+		return true
+	}
+	if strings.HasPrefix(path, "/admin/schematics/") {
+		return true
+	}
+	return false
 }
 
 func adminOnlyMiddleware(next http.Handler) http.Handler {

--- a/internal/router/upload_route_test.go
+++ b/internal/router/upload_route_test.go
@@ -1,0 +1,34 @@
+package router
+
+import "testing"
+
+// TestIsUploadRoute guards the larger request-body cap for endpoints that carry
+// an .nbt plus inline screenshots. Regression: /u/{token}/make-public was NOT
+// covered, so publishing with a few MB of images hit the default 10 MB cap and
+// returned a misleading "under 100 MB" error.
+func TestIsUploadRoute(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/u/abc123def/make-public", true},
+		{"/schematics/my-cool-build/update", true},
+		{"/admin/schematics/abc123", true},
+		{"/upload/nbt", true},
+		{"/api/images/upload", true},
+		{"/api/schematics/upload", true},
+		{"/api/schematics/upload-anonymous", true},
+		{"/u/abc123/add-file", true},
+		// Not upload routes:
+		{"/schematics/my-cool-build", false},
+		{"/api/schematics/my-cool-build/download", false},
+		{"/schematics", false},
+		{"/", false},
+		{"/api/notifications/unread-count", false},
+	}
+	for _, c := range cases {
+		if got := isUploadRoute(c.path); got != c.want {
+			t.Errorf("isUploadRoute(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Publishing (/u/{token}/make-public) and editing a schematic POST the .nbt plus several inline screenshots in one multipart body, but those routes were not in isUploadRoute, so they hit the default 10 MB body cap. This fixes that