### PR TITLE
fix(static): disable directory listings under /assets/x/

### DIFF
--- a/internal/router/main.go
+++ b/internal/router/main.go
@@ -367,7 +367,7 @@ func Register(p RegisterParams) chi.Router {
 		io.Copy(w, reader)
 	})
 	// Static assets with long cache (files use ?v=hash cache-busting)
-	staticFS := http.StripPrefix("/assets/x/", http.FileServer(http.Dir("./template/static")))
+	staticFS := http.StripPrefix("/assets/x/", http.FileServer(noListFS{http.Dir("./template/static")}))
 	r.Handle("/assets/x/*", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// During a rolling deploy, a request for the NEW ?v= can land on an
 		// OLD pod (the file server ignores the query); with an immutable
@@ -1646,6 +1646,32 @@ func maxBodyMiddleware(maxBytes int64) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// noListFS wraps an http.FileSystem to disable directory listings: a request
+// for a directory that has no index.html returns os.ErrNotExist (a 404 from
+// http.FileServer) instead of an auto-generated listing of its files.
+type noListFS struct{ fs http.FileSystem }
+
+func (n noListFS) Open(name string) (http.File, error) {
+	f, err := n.fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if info.IsDir() {
+		index, idxErr := n.fs.Open(strings.TrimSuffix(name, "/") + "/index.html")
+		if idxErr != nil {
+			f.Close()
+			return nil, os.ErrNotExist
+		}
+		index.Close()
+	}
+	return f, nil
 }
 
 func isUploadRoute(path string) bool {

--- a/internal/router/nolist_fs_test.go
+++ b/internal/router/nolist_fs_test.go
@@ -1,0 +1,56 @@
+package router
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNoListFS verifies directory listings are disabled: a directory with no
+// index.html is not openable (404 via http.FileServer), while files and
+// directories that do have an index.html still work.
+func TestNoListFS(t *testing.T) {
+	root := t.TempDir()
+	// root/ads/banner.webp  (a directory with no index.html)
+	if err := os.MkdirAll(filepath.Join(root, "ads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ads", "banner.webp"), []byte("img"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// root/withindex/index.html
+	if err := os.MkdirAll(filepath.Join(root, "withindex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "withindex", "index.html"), []byte("<h1>ok</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := noListFS{http.Dir(root)}
+
+	// A directory without index.html must be denied (-> 404).
+	if _, err := fs.Open("/ads"); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("Open(/ads) err = %v, want os.ErrNotExist (listing not disabled)", err)
+	}
+	if _, err := fs.Open("/ads/"); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("Open(/ads/) err = %v, want os.ErrNotExist", err)
+	}
+
+	// A real file must still serve.
+	f, err := fs.Open("/ads/banner.webp")
+	if err != nil {
+		t.Errorf("Open(/ads/banner.webp) err = %v, want nil", err)
+	} else {
+		f.Close()
+	}
+
+	// A directory that has an index.html is allowed (FileServer serves it).
+	d, err := fs.Open("/withindex")
+	if err != nil {
+		t.Errorf("Open(/withindex) err = %v, want nil (has index.html)", err)
+	} else {
+		d.Close()
+	}
+}


### PR DESCRIPTION
http.FileServer auto-generates a browsable file listing for any directory without an index.html, so /assets/x/ads/ (and every other static subdir) exposed the full list of files. Wrap the static FileSystem in noListFS, which returns 404 for a directory that has no index.html while still serving individual files normally.